### PR TITLE
Fix: Drop events that ended before local midnight

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -489,7 +489,7 @@ Please update Keymaster to at least v0.1.0-b0
         _LOGGER.debug("Start: %s, End: %s", start, end)
         _LOGGER.debug("From: %s", from_date)
         # Ignore events that ended this midnight.
-        if (dt.as_utc(end).date() < dt.as_utc(from_date).date()) or (
+        if (dt.as_utc(end) < dt.as_utc(from_date)) or (
             dt.as_utc(end).date() == dt.as_utc(from_date).date()
             and end.hour == 0
             and end.minute == 0


### PR DESCRIPTION
Events that ended at or before local midnight have no effect on current
scheduling so they should be dropped.

Issue: Fixes #295
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
