### PR TITLE
Docs: Add statement about Keymaster dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ And it will create a calendar-entry that can be used in the calendar cards etc.
 
 ## Installation
 
+Make sure that you have installed
+[Keymaster](https://github.com/FutureTense/keymaster) as this integration
+depends upon it.
+
 Copy all files from the "custom_components/rental-control" directory to your
 home-assistant config directory under custom_components/rental-control.
 


### PR DESCRIPTION
Keymaster is currently a hard dependency and as such, should be stated
in the documentation.

Issue: #30
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
