### PR TITLE
Feat: Add additional Guesty summary detector

### DIFF
--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -313,6 +313,12 @@ def get_slot_name(summary: str, description: str, prefix: str) -> str | None:
         if len(ret):
             return str(ret[0]).strip()
 
+    # Guesty API
+    p = re.compile(r"^Reservation (.*)")
+    ret = p.findall(name)
+    if len(ret):
+        return str(ret[0]).strip()
+
     # Guesty
     p = re.compile(r"-(.*)-.*-")
     ret = p.findall(name)


### PR DESCRIPTION
The previous Guesty summary detector was looking at summary lines that
were from a URL that gave a different set of information. The summaries
coming out of
https://app.guesty.com/api/public/calendar-dashboard-api/export appear
to have a different configuration and all start with `Reservation `. As
the word `Reservation ` could show up in the previous format as well,
but in the center of the string we're putting the API format first to
catch those.

Fixes: #323
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
