### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
 
@@ -38,12 +38,12 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.18.0
+    rev: v0.19.0dev
     hooks:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.28.0
+    rev: v1.29.0
     hooks:
       - id: yamllint
 


### PR DESCRIPTION
* github.com/psf/black: 22.10.0 -> 22.12.0
* github.com/jorisroovers/gitlint: v0.18.0 -> v0.19.0dev
* github.com/adrienverge/yamllint.git: v1.28.0 -> v1.29.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
