### PR TITLE
Fix: Handle tracking only installations

### DIFF
--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -299,7 +299,9 @@ class RentalControlCalSensor(Entity):
             )
             self._event_attributes["slot_name"] = slot_name
 
-            override = overrides.get_slot_with_name(slot_name)
+            override = None
+            if overrides:
+                override = overrides.get_slot_with_name(slot_name)
             if override is None:
                 set_code = True
 
@@ -345,7 +347,7 @@ class RentalControlCalSensor(Entity):
             self._parsed_attributes = parsed_attributes
 
             # fire set_code if not in current overrides
-            if set_code:
+            if overrides and set_code:
                 await async_fire_set_code(
                     self.coordinator,
                     self,

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -105,6 +105,9 @@ async def async_fire_clear_code(coordinator, slot: int) -> None:
     hass = coordinator.hass
     reset_entity = f"{INPUT_BOOLEAN}.reset_codeslot_{coordinator.lockname}_{slot}"
 
+    if not coordinator.lockname:
+        return
+
     # Make sure that the reset is already off before sending a turn on event
     await hass.services.async_call(
         domain=INPUT_BOOLEAN,
@@ -126,6 +129,9 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
 
     lockname: str = coordinator.lockname
     coro: List[Coroutine] = []
+
+    if not lockname:
+        return
 
     # Disable the slot, this should help avoid notices from Keymaster about
     # pin changes
@@ -229,7 +235,7 @@ async def async_fire_update_times(coordinator, event) -> None:
     slot_name: str = event.extra_state_attributes["slot_name"]
     slot = coordinator.event_overrides.get_slot_key_by_name(slot_name)
 
-    if not slot:
+    if not slot or not lockname:
         return
 
     coro = add_call(


### PR DESCRIPTION
Make sure that we don't require the event_overrides be defined if there
is no lock being managed.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
