### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,13 @@ repos:
       - id: reorder-python-imports
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
+    rev: v3.0.0-alpha.6
     hooks:
       - id: prettier
         stages: [commit]
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.19.0dev
+    rev: v0.19.0
     hooks:
       - id: gitlint
 
@@ -54,7 +54,7 @@ repos:
         args: [-vv, --fail-under=100]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.1.1
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
* github.com/pre-commit/mirrors-prettier: v3.0.0-alpha.4 -> v3.0.0-alpha.6
* github.com/jorisroovers/gitlint: v0.19.0dev -> v0.19.0
* github.com/pre-commit/mirrors-mypy: v1.0.1 -> v1.1.1

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
