### PR TITLE
Refactor: Code cleanup - rename of classes

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -56,8 +56,6 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
-
 
 def setup(hass, config):  # pylint: disable=unused-argument
     """Set up this integration with config flow."""
@@ -70,11 +68,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug(
         "Running init async_setup_entry for calendar %s", config.get(CONF_NAME)
     )
-    # TODO Store an API object for your platforms to access
-    # hass.data[DOMAIN][entry.entry_id] = MyApi(...)
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][entry.unique_id] = ICalEvents(
+    hass.data[DOMAIN][entry.unique_id] = RentalControl(
         hass=hass, config=config, unique_id=entry.unique_id
     )
 
@@ -153,7 +149,7 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     hass.data[DOMAIN][entry.unique_id].update_config(new_data)
 
 
-class ICalEvents:
+class RentalControl:
     """Get a list of events."""
 
     # pylint: disable=too-many-instance-attributes
@@ -229,7 +225,7 @@ class ICalEvents:
         self, hass, start_date, end_date
     ) -> list[CalendarEvent]:  # pylint: disable=unused-argument
         """Get list of upcoming events."""
-        _LOGGER.debug("Running ICalEvents async_get_events")
+        _LOGGER.debug("Running RentalControl async_get_events")
         events = []
         if len(self.calendar) > 0:
             for event in self.calendar:
@@ -249,7 +245,7 @@ class ICalEvents:
 
     async def update(self):
         """Regularly update the calendar."""
-        _LOGGER.debug("Running ICalEvents update for calendar %s", self.name)
+        _LOGGER.debug("Running RentalControl update for calendar %s", self.name)
 
         now = dt.now()
         _LOGGER.debug("Refresh frequency is: %d", self.refresh_frequency)
@@ -416,7 +412,7 @@ class ICalEvents:
 
     async def _refresh_calendar(self):
         """Update list of upcoming events."""
-        _LOGGER.debug("Running ICalEvents _refresh_calendar for %s", self.name)
+        _LOGGER.debug("Running RentalControl _refresh_calendar for %s", self.name)
 
         session = async_get_clientsession(self.hass, verify_ssl=self.verify_ssl)
         with async_timeout.timeout(REQUEST_TIMEOUT):

--- a/custom_components/rental_control/calendar.py
+++ b/custom_components/rental_control/calendar.py
@@ -25,12 +25,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     rental_control_events = hass.data[DOMAIN][config_entry.unique_id]
 
-    calendar = RentalCalendar(hass, f"{NAME} {name}", rental_control_events)
+    calendar = RentalControlCalendar(hass, f"{NAME} {name}", rental_control_events)
 
     async_add_entities([calendar], True)
 
 
-class RentalCalendar(CalendarEntity):
+class RentalControlCalendar(CalendarEntity):
     """A device for getting the next Task from a WebDav Calendar."""
 
     def __init__(
@@ -70,13 +70,13 @@ class RentalCalendar(CalendarEntity):
 
     async def async_get_events(self, hass, start_date, end_date) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
-        _LOGGER.debug("Running RentalCalendar async get events")
+        _LOGGER.debug("Running RentalControlCalendar async get events")
         return await self.rental_control_events.async_get_events(
             hass, start_date, end_date
         )
 
     async def async_update(self):
         """Update event data."""
-        _LOGGER.debug("Running RentalCalendar async update for %s", self.name)
+        _LOGGER.debug("Running RentalControlCalendar async update for %s", self.name)
         await self.rental_control_events.update()
         self._event = self.rental_control_events.event

--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -42,7 +42,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     sensors = []
     for eventnumber in range(max_events):
         sensors.append(
-            ICalSensor(
+            RentalControlCalSensor(
                 hass,
                 rental_control_events,
                 f"{NAME} {name}",
@@ -53,7 +53,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(sensors)
 
 
-class ICalSensor(Entity):
+class RentalControlCalSensor(Entity):
     """
     Implementation of a iCal sensor.
 
@@ -275,7 +275,7 @@ class ICalSensor(Entity):
 
     async def async_update(self):
         """Update the sensor."""
-        _LOGGER.debug("Running ICalSensor async update for %s", self.name)
+        _LOGGER.debug("Running RentalControlCalSensor async update for %s", self.name)
 
         await self.rental_control_events.update()
 


### PR DESCRIPTION
Rename the classes to something more relevant to the integration. The
previous names were hold-overs from the fork of the iCal integration

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
