### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.27.1
+    rev: v1.28.0
     hooks:
       - id: yamllint
 


### PR DESCRIPTION
* github.com/adrienverge/yamllint.git: v1.27.1 -> v1.28.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
