### PR TITLE
Fix: Make prepend work for no reservation

### DIFF
--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -66,15 +66,19 @@ class ICalSensor(Entity):
             f"{sensor_name} event {self._event_number}",
             hass=self._hass,
         )
+        if rental_control_events.event_prefix:
+            summary = f"{rental_control_events.event_prefix} No reservation"
+        else:
+            summary = "No reservation"
         self._event_attributes = {
-            "summary": "No reservation",
+            "summary": summary,
             "description": None,
             "location": None,
             "start": None,
             "end": None,
             "eta": None,
         }
-        self._state = None
+        self._state = summary
         self._is_available = None
 
     @property
@@ -147,12 +151,16 @@ class ICalSensor(Entity):
                 str(self._event_number),
                 self.name,
             )
+            if self.rental_control_events.event_prefix:
+                summary = f"{self.rental_control_events.event_prefix} No reservation"
+            else:
+                summary = "No reservation"
             self._event_attributes = {
-                "summary": "No reservation",
+                "summary": summary,
                 "description": None,
                 "location": None,
                 "start": None,
                 "end": None,
                 "eta": None,
             }
-            self._state = "No reservation"
+            self._state = summary


### PR DESCRIPTION
In the case of no reservation being found to fill a sensor we should
make sure that if a prepend for events is defined that it applies in
this edge case.

Issue: #53
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
