### PR TITLE
Fix: Make last 4 digit check more lenient

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ calendars and sensors to go with them related to managing rental properties.
         another generator fails to produce a code)
     -   A random 4 digit (or greater) code based on the event description
     -   The last 4 digits of the phone number. This only works properly if the
-        event description contains 'Last 4 Digits' followed quickly by a 4 digit
-        number. This is the most stable, but only works if the event
-        descriptions have the needed data. The previous two methods can have the
-        codes change if the event makes changes to length or to the description.
+        event description contains '(Last 4 Digits): ' or 'Last 4 Digits: '
+        followed quickly by a 4 digit number. This is the most stable, but only
+        works if the event descriptions have the needed data. The previous two
+        methods can have the codes change if the event makes changes to length
+        or to the description.
 -   All events will get a code associated with it. In the case that the criteria
     to create the code are not fulfilled, then the check-in/out date based
     method will be used as a fallback

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -78,7 +78,7 @@ class RentalControlCalSensor(Entity):
         """Extract the last 4 digits from a description."""
         if self._event_attributes["description"] is None:
             return None
-        p = re.compile(r"""\(Last 4 Digits\):\s+(\d{4})""")
+        p = re.compile(r"""\(?Last 4 Digits\)?:\s+(\d{4})""")
         ret = p.findall(self._event_attributes["description"])
         if ret:
             return str(ret[0])

--- a/info.md
+++ b/info.md
@@ -39,10 +39,11 @@ calendars and sensors to go with them related to managing rental properties.
         another generator fails to produce a code)
     -   A random 4 digit (or greater) code based on the event description
     -   The last 4 digits of the phone number. This only works properly if the
-        event description contains 'Last 4 Digits' followed quickly by a 4 digit
-        number. This is the most stable, but only works if the event
-        descriptions have the needed data. The previous two methods can have the
-        codes change if the event makes changes to length or to the description.
+        event description contains '(Last 4 Digits): ' or 'Last 4 Digits: '
+        followed quickly by a 4 digit number. This is the most stable, but only
+        works if the event descriptions have the needed data. The previous two
+        methods can have the codes change if the event makes changes to length
+        or to the description.
 -   All events will get a code associated with it. In the case that the criteria
     to create the code are not fulfilled, then the check-in/out date based
     method will be used as a fallback


### PR DESCRIPTION
The documentation and regex for getting door codes that are the last 4
digits of a phone number are to be made more clear and lenient.

Issue: Fixes #141
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
