### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
 
@@ -38,12 +38,12 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.19.0
+    rev: v0.19.1
     hooks:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: yamllint
 
@@ -54,7 +54,7 @@ repos:
         args: [-vv, --fail-under=100]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.2.0
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
* github.com/psf/black: updating 23.1.0 -> 23.3.0
* github.com/jorisroovers/gitlint: v0.19.0 -> v0.19.1
* github.com/adrienverge/yamllint: v1.29.0 -> v1.30.0
* github.com/pre-commit/mirrors-mypy: v1.1.1 -> v1.2.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
