### PR TITLE
Chore: Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
 
@@ -27,7 +27,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.6.0
+    rev: v2.7.1
     hooks:
       - id: reorder-python-imports
 


### PR DESCRIPTION
Updates:

* github.com/psf/black: 21.12b0 -> 22.1.0
* github.com/asottile/reorder_python_imports: v2.6.0 -> v2.7.1

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
