### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 193ee766ca496871f93621d6b58d57a6564ff81b # frozen: 23.7.0
+    rev: e87737140f32d3cd7c44ede75f02dcd58e55820e # frozen: 23.9.1
     hooks:
       - id: black
 
@@ -27,7 +27,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: ba4e0d3cf2eeb6986169966bbc87b0e4eb2be50f # frozen: v3.10.0
+    rev: 43e38f4f7df386768899234763de730221c23bc0 # frozen: v3.11.0
     hooks:
       - id: reorder-python-imports
 


### PR DESCRIPTION
github.com/psf/black: 23.7.0 -> 23.9.1 (frozen)
github.com/asottile/reorder_python_imports: 3.10.0 -> v3.11.0 (frozen)

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
