### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 02609a0003fd4903bd7f43852e5dfc82242a96db # frozen: v0.4.9
+    rev: 1dc9eb131c2ea4816c708e4d85820d2cc8542683 # frozen: v0.5.0
     hooks:
       - id: ruff
         files: ^(scripts|tests|custom_components)/.+\.py$
@@ -55,7 +55,7 @@ repos:
           - setuptools
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: e5ea6670624c24f8321f6328ef3176dbba76db46 # frozen: v1.10.0
+    rev: 6f546f30c2b142ad5b3edcf20e3d27cf1789b932 # frozen: v1.10.1
     hooks:
       - id: mypy
         additional_dependencies:
@@ -68,7 +68,7 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/fsfe/reuse-tool
-    rev: d8ec50072a04d53e027b4926bd73c999573a5edd # frozen: v3.1.0a1
+    rev: dedabab03c34f0f4ee77be8baf0a684714bdb6e9 # frozen: v4.0.2
     hooks:
       - id: reuse
 


### PR DESCRIPTION
* github.com/astral-sh/ruff-pre-commit: v0.4.9 -> v0.5.0 (frozen)
* github.com/pre-commit/mirrors-mypy: v1.100 -> v1.10.1 (frozen)
* github.com/fsfe/reuse-tool: v3.1.0a1 -> v4.0.2 (frozen)

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
