### PR TITLE
Fix: Update hacs.json

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -3,7 +3,6 @@ name: Validate for HACS
 
 # yamllint disable-line rule:truthy
 on:
-  push:
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,6 @@
 {
   "name": "Rental Control",
   "hacs": "1.13.2",
-  "domains": ["calendar", "sensor"],
-  "iot_class": "Cloud Polling",
   "zip_release": true,
   "filename": "rental_control.zip",
   "homeassistant": "2022.5.0"


### PR DESCRIPTION
HACS Validation started failing because of unsupported keys in the
hacs.json file. Remove the undocumented keys.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
