### PR TITLE
Chore: Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,12 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.7.1
+    rev: v3.0.1
     hooks:
       - id: reorder-python-imports
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.6.0
     hooks:
       - id: prettier
         stages: [commit]


### PR DESCRIPTION
Updates:

* github.com/asottile/reorder_python_imports: v2.7.1 -> v3.0.1
* github.com/pre-commit/mirrors-prettier: v2.5.1 -> v2.6.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
