### PR TITLE
Fix: Await the async_forward_entry_setups call by

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -126,10 +126,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # Start listeners if needed
     await async_start_listener(hass, config_entry)
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     config_entry.add_update_listener(update_listener)
 


### PR DESCRIPTION
Starting with Home Assistant 2024.7 the async_forward_entry_setups
method must be awaited or we get a deprecation notice.

Issue: Fixes #211
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
