### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.8.2
+    rev: v3.8.3
     hooks:
       - id: reorder-python-imports
 
@@ -54,7 +54,7 @@ repos:
         args: [-vv, --fail-under=100]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.981
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
* github.com/asottile/reorder_python_imports: v3.8.2 -> v3.8.3
* github.com/pre-commit/mirrors-mypy: v0.971 -> v0.981

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
