### PR TITLE
Fix: Convert device_state_attributes to extra_

### DIFF
--- a/custom_components/rental_control/calendar.py
+++ b/custom_components/rental_control/calendar.py
@@ -45,8 +45,8 @@ class ICalCalendarEventDevice(CalendarEventDevice):
         self.rental_control_events = rental_control_events
 
     @property
-    def device_state_attributes(self):
-        """Return the device state attributes."""
+    def extra_state_attributes(self):
+        """Return the custom state attributes."""
         return {"offset_reached": self._offset_reached}
 
     @property

--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -98,14 +98,14 @@ class ICalSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the attributes of the event."""
         return self._event_attributes
 
     @property
     def available(self):
         """Return True if ZoneMinder is available."""
-        return self.device_state_attributes["start"] is not None
+        return self._event_attributes["start"] is not None
 
     async def async_update(self):
         """Update the sensor."""


### PR DESCRIPTION
Home Assistant 2021.12 started throwing a warning about having
implemented device_state_attributes. The correct property to implement
is extra_state_attributes

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
