### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.0.1
+    rev: v3.1.0
     hooks:
       - id: reorder-python-imports
 


### PR DESCRIPTION
github.com/asottile/reorder_python_imports: v3.0.1 -> v3.1.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
