### PR TITLE
Fix: Correct regex for last 4 digits

### DIFF
--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -111,7 +111,7 @@ class ICalSensor(Entity):
         """Extract the last 4 digits from a description."""
         if self._event_attributes["description"] is None:
             return None
-        p = re.compile(r"""\\(Last 4 Digits\\):\\s+(\\d{4})""")
+        p = re.compile(r"""\(Last 4 Digits\):\s+(\d{4})""")
         ret = p.findall(self._event_attributes["description"])
         if ret:
             return ret[0]


### PR DESCRIPTION
The regex for the last four digits got modified by the black
pretification pre-commit hook and broke. This corrects the regex to work
correctly

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
