### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.3.0
+    rev: v3.8.1
     hooks:
       - id: reorder-python-imports
 
@@ -43,7 +43,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.26.3
+    rev: v1.27.1
     hooks:
       - id: yamllint
 


### PR DESCRIPTION
github.com/asottile/reorder_python_imports: v3.3.0 -> v3.8.1
github.com/adrienverge/yamllint.git: v1.26.3 -> v1.27.1

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
