### PR TITLE
Chore: Update pre-commit to latest frozen versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: c4a0b883114b00d8d76b479c820ce7950211c99b # frozen: v4.5.0
+    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # frozen: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
@@ -17,7 +17,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 6fdf8a4af28071ed1d079c01122b34c5d587207a # frozen: 24.2.0
+    rev: 3702ba224ecffbcec30af640c149f231d90aebdb # frozen: 24.4.2
     hooks:
       - id: black
 
@@ -51,7 +51,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/econchick/interrogate
-    rev: e18b9df8debc03a5b76a18d3be693c67b2816378 # frozen: 1.5.0
+    rev: a6268877efd41a21197445cc04cbf28f9c6facba # frozen: 1.7.0
     hooks:
       - id: interrogate
         args: [-vv, --fail-under=100]
@@ -59,7 +59,7 @@ repos:
           - setuptools
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 8cd2d4056637e242709fe09f15a36f0b4b682bda # frozen: v1.8.0
+    rev: e5ea6670624c24f8321f6328ef3176dbba76db46 # frozen: v1.10.0
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
* github.com/pre-commit/pre-commit-hooks: v4.5.0 -> v4.6.0
* github.com/psf/black: 24.2.0 -> 24.4.2
* github.com/econchick/interrogate: 1.5.0 -> 1.7.0
* github.com/pre-commit/mirrors-mypy: 1.8.0 -> v1.10.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
