### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
@@ -17,7 +17,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
 
@@ -32,7 +32,7 @@ repos:
       - id: reorder-python-imports
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.0
+    rev: v2.6.2
     hooks:
       - id: prettier
         stages: [commit]


### PR DESCRIPTION
github.com/pre-commit/pre-commit-hooks: v4.1.0 -> v4.2.0
github.com/psf/black: 22.1.0 -> 22.3.0
github.com/pre-commit/mirrors-prettier: v2.6.0 -> v2.6.2

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
