### PR TITLE
Chore: Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 ---
+ci:
+  autofix_commit_msg: "Chore: pre-commit autofixes"
+  autoupdate_commit_msg: "Chore: pre-commit autoupdate"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.12b0
     hooks:
       - id: black
 
@@ -27,13 +27,13 @@ repos:
       - id: reorder-python-imports
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.4.1
+    rev: v2.5.1
     hooks:
       - id: prettier
         stages: [commit]
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.16.0
+    rev: v0.17.0
     hooks:
       - id: gitlint
 


### PR DESCRIPTION
github.com/psf/black: 21.9b0 -> 21.12b0
github.com/pre-commit/mirrors-prettier: v2.4.1 -> v2.5.1
github.com/jorisroovers/gitlint: v0.16.0 -> v0.17.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>