### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
@@ -22,7 +22,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
 
@@ -38,7 +38,7 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.17.0
+    rev: v0.18.0
     hooks:
       - id: gitlint
 
@@ -54,7 +54,7 @@ repos:
         args: [-vv, --fail-under=100]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.990
+    rev: v0.991
     hooks:
       - id: mypy
         additional_dependencies:

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -18,7 +18,7 @@ import logging
 import os
 import re
 import uuid
-from typing import Any
+from typing import Any  # noqa: F401
 from typing import List
 
 from homeassistant.components.automation import DOMAIN as AUTO_DOMAIN


### PR DESCRIPTION
* github.com/pre-commit/pre-commit-hooks: v4.3.0 -> v4.4.0
* github.com/pycqa/flake8: 5.0.4 -> 6.0.0
* github.com/jorisroovers/gitlint: v0.17.0 -> v0.18.0
* github.com/pre-commit/mirrors-mypy: v0.990 -> v0.991

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
