### PR TITLE
Chore: Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.26.2
+    rev: v1.26.3
     hooks:
       - id: yamllint
 


### PR DESCRIPTION
* github.com/adrienverge/yamllint.git: v1.26.2 -> v1.26.3

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>