### PR TITLE
Chore: Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.26.1
+    rev: v1.26.2
     hooks:
       - id: yamllint
 


### PR DESCRIPTION
* github.com/adrienverge/yamllint.git: v1.26.1 → v1.26.2

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>