### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black
 


### PR DESCRIPTION
* github.com/psf/black: 22.6.0 -> 22.8.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
