### PR TITLE
CI: Remove uneeded hooks and add new hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,41 +9,34 @@ repos:
     rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # frozen: v4.6.0
     hooks:
       - id: check-added-large-files
+      - id: check-ast
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
       - id: check-yaml
+      - id: debug-statements
       - id: end-of-file-fixer
-      - id: trailing-whitespace
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
       - id: no-commit-to-branch
         args:
           - --branch=main
-
-  - repo: https://github.com/psf/black
-    rev: 3702ba224ecffbcec30af640c149f231d90aebdb # frozen: 24.4.2
-    hooks:
-      - id: black
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 7d37d9032d0d161634be4554273c30efd4dea0b3 # frozen: 7.0.0
-    hooks:
-      - id: flake8
-
-  - repo: https://github.com/pycqa/isort
-    rev: c235f5e450b4b84e58d114ed4c589cbf454175a3 # frozen: 5.13.2
-    hooks:
-      - id: isort
-        name: isort (python)
-        additional_dependencies:
-          - setuptools
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        stages: [commit]
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
 
   - repo: https://github.com/jorisroovers/gitlint
     rev: acc9d9de6369b76d22cb4167029d2035e8730b98 # frozen: v0.19.1
     hooks:
       - id: gitlint
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 5559d0350deec43675eef448015296e1d79800bd  # frozen: v0.4.3
+    hooks:
+      - id: ruff
+        files: ^(scripts|tests|custom_components)/.+\.py$
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+        files: ^(scripts|tests|custom_components)/.+\.py$
 
   - repo: https://github.com/adrienverge/yamllint.git
     rev: 81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6 # frozen: v1.35.1
@@ -64,3 +57,8 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-pytz
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: c6bd06256dd700a45e483869bcdcf304239393a6  # frozen: v1.6.27
+    hooks:
+      - id: actionlint

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -11,6 +11,7 @@
 #   Andrew Grimberg - Initial implementation
 ##############################################################################
 """The Rental Control integration."""
+
 from __future__ import annotations
 
 import asyncio
@@ -454,9 +455,7 @@ class RentalControl:
 
         return self._events_ready
 
-    async def async_get_events(
-        self, hass, start_date, end_date
-    ) -> list[CalendarEvent]:  # pylint: disable=unused-argument
+    async def async_get_events(self, hass, start_date, end_date) -> list[CalendarEvent]:  # pylint: disable=unused-argument
         """Get list of upcoming events."""
         _LOGGER.debug("Running RentalControl async_get_events")
         events = []

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -11,6 +11,7 @@
 #   Andrew Grimberg - Initial implementation
 ##############################################################################
 """Rental Control EventOVerrides."""
+
 import asyncio
 from datetime import datetime
 import logging

--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -15,9 +15,7 @@ from .sensors.calsensor import RentalControlCalSensor
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(
-    hass, config, add_entities, discovery_info=None
-):  # pylint: disable=unused-argument
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):  # pylint: disable=unused-argument
     """Set up this integration with config flow."""
     return True
 

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -11,6 +11,7 @@
 #   Andrew Grimberg - Initial implementation
 ##############################################################################
 """Rental Control utils."""
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
Remove the hooks for black, flake8, isort, and prettier as these are
subsumed by ruff.

Also addo actionlint to the pre-commit hooks to check the GitHub
Actions workflows.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
