### PR TITLE
Fix: Do not translate integration title

### DIFF
--- a/custom_components/rental_control/strings.json
+++ b/custom_components/rental_control/strings.json
@@ -58,6 +58,5 @@
         }
       }
     }
-  },
-  "title": "Rental Control"
+  }
 }

--- a/custom_components/rental_control/translations/en.json
+++ b/custom_components/rental_control/translations/en.json
@@ -58,6 +58,5 @@
         }
       }
     }
-  },
-  "title": "Rental Control"
+  }
 }


### PR DESCRIPTION
According to hassfest the integration title should not be translated.
Alternatively, an exception should be added to allow it. For now, we'll
just not translate it

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
