### PR TITLE
Docs: Add dependabot labels to release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,6 +27,8 @@ categories:
       - "documentation"
       - "maintenance"
       - "repo"
+      - "dependencies"
+      - "github_actions"
   - title: ":mortar_board: Code Quality :mortar_board:"
     labels:
       - "code-quality"


### PR DESCRIPTION
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
