### PR TITLE
Fix: Prevent inaccessible calendars from deleting

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -337,6 +337,8 @@ class RentalControl:
         self.verify_ssl = config.get(CONF_VERIFY_SSL)
         self.calendar = []
         self.calendar_ready = False
+        self.calendar_loaded = False
+        self.overrides_loaded = False
         self.event_overrides = {}
         self.event_sensors = []
         self.code_generator = config.get(CONF_CODE_GENERATION, DEFAULT_CODE_GENERATION)
@@ -534,7 +536,9 @@ class RentalControl:
         _LOGGER.debug("event_overrides: '%s'", self.event_overrides)
         if len(self.event_overrides) == self.max_events:
             _LOGGER.debug("max_events reached, flagging as ready")
-            self.calendar_ready = True
+            self.overrides_loaded = True
+            if self.calendar_loaded:
+                self.calendar_ready = True
         else:
             _LOGGER.debug(
                 "max_events not reached yet, calendar_ready is '%s'",
@@ -708,7 +712,12 @@ class RentalControl:
                 event_list, start_of_events, end_of_events
             )
 
+            self.calendar_loaded = True
+
             if self.lockname is None:
+                self.overrides_loaded = True
+
+            if self.overrides_loaded:
                 self.calendar_ready = True
 
         if len(self.calendar) > 0:

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -227,6 +227,10 @@ class RentalControlCalSensor(Entity):
 
         await self.rental_control_events.update()
 
+        # Calendar is not ready, no reason to continue processing
+        if not self.rental_control_events.calendar_ready:
+            return
+
         self._code_generator = self.rental_control_events.code_generator
         self._code_length = self.rental_control_events.code_length
         event_list = self.rental_control_events.calendar


### PR DESCRIPTION
A calendar that is inaccessible when the integration is starting up
primarily during a restart of HA, but also when the integration is
reloaded, could potentially cause currently defined lock slots to get
deleted. This can cause major issues, particularly if the slot had an
override on the code in place as the override is lost.

Instead, we keep the sensors as unavailable and do not fire any events
related to setting or clearing the the codes until we have managed to
load the calendar successfully.

Issue: Fixes #126
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
