### PR TITLE
Feat: Add support for short events

### DIFF
--- a/custom_components/rental_control/manifest.json
+++ b/custom_components/rental_control/manifest.json
@@ -9,6 +9,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tykeal/homeassistant-rental-control/issues",
-  "requirements": ["icalendar==5.0.7"],
+  "requirements": ["icalendar==5.0.7", "x-wr-timezone==0.0.7"],
   "version": "v0.0.0"
 }


### PR DESCRIPTION
Allow calendar entries that are not full-day events to be used directly
instead of overriding the start / stop times. This is useful for
maintenance calendars that have a specific time for an event.

Issue: Fixes #198
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
