### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9 # frozen: v4.4.0
+    rev: c4a0b883114b00d8d76b479c820ce7950211c99b # frozen: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
@@ -17,22 +17,25 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: e87737140f32d3cd7c44ede75f02dcd58e55820e # frozen: 23.9.1
+    rev: 6fdf8a4af28071ed1d079c01122b34c5d587207a # frozen: 24.2.0
     hooks:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 10f4af6dbcf93456ba7df762278ae61ba3120dc6 # frozen: 6.1.0
+    rev: 7d37d9032d0d161634be4554273c30efd4dea0b3 # frozen: 7.0.0
     hooks:
       - id: flake8
 
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: 43e38f4f7df386768899234763de730221c23bc0 # frozen: v3.11.0
+  - repo: https://github.com/pycqa/isort
+    rev: c235f5e450b4b84e58d114ed4c589cbf454175a3 # frozen: 5.13.2
     hooks:
-      - id: reorder-python-imports
+      - id: isort
+        name: isort (python)
+        additional_dependencies:
+          - setuptools
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: fc260393cc4ec09f8fc0a5ba4437f481c8b55dc1 # frozen: v3.0.3
+    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
     hooks:
       - id: prettier
         stages: [commit]
@@ -43,7 +46,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: b05e028c5881819161d11cb543fd96a30c06cceb # frozen: v1.32.0
+    rev: 81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6 # frozen: v1.35.1
     hooks:
       - id: yamllint
 
@@ -52,9 +55,11 @@ repos:
     hooks:
       - id: interrogate
         args: [-vv, --fail-under=100]
+        additional_dependencies:
+          - setuptools
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 08cbc46b6e135adec84911b20e98e5bc52032152 # frozen: v1.5.1
+    rev: 8cd2d4056637e242709fe09f15a36f0b4b682bda # frozen: v1.8.0
     hooks:
       - id: mypy
         additional_dependencies:

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -14,19 +14,16 @@
 from __future__ import annotations
 
 import asyncio
-import functools
-import logging
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
+import functools
+import logging
 from typing import Any
 from typing import Dict
 from zoneinfo import ZoneInfo  # noreorder
 
 import async_timeout
-import homeassistant.helpers.config_validation as cv
-import voluptuous as vol
-from icalendar import Calendar
 from homeassistant.components.calendar import CalendarEvent
 from homeassistant.components.persistent_notification import async_create
 from homeassistant.components.persistent_notification import async_dismiss
@@ -35,12 +32,13 @@ from homeassistant.const import CONF_NAME
 from homeassistant.const import CONF_URL
 from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.event import (
-    async_track_state_change_event,
-)
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util import dt
+from icalendar import Calendar
+import voluptuous as vol
 
 from .config_flow import _lock_entry_convert as lock_entry_convert
 from .const import ATTR_NAME
@@ -72,13 +70,13 @@ from .const import PLATFORMS
 from .const import REQUEST_TIMEOUT
 from .const import UNSUB_LISTENERS
 from .const import VERSION
+from .event_overrides import EventOverrides
 from .sensors.calsensor import RentalControlCalSensor
 from .util import async_reload_package_platforms
 from .util import delete_rc_and_base_folder
 from .util import gen_uuid
 from .util import get_slot_name
 from .util import handle_state_change
-from .event_overrides import EventOverrides
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/rental_control/calendar.py
+++ b/custom_components/rental_control/calendar.py
@@ -1,4 +1,5 @@
 """Support for iCal-URLs."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Rental Control integration."""
+
 import logging
 import re
 from typing import Any
@@ -7,17 +8,17 @@ from typing import Optional
 from typing import Union
 
 import async_timeout
-import homeassistant.helpers.config_validation as cv
-import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 from homeassistant.const import CONF_URL
 from homeassistant.const import CONF_VERIFY_SSL
-from homeassistant.core import callback
 from homeassistant.core import HomeAssistant
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt
 from pytz import common_timezones
+import voluptuous as vol
 from voluptuous.schema_builder import ALLOW_EXTRA
 
 from .const import CODE_GENERATORS

--- a/custom_components/rental_control/const.py
+++ b/custom_components/rental_control/const.py
@@ -1,4 +1,5 @@
 """Constants for Rental Control."""
+
 # Base component constants
 NAME = "Rental Control"
 DOMAIN = "rental_control"

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -12,9 +12,9 @@
 ##############################################################################
 """Rental Control EventOVerrides."""
 import asyncio
+from datetime import datetime
 import logging
 import re
-from datetime import datetime
 from typing import Dict
 from typing import List
 from typing import TypedDict
@@ -23,7 +23,6 @@ from homeassistant.util import dt
 
 from .util import async_fire_clear_code
 from .util import get_event_names
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -1,4 +1,5 @@
 """Creating sensors for upcoming events."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -1,10 +1,11 @@
 """Creating sensors for upcoming events."""
+
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 import random
 import re
-from datetime import datetime
 
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity import EntityCategory

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -18,11 +18,11 @@ import hashlib
 import logging
 import os
 import re
-import uuid
 from typing import Any  # noqa: F401
 from typing import Coroutine
 from typing import Dict
 from typing import List
+import uuid
 
 from homeassistant.components.automation import DOMAIN as AUTO_DOMAIN
 from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,14 +25,13 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 indent = "    "
-# by default isort don't check module indexes
-not_skip = __init__.py
 # will group `import x` and `from x import` of the same module.
 force_sort_within_sections = true
 sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 default_section = THIRDPARTY
 known_first_party = custom_components.rental_control, tests
-combine_as_imports = true
+force_single_line = true
+profile = black
 
 [tool:pytest]
 addopts = -qq --cov=custom_components.rental_control


### PR DESCRIPTION
* github.com/pre-commit/pre-commit-hooks: v4.4.0 -> v4.5.0
* github.com/psf/black: 23.9.1 -> 24.2.0
* github.com/pycqa/flake8: 6.1.0 -> 7.0.0
* github.com/pre-commit/mirrors-prettier: v3.0.3 -> v4.0.0-alpha.8
* github.com/adrienverge/yamllint: v1.32.0 -> v1.35.1
* github.com/pre-commit/mirrors-mypy: v1.5.1 -> v1.8.0

* add github.com/pycqa/isort: 5.13.2 as a replacement for reorder-python-imports
* add dependencies for interrogate

* remove github.com/asottile/reorder_python_imports as it conflicts with
  black

* Pick up some formatting changes from black and isort

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
