### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
 


### PR DESCRIPTION
* github.com/pycqa/flake8: 4.0.1 -> 5.0.4

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
