### PR TITLE
CI: Update configuration for pre-commit CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,3 +25,4 @@ max_line_length = 80
 
 [*.yaml]
 indent_size = 2
+max_line_length = 120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,16 @@
 
 ---
 ci:
-  autofix_commit_msg: "Chore: pre-commit autofixes"
+  autofix_commit_msg: |
+    Chore: pre-commit autofixes
+
+    Signed-off-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   autofix_prs: false
-  autoupdate_commit_msg: "Chore: pre-commit autoupdate"
+  autoupdate_commit_msg: |
+    Chore: pre-commit autoupdate
+
+    Signed-off-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.yamllint
+++ b/.yamllint
@@ -11,3 +11,5 @@ rules:
     # prettier forces 1 space comment separator
     min-spaces-from-content: 1
     level: error
+  line-length:
+    max: 120


### PR DESCRIPTION
Make sure that pre-commit-ci is adding a DCO line. Upstream does not
view this as something that they should directly support or even do, but
since it is possible to set more than just the subject line, we can
effectively add the DCO line to the commit message just at the top of
the body instead of the footer.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
