### PR TITLE
Fix: Correct error strings

### DIFF
--- a/custom_components/rental_control/strings.json
+++ b/custom_components/rental_control/strings.json
@@ -1,9 +1,9 @@
 {
   "config": {
     "error": {
-      "bad_ics": "Only AirBnB iCalendars are supported",
+      "bad_ics": "URL did not provide valid calendar",
       "bad_time": "Check-in/out time is invalid. Use 24 hour time",
-      "invalid_url": "Invalid Calendar URL",
+      "invalid_url": "Only https URLs are supported",
       "same_name": "Name already in use",
       "unknown": "Unexpected error"
     },
@@ -28,9 +28,9 @@
   },
   "options": {
     "error": {
-      "bad_ics": "Only AirBnB iCalendars are supported",
+      "bad_ics": "URL did not provide valid calendar",
       "bad_time": "Check-in/out time is invalid. Use 24 hour time",
-      "invalid_url": "Invalid Calendar URL",
+      "invalid_url": "Only https URLs are supported",
       "same_name": "Name already in use",
       "unknown": "Unexpected error"
     },

--- a/custom_components/rental_control/translations/en.json
+++ b/custom_components/rental_control/translations/en.json
@@ -1,9 +1,9 @@
 {
   "config": {
     "error": {
-      "bad_ics": "Only AirBnB iCalendars are supported",
+      "bad_ics": "URL did not provide valid calendar",
       "bad_time": "Check-in/out time is invalid. Use 24 hour time",
-      "invalid_url": "Invalid Calendar URL",
+      "invalid_url": "Only https URLs are supported",
       "same_name": "Name already in use",
       "unknown": "Unexpected error"
     },
@@ -28,9 +28,9 @@
   },
   "options": {
     "error": {
-      "bad_ics": "Only AirBnB iCalendars are supported",
+      "bad_ics": "URL did not provide valid calendar",
       "bad_time": "Check-in/out time is invalid. Use 24 hour time",
-      "invalid_url": "Invalid Calendar URL",
+      "invalid_url": "Only https URLs are supported",
       "same_name": "Name already in use",
       "unknown": "Unexpected error"
     },


### PR DESCRIPTION
The error string for a URL that returns bad data incorrectly states that
AirBnB is the only supported calendar. This is incorrect as we now
verify that the data returns is of type text/calendar and accept any
calendar that passes this.

Additionally, the error string for invalid URLs was not giving a reason
why it was considered invalid.

Issue: #73
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
