### PR TITLE
CI: Disable pre-commit.ci from doing autofix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ---
 ci:
   autofix_commit_msg: "Chore: pre-commit autofixes"
+  autofix_prs: false
   autoupdate_commit_msg: "Chore: pre-commit autoupdate"
 
 repos:


### PR DESCRIPTION
pre-commit.ci does bad autofixes as it re-orders imports differently
than locally run validator and what also runs in pre-commit.ci!
Additionally, the commit messages that it produces do not conform to
requirements in gitlint

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
