### PR TITLE
Chore: Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 21.9b0
     hooks:
       - id: black
 
@@ -27,7 +27,7 @@ repos:
       - id: reorder-python-imports
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.3.2
+    rev: v2.4.1
     hooks:
       - id: prettier
         stages: [commit]
@@ -43,7 +43,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/econchick/interrogate
-    rev: 1.4.0
+    rev: 1.5.0
     hooks:
       - id: interrogate
         args: [-vv, --fail-under=100]


### PR DESCRIPTION
* github.com/psf/black: 21.8b0 -> 21.9b0
* github.com/pre-commit/mirrors-prettier: v2.3.2 -> v2.4.1
* github.com/econchick/interrogate: 1.4.0 -> 1.5.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>