### PR TITLE
Fix: Make ICS URL less strict on AirBnB

### DIFF
--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -227,7 +227,7 @@ async def _start_config_flow(
         try:
             cv.url(user_input["url"])
             # We currently only support AirBnB ical at this time
-            if not re.search("^https://www.airbnb.com/.*ics", user_input["url"]):
+            if not re.search("^https://www\\.airbnb\\..*ics", user_input["url"]):
                 errors["base"] = "bad_ics"
         except vol.Invalid as err:
             _LOGGER.exception(err.msg)


### PR DESCRIPTION
AirBnB uses at least one other domain suffix than just .com. As such, we
need to relax the validation a little bit on the URL for the ics

Issue: #40
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
