### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 6a19e69c83fd6e3a3ffdd5e32a40e35c37b02218 # frozen: v0.7.3
+    rev: 859e42ab7d54544f32d4f73bbc2136a7d9094f54 # frozen: v0.8.1
     hooks:
       - id: ruff
         files: ^(scripts|tests|custom_components)/.+\.py$
@@ -68,7 +68,7 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/fsfe/reuse-tool
-    rev: 4906d887c29f724e91a710c988cc786bd5b695b3 # frozen: v4.0.3
+    rev: 60dfc6b2ad9e1f3eabfbcf3a0dc202ee89dc5a00 # frozen: v5.0.2
     hooks:
       - id: reuse
 


### PR DESCRIPTION
* github.com/astral-sh/ruff-pre-commit: v0.7.3 -> v0.8.1 (frozen)
* github.com/fsfe/reuse-tool: v4.0.3 -> v5.0.2 (frozen)

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
