### PR TITLE
Fix: Correct the displayed integration name

### DIFF
--- a/custom_components/rental_control/strings.json
+++ b/custom_components/rental_control/strings.json
@@ -1,5 +1,5 @@
 {
-  "title": "rental_control",
+  "title": "Rental Control",
   "config": {
     "step": {
       "user": {

--- a/custom_components/rental_control/translations/de.json
+++ b/custom_components/rental_control/translations/de.json
@@ -20,5 +20,5 @@
       }
     }
   },
-  "title": "rental_control"
+  "title": "Rental Control"
 }

--- a/custom_components/rental_control/translations/en.json
+++ b/custom_components/rental_control/translations/en.json
@@ -20,5 +20,5 @@
       }
     }
   },
-  "title": "rental_control"
+  "title": "Rental Control"
 }


### PR DESCRIPTION
Make sure that the integration is searchable as 'Rental Control' and
does not show up as 'rental_control'

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>