### PR TITLE
Fix: Update HACS to do zip releases

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,9 @@
 {
   "name": "Rental Control",
   "hacs": "1.13.2",
-  "domains": ["sensor"],
+  "domains": ["calendar", "sensor"],
   "iot_class": "Cloud Polling",
+  "zip_release": true,
+  "filename": "rental_control.zip",
   "homeassistant": "2021.7.0"
 }


### PR DESCRIPTION
While doing some looking into analytics it was discovered that all
versions of Rental Control were reporting version 0.0.0 which means that
all installed versions have been installing directly from the
repository. This makes it hard to understand what the install base is!

As zip releases were supposed to be on for a long time this actually
fixes it to have them on.

It also fixes the fact that the calendar domain was not listed

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
