### PR TITLE
Fix: Remove required Keymaster version contant

### DIFF
--- a/custom_components/rental_control/const.py
+++ b/custom_components/rental_control/const.py
@@ -10,8 +10,6 @@ DOMAIN_DATA = f"{DOMAIN}_DATA"
 VERSION = "0.0.1"
 LOCK_MANAGER = "keymaster"
 
-REQUIRED_KEYMASTER_MIN_VERSION = "v0.1.0-b0"
-
 ISSUE_URL = "https://github.com/tykeal/homeassistant-rental-control/issues"
 
 # In seconds; argument to asyncio.timeout

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -64,7 +64,6 @@ from .const import DEFAULT_CODE_LENGTH
 from .const import DEFAULT_REFRESH_FREQUENCY
 from .const import DOMAIN
 from .const import REQUEST_TIMEOUT
-from .const import REQUIRED_KEYMASTER_MIN_VERSION
 from .const import VERSION
 from .event_overrides import EventOverrides
 from .sensors.calsensor import RentalControlCalSensor
@@ -138,9 +137,9 @@ class RentalControlCoordinator:
             )
             has_reset = entity_registry.async_get(reset_entity)
             if has_reset is None:
-                error_msg = f"""
+                error_msg = """
 The version of Keymaster is incompatible with this version of Rental Control.
-Please update Keymaster to at least {REQUIRED_KEYMASTER_MIN_VERSION}
+Please update Keymaster to at least v0.1.0-b0
 """
                 _LOGGER.error(error_msg)
                 async_create(


### PR DESCRIPTION
For some reason the release did not pick up the new version of the
constants file. Just hard code it

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
