### PR TITLE
Chore: Update release-drafter with proper labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,11 +10,9 @@ categories:
   - title: ":boom: Breaking Change :boom:"
     labels:
       - "breaking-change"
-  - title: ":zap: Enhancments :zap:"
+  - title: ":sparkles: New Features and Enhancements :sparkles:"
     labels:
       - "enhancement"
-  - title: ":sparkles: New Features :sparkles:"
-    labels:
       - "feature"
   - title: ":bug: Bug Fixes :bug:"
     labels:
@@ -39,7 +37,7 @@ autolabeler:
   - label: "breaking-change"
     title:
       - "/!:/i"
-  - label: "feature"
+  - label: "enhancement"
     title:
       - "/feat:/i"
   - label: "bug"


### PR DESCRIPTION
The "feature" label has not exhisted at all and previous "Feat:" commits
were manually getting marked as enhancement. Instead of needing to do
this manual work, we're switching the label to "enhancement" and
updating the release-drafter.yml to match.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
