### PR TITLE
Chore: Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: reorder-python-imports
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0-alpha.0
     hooks:
       - id: prettier
         stages: [commit]


### PR DESCRIPTION
* github.com/pre-commit/mirrors-prettier: v2.7.1 -> v3.0.0-alpha.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
