### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
 
@@ -27,12 +27,12 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.8.3
+    rev: v3.9.0
     hooks:
       - id: reorder-python-imports
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.0
+    rev: v3.0.0-alpha.4
     hooks:
       - id: prettier
         stages: [commit]
@@ -54,7 +54,7 @@ repos:
         args: [-vv, --fail-under=100]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.990
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
* github.com/psf/black 22.8.0 -> 22.10.0
* github.com/asottile/reorder_python_imports v3.8.3 -> v3.9.0
* github.com/pre-commit/mirrors-prettier v3.0.0-alpha.0 -> v3.0.0-alpha.4
* github.com/pre-commit/mirrors-mypy v0.981 -> v0.990

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
