### PR TITLE
Chore: Force update of requirements

### DIFF
--- a/custom_components/rental_control/manifest.json
+++ b/custom_components/rental_control/manifest.json
@@ -9,6 +9,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tykeal/homeassistant-rental-control/issues",
-  "requirements": ["icalendar", "x-wr-timezone"],
+  "requirements": ["icalendar>=6.1.0", "x-wr-timezone>=2.0.0"],
   "version": "v0.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "hacs": "1.32.1",
   "zip_release": true,
   "filename": "rental_control.zip",
-  "homeassistant": "2024.5.0"
+  "homeassistant": "2025.1.0"
 }


### PR DESCRIPTION
The previous version of icalendar is no longer in sync with the version
that is used by core Home Assistant. Make sure that installing the
integration uses the correct version and also forces an upgrade of
x-wr-timezone to the latest version.

Finally, since HA 2025.1.0 is the version that explicitly starts using
icalendar 6.1.0, make sure that is the base version needed.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
