### PR TITLE
Fix: Stringify rental_control_name in automations

### DIFF
--- a/custom_components/rental_control/templates/clear_code.yaml.j2
+++ b/custom_components/rental_control/templates/clear_code.yaml.j2
@@ -7,7 +7,7 @@ automation:
     - platform: event
       event_type: rental_control_clear_code
       event_data:
-        rental_control_name: {{ rc_name }}
+        rental_control_name: "{{ rc_name }}"
   condition: []
   action:
     service: input_boolean.toggle

--- a/custom_components/rental_control/templates/set_code.yaml.j2
+++ b/custom_components/rental_control/templates/set_code.yaml.j2
@@ -9,7 +9,7 @@ automation:
     - platform: event
       event_type: rental_control_set_code
       event_data:
-        rental_control_name: {{ rc_name }}
+        rental_control_name: "{{ rc_name }}"
       variables:
         slot_name: '{% raw %}{{ trigger.event.data.slot_name }}{% endraw %}'
         code_slot: '{% raw %}{{ trigger.event.data.code_slot }}{% endraw %}'

--- a/custom_components/rental_control/templates/startup.yaml.j2
+++ b/custom_components/rental_control/templates/startup.yaml.j2
@@ -9,7 +9,7 @@ automation:
     - platform: event
       event_type: rental_control_refresh
       event_data:
-        rental_control_name: {{ rc_name }}
+        rental_control_name: "{{ rc_name }}"
   condition: []
   action:
     - delay:


### PR DESCRIPTION
If a RC is defined with a name that is purely numeric then the default
behavior of yaml is to treat an numeric as a numeric and not a string.
This has a side effect of not properly stringifing the name where it
needs to be a string in the automations.

Fixes: #164
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
