### PR TITLE
CI: Workflow updates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
           cd ${{ github.workspace }}/custom_components/rental_control
           zip rental_control.zip -r ./
       - name: Upload zip to release
-        uses: svenstaro/upload-release-action@v1-release
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           # yamllint disable-line rule:line-length

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v1
       - name: Get Version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
       - name: Update versions
         # yamllint disable rule:line-length
         run: |


### PR DESCRIPTION
Update release mechanisms to meet current needs of GitHub

- Chore: Update upload-release-action to v2
- CI: Update output set to new method
