### PR TITLE
CI: Fix job names to differentiate

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -7,7 +7,7 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  validate:
+  validate-hacs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v2"

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -7,7 +7,7 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  validate:
+  validate-hassfest:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
The hacs and hassfest validation jobs were both titled 'validate' which
made it impossible to use a hard validation on just one of them in
branch protections. As such, we're differentiating some so that we can
utilize branch protection but also so that it's easier to tell which
action failed.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>