### PR TITLE
CI: Add gitlint action

### DIFF
--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -1,0 +1,27 @@
+name: Gitlint
+on:
+  pull_request:
+
+jobs:
+  gitlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Check out at the last commit (pre-automated merge, we don't care
+          # about the temporary commit for linting)
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Get all history
+          fetch-depth: 0
+
+      - name: Install gitlint
+        shell: bash
+        run: |
+          python -m pip install gitlint
+
+      - name: Run gitlint
+        shell: bash
+        run: |
+          # Lint everything from the base to the latest
+          gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD"


### PR DESCRIPTION
Pre-commit.ci doesn't support the commit-msg handler for PRs. Since we
still want to enforce our gitlinting we need to do it ourselves.

This workflow comes from https://joe.gl/ombek/blog/pr-gitlint/

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
