### PR TITLE
Chore: Update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.0.1
     hooks:
       - id: check-added-large-files
       - id: check-yaml
@@ -11,8 +11,8 @@ repos:
         args:
           - --branch=main
 
-  - repo: https://github.com/ambv/black
-    rev: 21.5b1
+  - repo: https://github.com/psf/black
+    rev: 21.7b0
     hooks:
       - id: black
 
@@ -22,12 +22,12 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.5.0
+    rev: v2.6.0
     hooks:
       - id: reorder-python-imports
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.3.2
     hooks:
       - id: prettier
         stages: [commit]


### PR DESCRIPTION
Updates:
- [github.com/pre-commit/pre-commit-hooks: v3.3.0 → v4.0.1]
- https://github.com/ambv/black → https://github.com/psf/black
- [github.com/psf/black: 21.5b1 → 21.7b0]
- [github.com/asottile/reorder_python_imports: v2.5.0 → v2.6.0]
- [github.com/pre-commit/mirrors-prettier: v2.2.1 → v2.3.2]

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>