### PR TITLE
Fix!: Cleanup mypy errors

### DIFF
--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -120,12 +120,15 @@ class RentalControlOptionsFlow(config_entries.OptionsFlow):
         user_input: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """Handle a flow initialized by the user."""
+        flow_data: Dict[str, Any] | None = None
+        if self.config_entry.data:
+            flow_data = dict(self.config_entry.data)
         return await _start_config_flow(
             self,
             "init",
             "",
             user_input,
-            self.config_entry.data,
+            flow_data,
             self.config_entry.entry_id,
         )
 

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -271,13 +271,16 @@ class EventOverrides:
         slot_name: str,
         start_time: datetime,
         end_time: datetime,
-        prefix: str,
+        prefix: str | None = None,
     ) -> None:
         """Update overrides."""
 
         _LOGGER.debug("In EventOverrides.update")
 
         overrides = self._overrides.copy()
+
+        if prefix is None:
+            prefix = ""
 
         if slot_name:
             regex = r"^(" + prefix + " )?(.*)$"

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "hacs": "1.32.1",
   "zip_release": true,
   "filename": "rental_control.zip",
-  "homeassistant": "2023.9.0"
+  "homeassistant": "2024.5.0"
 }

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,6 @@ ignore_missing_imports = True
 
 [mypy-icalendar.*]
 ignore_missing_imports = True
+
+[mypy-x_wr_timezone.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Home Assistant 2024.5 introduced changes that caused mypy to start
throwing new errors along with newer versions of mypy.

Requires Home Assistant 2024.5.0 or newer.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
