### PR TITLE
CI: Disable dependabot for python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot is doing weird things to the uv lock file. I don't really
want to deal with it right now.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
