### PR TITLE
Test(integration): add Phase 6 integration tests

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Execution Date: 2026-02-06
 
-## Overall Status: Phase 5 Complete - Sensor and Entity Tests Implemented
+## Overall Status: Phase 6 Complete - Integration Tests Implemented
 
 ### Checklists Verification
 ✓ PASS - All checklists complete (requirements.md: 16/16 items completed)
@@ -105,13 +105,43 @@ SPDX-License-Identifier: Apache-2.0
 - [X] T100-T101: Unique ID and device_info delegation
 - [X] T102: CalSensor-specific: entity_category, icon, override interactions (set_code, update_times, clear_code, eta_days=0)
 
-#### ⏸️ Phases 6-7: Not Started (0/34 tasks)
-- Phase 6: User Story 4 - Integration Testing (0/23 tasks)
+#### ✅ Phase 6: User Story 4 - Integration Testing (100% Complete - 23/23 tasks)
+
+**Full Setup Integration Tests (T103-T110):** 8 tests implemented and passing
+- [x] T103: Created tests/integration/test_full_setup.py with structure
+- [x] T104: test_integration_setup_minimal_config - minimal config loads correctly
+- [x] T105: test_integration_setup_complete_config - all options load correctly
+- [x] T106: test_entities_created - 4 entities (1 calendar + 3 sensors) registered
+- [x] T107: test_coordinator_initialized - coordinator accessible via hass.data
+- [x] T108: test_platforms_loaded - sensor and calendar platforms registered
+- [x] T109: test_device_registry_entry - device created with correct identifiers
+- [x] T110: test_integration_unload - clean removal from hass.data + listeners
+
+**Refresh Cycle Integration Tests (T111-T117):** 6 tests implemented and passing
+- [x] T111: Created tests/integration/test_refresh_cycle.py with structure
+- [x] T112: test_initial_data_load - first refresh loads and parses ICS data
+- [x] T113: test_scheduled_refresh - next_refresh advances after interval
+- [x] T114: test_sensor_updates_on_refresh - sensor state includes guest name
+- [x] T115: test_calendar_updates_on_refresh - coordinator.event set correctly
+- [x] T116: test_door_code_generation_on_refresh - slot_code generated (4-digit)
+- [x] T117: test_concurrent_calendar_updates - two entries maintain independent state
+
+**Error Handling Integration Tests (T118-T125):** 7 tests implemented and passing
+- [x] T118: Created tests/integration/test_error_handling.py with structure
+- [x] T119: test_network_error_handling - HTTP 500 handled gracefully
+- [x] T120: test_invalid_ics_handling - missing-field events skipped
+- [x] T121: test_missing_calendar_handling - 404 responses handled
+- [x] T122: test_timeout_handling - TimeoutError does not crash setup
+- [x] T123: test_sensor_availability_on_error - sensors show "No reservation"
+- [x] T124: test_recovery_after_error - transitions from not-loaded to loaded
+- [x] T125: test_coordinator_error_state - calendar_loaded/calendar_ready tracking
+
+#### ⏸️ Phase 7: Not Started (0/11 tasks)
 - Phase 7: Polish & Cross-Cutting Concerns (0/11 tasks)
 
 ### Infrastructure Improvements
 
-#### Files Created (15 files)
+#### Files Created (19 files)
 1. `tests/__init__.py` - Test suite module
 2. `tests/conftest.py` - pytest fixtures and configuration
 3. `tests/fixtures/__init__.py` - Fixtures module
@@ -127,8 +157,12 @@ SPDX-License-Identifier: Apache-2.0
 13. `tests/unit/test_util.py` - Utility function tests (51 passing)
 14. `tests/unit/test_sensors.py` - Sensor platform and CalSensor entity tests (74 passing)
 15. `tests/integration/__init__.py` - Integration tests module
+16. `tests/integration/helpers.py` - Shared integration test helpers (FROZEN_TIME, future_ics)
+17. `tests/integration/test_full_setup.py` - Full setup integration tests (8 passing)
+18. `tests/integration/test_refresh_cycle.py` - Refresh cycle integration tests (6 passing)
+19. `tests/integration/test_error_handling.py` - Error handling integration tests (7 passing)
 
-#### Files Modified (4 files)
+#### Files Modified (5 files)
 1. `pyproject.toml` - Updated coverage settings (fail_under=80), added asyncio_mode config
 2. `setup.cfg` - Updated coverage fail_under from 100 to 80
 3. `requirements_test.txt` - Added aioresponses dependency
@@ -138,8 +172,8 @@ SPDX-License-Identifier: Apache-2.0
 ### Test Execution Results
 
 ```
-✓ All 227 tests passing
-✓ Phase 1-5 complete (102/140 tasks = 73%)
+✓ All 249 tests passing
+✓ Phase 1-6 complete (125/140 tasks = 89%)
 ✓ pytest-homeassistant-custom-component integration successful
 ✓ Async test execution configured correctly
 ✓ All pre-commit hooks passing

--- a/specs/001-test-coverage/tasks.md
+++ b/specs/001-test-coverage/tasks.md
@@ -231,35 +231,35 @@ SPDX-License-Identifier: Apache-2.0
 
 #### Full Setup Integration Tests
 
-- [ ] T103 [P] [US4] Create tests/integration/test_full_setup.py with SPDX header and module docstring
-- [ ] T104 [US4] Add test_integration_setup_minimal_config to verify integration loads with minimal required config in tests/integration/test_full_setup.py
-- [ ] T105 [US4] Add test_integration_setup_complete_config to verify integration loads with all configuration options in tests/integration/test_full_setup.py
-- [ ] T106 [US4] Add test_entities_created to verify all expected entities appear in entity registry in tests/integration/test_full_setup.py
-- [ ] T107 [US4] Add test_coordinator_initialized to verify coordinator is created and accessible in tests/integration/test_full_setup.py
-- [ ] T108 [US4] Add test_platforms_loaded to verify sensor and calendar platforms are loaded in tests/integration/test_full_setup.py
-- [ ] T109 [US4] Add test_device_registry_entry to verify device is registered for the calendar in tests/integration/test_full_setup.py
-- [ ] T110 [US4] Add test_integration_unload to verify clean unload and entity removal in tests/integration/test_full_setup.py
+- [x] T103 [P] [US4] Create tests/integration/test_full_setup.py with SPDX header and module docstring
+- [x] T104 [US4] Add test_integration_setup_minimal_config to verify integration loads with minimal required config in tests/integration/test_full_setup.py
+- [x] T105 [US4] Add test_integration_setup_complete_config to verify integration loads with all configuration options in tests/integration/test_full_setup.py
+- [x] T106 [US4] Add test_entities_created to verify all expected entities appear in entity registry in tests/integration/test_full_setup.py
+- [x] T107 [US4] Add test_coordinator_initialized to verify coordinator is created and accessible in tests/integration/test_full_setup.py
+- [x] T108 [US4] Add test_platforms_loaded to verify sensor and calendar platforms are loaded in tests/integration/test_full_setup.py
+- [x] T109 [US4] Add test_device_registry_entry to verify device is registered for the calendar in tests/integration/test_full_setup.py
+- [x] T110 [US4] Add test_integration_unload to verify clean unload and entity removal in tests/integration/test_full_setup.py
 
 #### Refresh Cycle Integration Tests
 
-- [ ] T111 [P] [US4] Create tests/integration/test_refresh_cycle.py with SPDX header and module docstring
-- [ ] T112 [US4] Add test_initial_data_load to verify first refresh fetches and processes calendar data in tests/integration/test_refresh_cycle.py
-- [ ] T113 [US4] Add test_scheduled_refresh to verify automatic refresh on schedule in tests/integration/test_refresh_cycle.py
-- [ ] T114 [US4] Add test_sensor_updates_on_refresh to verify sensor states update after coordinator refresh in tests/integration/test_refresh_cycle.py
-- [ ] T115 [US4] Add test_calendar_updates_on_refresh to verify calendar entity reflects new events in tests/integration/test_refresh_cycle.py
-- [ ] T116 [US4] Add test_door_code_generation_on_refresh to verify door codes are generated during refresh in tests/integration/test_refresh_cycle.py
-- [ ] T117 [US4] Add test_concurrent_calendar_updates to verify multiple calendars update independently in tests/integration/test_refresh_cycle.py
+- [x] T111 [P] [US4] Create tests/integration/test_refresh_cycle.py with SPDX header and module docstring
+- [x] T112 [US4] Add test_initial_data_load to verify first refresh fetches and processes calendar data in tests/integration/test_refresh_cycle.py
+- [x] T113 [US4] Add test_scheduled_refresh to verify automatic refresh on schedule in tests/integration/test_refresh_cycle.py
+- [x] T114 [US4] Add test_sensor_updates_on_refresh to verify sensor states update after coordinator refresh in tests/integration/test_refresh_cycle.py
+- [x] T115 [US4] Add test_calendar_updates_on_refresh to verify calendar entity reflects new events in tests/integration/test_refresh_cycle.py
+- [x] T116 [US4] Add test_door_code_generation_on_refresh to verify door codes are generated during refresh in tests/integration/test_refresh_cycle.py
+- [x] T117 [US4] Add test_concurrent_calendar_updates to verify multiple calendars update independently in tests/integration/test_refresh_cycle.py
 
 #### Error Handling Integration Tests
 
-- [ ] T118 [P] [US4] Create tests/integration/test_error_handling.py with SPDX header and module docstring
-- [ ] T119 [US4] Add test_network_error_handling to verify integration handles HTTP failures gracefully in tests/integration/test_error_handling.py
-- [ ] T120 [US4] Add test_invalid_ics_handling to verify integration handles malformed ICS data in tests/integration/test_error_handling.py
-- [ ] T121 [US4] Add test_missing_calendar_handling to verify integration handles 404 responses in tests/integration/test_error_handling.py
-- [ ] T122 [US4] Add test_timeout_handling to verify integration handles request timeouts in tests/integration/test_error_handling.py
-- [ ] T123 [US4] Add test_sensor_availability_on_error to verify sensors show unavailable on persistent errors in tests/integration/test_error_handling.py
-- [ ] T124 [US4] Add test_recovery_after_error to verify integration recovers when calendar becomes available again in tests/integration/test_error_handling.py
-- [ ] T125 [US4] Add test_coordinator_error_state to verify coordinator maintains error state correctly in tests/integration/test_error_handling.py
+- [x] T118 [P] [US4] Create tests/integration/test_error_handling.py with SPDX header and module docstring
+- [x] T119 [US4] Add test_network_error_handling to verify integration handles HTTP failures gracefully in tests/integration/test_error_handling.py
+- [x] T120 [US4] Add test_invalid_ics_handling to verify integration handles malformed ICS data in tests/integration/test_error_handling.py
+- [x] T121 [US4] Add test_missing_calendar_handling to verify integration handles 404 responses in tests/integration/test_error_handling.py
+- [x] T122 [US4] Add test_timeout_handling to verify integration handles request timeouts in tests/integration/test_error_handling.py
+- [x] T123 [US4] Add test_sensor_availability_on_error to verify sensors show unavailable on persistent errors in tests/integration/test_error_handling.py
+- [x] T124 [US4] Add test_recovery_after_error to verify integration recovers when calendar becomes available again in tests/integration/test_error_handling.py
+- [x] T125 [US4] Add test_coordinator_error_state to verify coordinator maintains error state correctly in tests/integration/test_error_handling.py
 
 **Checkpoint**: All user stories should now be independently functional. Integration tests verify end-to-end scenarios work correctly.
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for integration tests."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+
+from homeassistant.util import dt as dt_util
+
+FROZEN_TIME = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+
+
+def future_ics(
+    summary: str = "Reserved: Test Guest",
+    description: str = "Email: test@example.com\\nPhone: +1234567890\\nGuests: 2",
+    days_ahead: int = 5,
+    duration: int = 5,
+    *,
+    base_time: datetime = FROZEN_TIME,
+) -> str:
+    """Build a single-event ICS with dates relative to *base_time*."""
+    start = (base_time + timedelta(days=days_ahead)).strftime("%Y%m%d")
+    end = (base_time + timedelta(days=days_ahead + duration)).strftime("%Y%m%d")
+    return (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//Test//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        f"DTSTART:{start}T160000Z\r\n"
+        f"DTEND:{end}T110000Z\r\n"
+        "UID:future-test@example.com\r\n"
+        f"SUMMARY:{summary}\r\n"
+        f"DESCRIPTION:{description}\r\n"
+        "STATUS:CONFIRMED\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
 # SPDX-License-Identifier: Apache-2.0
+
 """Shared helpers for integration tests."""
 
 from __future__ import annotations

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from homeassistant.util import dt as dt_util
 
 FROZEN_TIME = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+FROZEN_START_OF_DAY = datetime(2024, 12, 20, 0, 0, 0, tzinfo=dt_util.UTC)
 
 
 def future_ics(
@@ -21,7 +22,11 @@ def future_ics(
     *,
     base_time: datetime = FROZEN_TIME,
 ) -> str:
-    """Build a single-event ICS with dates relative to *base_time*."""
+    """Build a single-event ICS with dates relative to *base_time*.
+
+    Event start/end times are fixed at 16:00:00Z and 11:00:00Z respectively;
+    only date components are derived from *base_time*.
+    """
     start = (base_time + timedelta(days=days_ahead)).strftime("%Y%m%d")
     end = (base_time + timedelta(days=days_ahead + duration)).strftime("%Y%m%d")
     return (

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for error handling in Rental Control.
+
+These tests verify that the integration handles network errors, malformed
+ICS data, HTTP failures, timeouts, and recovery scenarios gracefully
+without crashing or leaving the system in an inconsistent state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from aioresponses import aioresponses
+import homeassistant.util.dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.rental_control.const import COORDINATOR
+from custom_components.rental_control.const import DOMAIN
+
+from tests.fixtures import calendar_data
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+FROZEN_TIME = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+
+
+def _future_ics(
+    summary: str = "Reserved: Test Guest",
+    days_ahead: int = 5,
+    duration: int = 5,
+    *,
+    base_time: datetime = FROZEN_TIME,
+) -> str:
+    """Build a single-event ICS with dates relative to *base_time*."""
+    start = (base_time + timedelta(days=days_ahead)).strftime("%Y%m%d")
+    end = (base_time + timedelta(days=days_ahead + duration)).strftime("%Y%m%d")
+    return (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//Test//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        f"DTSTART:{start}T160000Z\r\n"
+        f"DTEND:{end}T110000Z\r\n"
+        "UID:future-test@example.com\r\n"
+        f"SUMMARY:{summary}\r\n"
+        "DESCRIPTION:Email: test@example.com\r\n"
+        "STATUS:CONFIRMED\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T119 – network error handling
+# ---------------------------------------------------------------------------
+
+
+async def test_network_error_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify integration handles HTTP failures gracefully.
+
+    When the calendar URL returns HTTP 500, the integration should still
+    set up successfully (coordinator is created), but the calendar should
+    not be marked as loaded.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=500,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+    assert coordinator.calendar_loaded is False
+    assert len(coordinator.calendar) == 0
+
+
+# ---------------------------------------------------------------------------
+# T120 – invalid ICS handling
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_ics_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify integration handles ICS data with missing fields.
+
+    ICS events that lack DTSTART/DTEND should be skipped during parsing.
+    The coordinator should still load without raising an exception.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=200,
+            body=calendar_data.ICS_MISSING_FIELDS,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+    # Missing-fields events are skipped; calendar_loaded may be True
+    # but the calendar list should be empty
+    assert len(coordinator.calendar) == 0
+
+
+# ---------------------------------------------------------------------------
+# T121 – missing calendar (404)
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_calendar_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify integration handles 404 responses.
+
+    A 404 means the calendar URL is not found. The coordinator should
+    handle this gracefully without crashing.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=404,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+    assert coordinator.calendar_loaded is False
+    assert len(coordinator.calendar) == 0
+
+
+# ---------------------------------------------------------------------------
+# T122 – timeout handling
+# ---------------------------------------------------------------------------
+
+
+async def test_timeout_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify integration handles request timeouts.
+
+    When the HTTP request raises a TimeoutError the coordinator should
+    not crash the integration setup.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        mock_session.get(
+            mock_config_entry.data["url"],
+            exception=asyncio.TimeoutError(),
+            repeat=True,
+        )
+
+        # Setup may succeed (coordinator created) even if fetch times out.
+        # The important thing is it doesn't raise an unhandled exception.
+        result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # If setup returned True, coordinator should exist but calendar not loaded
+    if result:
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+        assert coordinator.calendar_loaded is False
+
+
+# ---------------------------------------------------------------------------
+# T123 – sensor availability on error
+# ---------------------------------------------------------------------------
+
+
+async def test_sensor_availability_on_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify sensors remain available but show no-reservation state on error.
+
+    When the calendar fails to load, sensors should still be created
+    and show "No reservation" as their state.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=500,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+    assert len(coordinator.event_sensors) == mock_config_entry.data["max_events"]
+
+    for sensor in coordinator.event_sensors:
+        assert "No reservation" in sensor.state
+
+
+# ---------------------------------------------------------------------------
+# T124 – recovery after error
+# ---------------------------------------------------------------------------
+
+
+async def test_recovery_after_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify integration recovers when calendar becomes available again.
+
+    First update returns an error; second update returns valid data.
+    The coordinator should transition from not-loaded to loaded.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    # Freeze time during setup so next_refresh is predictable
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=500,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+    assert coordinator.calendar_loaded is False
+
+    # Advance past refresh interval and provide valid data
+    future = FROZEN_TIME + timedelta(minutes=coordinator.refresh_frequency + 1)
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=future),
+        patch.object(dt_util, "start_of_local_day", return_value=future),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=200,
+            body=_future_ics(base_time=future),
+            repeat=True,
+        )
+
+        await coordinator.update()
+        await hass.async_block_till_done()
+
+    assert coordinator.calendar_loaded is True
+    assert len(coordinator.calendar) > 0
+
+
+# ---------------------------------------------------------------------------
+# T125 – coordinator error state tracking
+# ---------------------------------------------------------------------------
+
+
+async def test_coordinator_error_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify coordinator maintains error state correctly.
+
+    After a failed fetch the coordinator should keep calendar_loaded as
+    False and calendar_ready as False. After a successful fetch both
+    should become True (ready depends on overrides, which are not
+    configured here so overrides_loaded defaults to True on first load).
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    # Freeze time during setup so next_refresh is predictable
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=500,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+    assert coordinator.calendar_loaded is False
+    assert coordinator.calendar_ready is False
+
+    # Now succeed with time advanced past next_refresh
+    future = FROZEN_TIME + timedelta(minutes=coordinator.refresh_frequency + 1)
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=future),
+        patch.object(dt_util, "start_of_local_day", return_value=future),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=200,
+            body=_future_ics(base_time=future),
+            repeat=True,
+        )
+
+        await coordinator.update()
+        await hass.async_block_till_done()
+
+    assert coordinator.calendar_loaded is True
+    assert coordinator.calendar_ready is True

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -23,6 +23,7 @@ from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DOMAIN
 
 from tests.fixtures import calendar_data
+from tests.integration.helpers import FROZEN_START_OF_DAY
 from tests.integration.helpers import FROZEN_TIME
 from tests.integration.helpers import future_ics
 
@@ -81,7 +82,7 @@ async def test_invalid_ics_handling(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=FROZEN_TIME),
-        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -217,7 +218,7 @@ async def test_recovery_after_error(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=FROZEN_TIME),
-        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -237,7 +238,11 @@ async def test_recovery_after_error(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=future),
-        patch.object(dt_util, "start_of_local_day", return_value=future),
+        patch.object(
+            dt_util,
+            "start_of_local_day",
+            return_value=future.replace(hour=0, minute=0, second=0, microsecond=0),
+        ),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -275,7 +280,7 @@ async def test_coordinator_error_state(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=FROZEN_TIME),
-        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -295,7 +300,11 @@ async def test_coordinator_error_state(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=future),
-        patch.object(dt_util, "start_of_local_day", return_value=future),
+        patch.object(
+            dt_util,
+            "start_of_local_day",
+            return_value=future.replace(hour=0, minute=0, second=0, microsecond=0),
+        ),
     ):
         mock_session.get(
             mock_config_entry.data["url"],

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -11,7 +11,6 @@ without crashing or leaving the system in an inconsistent state.
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -24,42 +23,11 @@ from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DOMAIN
 
 from tests.fixtures import calendar_data
+from tests.integration.helpers import FROZEN_TIME
+from tests.integration.helpers import future_ics
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-
-
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
-
-FROZEN_TIME = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
-
-
-def _future_ics(
-    summary: str = "Reserved: Test Guest",
-    days_ahead: int = 5,
-    duration: int = 5,
-    *,
-    base_time: datetime = FROZEN_TIME,
-) -> str:
-    """Build a single-event ICS with dates relative to *base_time*."""
-    start = (base_time + timedelta(days=days_ahead)).strftime("%Y%m%d")
-    end = (base_time + timedelta(days=days_ahead + duration)).strftime("%Y%m%d")
-    return (
-        "BEGIN:VCALENDAR\r\n"
-        "VERSION:2.0\r\n"
-        "PRODID:-//Test//EN\r\n"
-        "BEGIN:VEVENT\r\n"
-        f"DTSTART:{start}T160000Z\r\n"
-        f"DTEND:{end}T110000Z\r\n"
-        "UID:future-test@example.com\r\n"
-        f"SUMMARY:{summary}\r\n"
-        "DESCRIPTION:Email: test@example.com\r\n"
-        "STATUS:CONFIRMED\r\n"
-        "END:VEVENT\r\n"
-        "END:VCALENDAR\r\n"
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -205,7 +173,7 @@ async def test_sensor_availability_on_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Verify sensors remain available but show no-reservation state on error.
+    """Verify sensors are created and show no-reservation state on error.
 
     When the calendar fails to load, sensors should still be created
     and show "No reservation" as their state.
@@ -274,7 +242,7 @@ async def test_recovery_after_error(
         mock_session.get(
             mock_config_entry.data["url"],
             status=200,
-            body=_future_ics(base_time=future),
+            body=future_ics(base_time=future),
             repeat=True,
         )
 
@@ -332,7 +300,7 @@ async def test_coordinator_error_state(
         mock_session.get(
             mock_config_entry.data["url"],
             status=200,
-            body=_future_ics(base_time=future),
+            body=future_ics(base_time=future),
             repeat=True,
         )
 

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -154,15 +154,14 @@ async def test_timeout_handling(
             repeat=True,
         )
 
-        # Setup may succeed (coordinator created) even if fetch times out.
-        # The important thing is it doesn't raise an unhandled exception.
+        # Setup succeeds even when fetch times out; coordinator is created
+        # but calendar data is not loaded.
         result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    # If setup returned True, coordinator should exist but calendar not loaded
-    if result:
-        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
-        assert coordinator.calendar_loaded is False
+    assert result is True
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+    assert coordinator.calendar_loaded is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_full_setup.py
+++ b/tests/integration/test_full_setup.py
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for full setup and teardown of Rental Control.
+
+These tests verify the end-to-end integration lifecycle: loading with
+various configurations, verifying entity and device creation, platform
+forwarding, and clean unload behavior.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aioresponses import aioresponses
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.rental_control.const import COORDINATOR
+from custom_components.rental_control.const import DOMAIN
+from custom_components.rental_control.const import PLATFORMS
+from custom_components.rental_control.const import UNSUB_LISTENERS
+
+from tests.fixtures import calendar_data
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_calendar_response(
+    mock_session: aioresponses,
+    url: str = "https://example.com/calendar.ics",
+    body: str = calendar_data.AIRBNB_ICS_CALENDAR,
+    *,
+    repeat: bool = True,
+) -> None:
+    """Register a mock GET response for a calendar URL."""
+    mock_session.get(url, status=200, body=body, repeat=repeat)
+
+
+# ---------------------------------------------------------------------------
+# T104 – minimal configuration
+# ---------------------------------------------------------------------------
+
+
+async def test_integration_setup_minimal_config(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify integration loads with minimal required configuration.
+
+    Uses the ``mock_config_entry`` fixture which carries only the
+    mandatory fields (name, url, timezone, checkin/checkout, start_slot,
+    max_events, days, verify_ssl, ignore_non_reserved).
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        _mock_calendar_response(mock_session, mock_config_entry.data["url"])
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert DOMAIN in hass.data
+    assert mock_config_entry.entry_id in hass.data[DOMAIN]
+    assert COORDINATOR in hass.data[DOMAIN][mock_config_entry.entry_id]
+
+
+# ---------------------------------------------------------------------------
+# T105 – complete configuration
+# ---------------------------------------------------------------------------
+
+
+async def test_integration_setup_complete_config(
+    hass: HomeAssistant,
+) -> None:
+    """Verify integration loads with all configuration options set.
+
+    Creates a config entry with all fields in ``data`` (as the
+    coordinator reads from ``config_entry.data``, not ``options``).
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Complete Rental",
+        data={
+            "name": "Complete Rental",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "America/New_York",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            "start_slot": 10,
+            "max_events": 5,
+            "days": 365,
+            "verify_ssl": True,
+            "ignore_non_reserved": True,
+            "code_generation": "date_based",
+            "code_length": 4,
+            "should_update_code": True,
+            "event_prefix": "Rental",
+        },
+        entry_id="test_entry_full_id",
+    )
+    entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        _mock_calendar_response(mock_session, entry.data["url"])
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+    assert coordinator.code_generator == "date_based"
+    assert coordinator.code_length == 4
+    assert coordinator.ignore_non_reserved is True
+
+
+# ---------------------------------------------------------------------------
+# T106 – entity creation
+# ---------------------------------------------------------------------------
+
+
+async def test_entities_created(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify all expected entities appear in the entity registry.
+
+    With max_events=3 the integration should create 3 sensor entities
+    and 1 calendar entity (4 entities total).
+    """
+    from homeassistant.helpers import entity_registry as er
+
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        _mock_calendar_response(mock_session, mock_config_entry.data["url"])
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(ent_reg, mock_config_entry.entry_id)
+
+    # 1 calendar + max_events (3) sensors
+    assert len(entities) == 4
+
+    domains = {e.domain for e in entities}
+    assert "calendar" in domains
+    assert "sensor" in domains
+
+    sensor_entities = [e for e in entities if e.domain == "sensor"]
+    assert len(sensor_entities) == 3
+
+
+# ---------------------------------------------------------------------------
+# T107 – coordinator accessible
+# ---------------------------------------------------------------------------
+
+
+async def test_coordinator_initialized(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify coordinator is created and accessible via hass.data."""
+    from custom_components.rental_control.coordinator import RentalControlCoordinator
+
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        _mock_calendar_response(mock_session, mock_config_entry.data["url"])
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+    assert isinstance(coordinator, RentalControlCoordinator)
+    assert coordinator.name == "Test Rental"
+    assert coordinator.url == mock_config_entry.data["url"]
+    assert coordinator.max_events == 3
+
+
+# ---------------------------------------------------------------------------
+# T108 – platforms loaded
+# ---------------------------------------------------------------------------
+
+
+async def test_platforms_loaded(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify sensor and calendar platforms are loaded."""
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        _mock_calendar_response(mock_session, mock_config_entry.data["url"])
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert DOMAIN in hass.config.components
+    for platform in PLATFORMS:
+        assert platform in hass.config.components
+
+
+# ---------------------------------------------------------------------------
+# T109 – device registry
+# ---------------------------------------------------------------------------
+
+
+async def test_device_registry_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify a device is registered for the integration entry."""
+    from homeassistant.helpers import device_registry as dr
+
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        _mock_calendar_response(mock_session, mock_config_entry.data["url"])
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    dev_reg = dr.async_get(hass)
+    devices = dr.async_entries_for_config_entry(dev_reg, mock_config_entry.entry_id)
+
+    assert len(devices) == 1
+    device = devices[0]
+    assert device.name == "Test Rental"
+    assert (DOMAIN, mock_config_entry.unique_id) in device.identifiers
+
+
+# ---------------------------------------------------------------------------
+# T110 – clean unload
+# ---------------------------------------------------------------------------
+
+
+async def test_integration_unload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify clean unload removes entry from hass.data."""
+
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        _mock_calendar_response(mock_session, mock_config_entry.data["url"])
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Verify entry exists before unload
+    assert mock_config_entry.entry_id in hass.data[DOMAIN]
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Entry should be removed from hass.data
+    assert mock_config_entry.entry_id not in hass.data.get(DOMAIN, {})
+
+
+async def test_integration_unload_clears_listeners(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify unload clears the listener subscriptions list."""
+    mock_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mock_session:
+        _mock_calendar_response(mock_session, mock_config_entry.data["url"])
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Listener list is present before unload
+    assert UNSUB_LISTENERS in hass.data[DOMAIN][mock_config_entry.entry_id]
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.entry_id not in hass.data.get(DOMAIN, {})

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -1,0 +1,428 @@
+# SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for calendar refresh cycles.
+
+These tests verify that the coordinator refresh pipeline works end-to-end:
+initial data load, scheduled refresh, sensor/calendar state propagation,
+door-code generation, and independent multi-entry updates.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from aioresponses import aioresponses
+import homeassistant.util.dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.rental_control.const import COORDINATOR
+from custom_components.rental_control.const import DOMAIN
+
+from tests.fixtures import calendar_data
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+# Frozen time before fixture events (Jan 2025)
+FROZEN_TIME = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+
+
+def _future_ics(
+    summary: str = "Reserved: Test Guest",
+    description: str = "Email: test@example.com\\nPhone: +1234567890\\nGuests: 2",
+    days_ahead: int = 5,
+    duration: int = 5,
+    *,
+    base_time: datetime = FROZEN_TIME,
+) -> str:
+    """Build a single-event ICS with dates relative to *base_time*."""
+    start = (base_time + timedelta(days=days_ahead)).strftime("%Y%m%d")
+    end = (base_time + timedelta(days=days_ahead + duration)).strftime("%Y%m%d")
+    return (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//Test//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        f"DTSTART:{start}T160000Z\r\n"
+        f"DTEND:{end}T110000Z\r\n"
+        "UID:future-test@example.com\r\n"
+        f"SUMMARY:{summary}\r\n"
+        f"DESCRIPTION:{description}\r\n"
+        "STATUS:CONFIRMED\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T112 – initial data load
+# ---------------------------------------------------------------------------
+
+
+async def test_initial_data_load(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify first refresh fetches and processes calendar data.
+
+    After integration setup the coordinator should have loaded the ICS
+    feed and populated its calendar list with parsed events.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=200,
+            body=calendar_data.AIRBNB_ICS_CALENDAR,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+    assert coordinator.calendar_loaded is True
+    assert len(coordinator.calendar) > 0
+
+
+# ---------------------------------------------------------------------------
+# T113 – scheduled refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_scheduled_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify automatic refresh happens after the refresh interval elapses.
+
+    Calls coordinator.update() twice: once to seed, then after advancing
+    past next_refresh to confirm a second fetch occurs.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=200,
+            body=calendar_data.AIRBNB_ICS_CALENDAR,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+        first_next_refresh = coordinator.next_refresh
+
+    # Advance past the refresh interval and trigger update
+    future = FROZEN_TIME + timedelta(minutes=coordinator.refresh_frequency + 1)
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=future),
+        patch.object(dt_util, "start_of_local_day", return_value=future),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=200,
+            body=calendar_data.AIRBNB_ICS_CALENDAR,
+            repeat=True,
+        )
+
+        await coordinator.update()
+        await hass.async_block_till_done()
+
+    assert coordinator.next_refresh > first_next_refresh
+
+
+# ---------------------------------------------------------------------------
+# T114 – sensor state updates on refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_sensor_updates_on_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify sensor entity states reflect data after coordinator refresh.
+
+    After setup, sensors are created but not yet updated with event data.
+    A subsequent coordinator update (with time advanced past next_refresh)
+    triggers sensor updates so their state includes the guest name.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    ics_body = _future_ics()
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=200,
+            body=ics_body,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+        assert len(coordinator.event_sensors) == mock_config_entry.data["max_events"]
+
+        # Advance past next_refresh so a second update triggers a full refresh
+        # which also calls async_update on all event sensors
+        future = FROZEN_TIME + timedelta(minutes=coordinator.refresh_frequency + 1)
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=future),
+        patch.object(dt_util, "start_of_local_day", return_value=future),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=200,
+            body=ics_body,
+            repeat=True,
+        )
+
+        await coordinator.update()
+        await hass.async_block_till_done()
+
+    first_sensor = coordinator.event_sensors[0]
+    assert first_sensor.state is not None
+    assert "Test Guest" in first_sensor.state
+
+
+# ---------------------------------------------------------------------------
+# T115 – calendar entity reflects new events
+# ---------------------------------------------------------------------------
+
+
+async def test_calendar_updates_on_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify calendar entity reflects events after refresh.
+
+    The coordinator.event should be set to the next upcoming event
+    after the initial data load.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    ics_body = _future_ics()
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+    ):
+        mock_session.get(
+            mock_config_entry.data["url"],
+            status=200,
+            body=ics_body,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
+
+    assert coordinator.event is not None
+    assert coordinator.event.summary == "Reserved: Test Guest"
+
+
+# ---------------------------------------------------------------------------
+# T116 – door code generation on refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_door_code_generation_on_refresh(
+    hass: HomeAssistant,
+) -> None:
+    """Verify door codes are generated during refresh when configured.
+
+    Uses a config entry with code_generation enabled. After the initial
+    setup, a second coordinator update (past next_refresh) triggers
+    sensor updates which generate door codes from event data.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Code Test",
+        data={
+            "name": "Code Test",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "America/New_York",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            "start_slot": 10,
+            "max_events": 3,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "code_generation": "date_based",
+            "code_length": 4,
+        },
+        entry_id="test_code_entry",
+    )
+    entry.add_to_hass(hass)
+
+    ics_body = _future_ics()
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+    ):
+        mock_session.get(
+            entry.data["url"],
+            status=200,
+            body=ics_body,
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+
+        # Trigger a second refresh to populate sensors with event data
+        future = FROZEN_TIME + timedelta(minutes=coordinator.refresh_frequency + 1)
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=future),
+        patch.object(dt_util, "start_of_local_day", return_value=future),
+    ):
+        mock_session.get(
+            entry.data["url"],
+            status=200,
+            body=ics_body,
+            repeat=True,
+        )
+
+        await coordinator.update()
+        await hass.async_block_till_done()
+
+    first_sensor = coordinator.event_sensors[0]
+
+    # Sensor with an event should have generated a door code (stored as slot_code)
+    attrs = first_sensor.extra_state_attributes
+    assert attrs.get("slot_code") is not None
+    assert len(attrs["slot_code"]) == 4
+    assert attrs["slot_code"].isdigit()
+
+
+# ---------------------------------------------------------------------------
+# T117 – concurrent calendar updates (multiple entries)
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_calendar_updates(
+    hass: HomeAssistant,
+) -> None:
+    """Verify multiple config entries update independently.
+
+    Sets up two separate integration entries, each with its own calendar
+    URL and ICS data, and confirms they maintain independent state.
+    Version is set to 7 to skip migrations that would overwrite
+    unique_id with gen_uuid(dt.now()) and cause a collision.
+    """
+    entry_a = MockConfigEntry(
+        domain=DOMAIN,
+        title="Rental A",
+        unique_id="unique_rental_a",
+        version=7,
+        data={
+            "name": "Rental A",
+            "url": "https://example.com/a.ics",
+            "timezone": "America/New_York",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            "start_slot": 10,
+            "max_events": 2,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "creation_datetime": "2025-01-01T00:00:00",
+        },
+        entry_id="entry_a",
+    )
+    entry_b = MockConfigEntry(
+        domain=DOMAIN,
+        title="Rental B",
+        unique_id="unique_rental_b",
+        version=7,
+        data={
+            "name": "Rental B",
+            "url": "https://example.com/b.ics",
+            "timezone": "America/Chicago",
+            "checkin": "15:00",
+            "checkout": "10:00",
+            "start_slot": 20,
+            "max_events": 3,
+            "days": 180,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "creation_datetime": "2025-02-01T00:00:00",
+        },
+        entry_id="entry_b",
+    )
+
+    ics_a = _future_ics(summary="Reserved: Guest A")
+    ics_b = _future_ics(summary="Reserved: Guest B", days_ahead=10)
+
+    entry_a.add_to_hass(hass)
+    entry_b.add_to_hass(hass)
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+    ):
+        mock_session.get(entry_a.data["url"], status=200, body=ics_a, repeat=True)
+        mock_session.get(entry_b.data["url"], status=200, body=ics_b, repeat=True)
+
+        # HA component setup auto-loads all registered config entries for the
+        # domain.  Calling async_setup on entry_a triggers async_setup_component
+        # which in turn sets up every entry added to hass for this domain.
+        assert await hass.config_entries.async_setup(entry_a.entry_id)
+        await hass.async_block_till_done()
+
+    coord_a = hass.data[DOMAIN][entry_a.entry_id][COORDINATOR]
+    coord_b = hass.data[DOMAIN][entry_b.entry_id][COORDINATOR]
+
+    assert coord_a.name == "Rental A"
+    assert coord_b.name == "Rental B"
+    assert coord_a.max_events == 2
+    assert coord_b.max_events == 3
+    assert len(coord_a.event_sensors) == 2
+    assert len(coord_b.event_sensors) == 3
+
+    # Each coordinator loaded its own calendar independently
+    assert coord_a.calendar_loaded is True
+    assert coord_b.calendar_loaded is True
+    assert coord_a.event.summary == "Reserved: Guest A"
+    assert coord_b.event.summary == "Reserved: Guest B"

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -10,7 +10,6 @@ door-code generation, and independent multi-entry updates.
 
 from __future__ import annotations
 
-from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -23,44 +22,11 @@ from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DOMAIN
 
 from tests.fixtures import calendar_data
+from tests.integration.helpers import FROZEN_TIME
+from tests.integration.helpers import future_ics
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-
-
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
-
-# Frozen time before fixture events (Jan 2025)
-FROZEN_TIME = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
-
-
-def _future_ics(
-    summary: str = "Reserved: Test Guest",
-    description: str = "Email: test@example.com\\nPhone: +1234567890\\nGuests: 2",
-    days_ahead: int = 5,
-    duration: int = 5,
-    *,
-    base_time: datetime = FROZEN_TIME,
-) -> str:
-    """Build a single-event ICS with dates relative to *base_time*."""
-    start = (base_time + timedelta(days=days_ahead)).strftime("%Y%m%d")
-    end = (base_time + timedelta(days=days_ahead + duration)).strftime("%Y%m%d")
-    return (
-        "BEGIN:VCALENDAR\r\n"
-        "VERSION:2.0\r\n"
-        "PRODID:-//Test//EN\r\n"
-        "BEGIN:VEVENT\r\n"
-        f"DTSTART:{start}T160000Z\r\n"
-        f"DTEND:{end}T110000Z\r\n"
-        "UID:future-test@example.com\r\n"
-        f"SUMMARY:{summary}\r\n"
-        f"DESCRIPTION:{description}\r\n"
-        "STATUS:CONFIRMED\r\n"
-        "END:VEVENT\r\n"
-        "END:VCALENDAR\r\n"
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +137,7 @@ async def test_sensor_updates_on_refresh(
     """
     mock_config_entry.add_to_hass(hass)
 
-    ics_body = _future_ics()
+    ics_body = future_ics()
 
     with (
         aioresponses() as mock_session,
@@ -231,7 +197,7 @@ async def test_calendar_updates_on_refresh(
     """
     mock_config_entry.add_to_hass(hass)
 
-    ics_body = _future_ics()
+    ics_body = future_ics()
 
     with (
         aioresponses() as mock_session,
@@ -289,7 +255,7 @@ async def test_door_code_generation_on_refresh(
     )
     entry.add_to_hass(hass)
 
-    ics_body = _future_ics()
+    ics_body = future_ics()
 
     with (
         aioresponses() as mock_session,
@@ -391,8 +357,8 @@ async def test_concurrent_calendar_updates(
         entry_id="entry_b",
     )
 
-    ics_a = _future_ics(summary="Reserved: Guest A")
-    ics_b = _future_ics(summary="Reserved: Guest B", days_ahead=10)
+    ics_a = future_ics(summary="Reserved: Guest A")
+    ics_b = future_ics(summary="Reserved: Guest B", days_ahead=10)
 
     entry_a.add_to_hass(hass)
     entry_b.add_to_hass(hass)

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -22,6 +22,7 @@ from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DOMAIN
 
 from tests.fixtures import calendar_data
+from tests.integration.helpers import FROZEN_START_OF_DAY
 from tests.integration.helpers import FROZEN_TIME
 from tests.integration.helpers import future_ics
 
@@ -48,7 +49,7 @@ async def test_initial_data_load(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=FROZEN_TIME),
-        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -84,7 +85,7 @@ async def test_scheduled_refresh(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=FROZEN_TIME),
-        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -105,7 +106,11 @@ async def test_scheduled_refresh(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=future),
-        patch.object(dt_util, "start_of_local_day", return_value=future),
+        patch.object(
+            dt_util,
+            "start_of_local_day",
+            return_value=future.replace(hour=0, minute=0, second=0, microsecond=0),
+        ),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -142,7 +147,7 @@ async def test_sensor_updates_on_refresh(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=FROZEN_TIME),
-        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -164,7 +169,11 @@ async def test_sensor_updates_on_refresh(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=future),
-        patch.object(dt_util, "start_of_local_day", return_value=future),
+        patch.object(
+            dt_util,
+            "start_of_local_day",
+            return_value=future.replace(hour=0, minute=0, second=0, microsecond=0),
+        ),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -202,7 +211,7 @@ async def test_calendar_updates_on_refresh(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=FROZEN_TIME),
-        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
     ):
         mock_session.get(
             mock_config_entry.data["url"],
@@ -260,7 +269,7 @@ async def test_door_code_generation_on_refresh(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=FROZEN_TIME),
-        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
     ):
         mock_session.get(
             entry.data["url"],
@@ -280,7 +289,11 @@ async def test_door_code_generation_on_refresh(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=future),
-        patch.object(dt_util, "start_of_local_day", return_value=future),
+        patch.object(
+            dt_util,
+            "start_of_local_day",
+            return_value=future.replace(hour=0, minute=0, second=0, microsecond=0),
+        ),
     ):
         mock_session.get(
             entry.data["url"],
@@ -366,7 +379,7 @@ async def test_concurrent_calendar_updates(
     with (
         aioresponses() as mock_session,
         patch.object(dt_util, "now", return_value=FROZEN_TIME),
-        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
     ):
         mock_session.get(entry_a.data["url"], status=200, body=ics_a, repeat=True)
         mock_session.get(entry_b.data["url"], status=200, body=ics_b, repeat=True)


### PR DESCRIPTION
## Phase 6: Integration Testing (T103-T125)

Adds 21 integration tests verifying end-to-end behavior of the Rental Control
integration within a realistic Home Assistant test environment.

### Test Files

**tests/integration/test_full_setup.py** (8 tests)
- Minimal and complete config setup verification
- Entity creation (1 calendar + max_events sensors)
- Coordinator accessibility and platform loading
- Device registry entry creation
- Clean unload and listener cleanup

**tests/integration/test_refresh_cycle.py** (6 tests)
- Initial ICS data load and parsing
- Scheduled refresh interval advancement
- Sensor state propagation after coordinator refresh
- Calendar entity event tracking
- Door code (slot_code) generation with date_based strategy
- Concurrent multi-entry independent updates (version=7 to skip migrations)

**tests/integration/test_error_handling.py** (7 tests)
- HTTP 500 error graceful handling
- Malformed ICS (missing fields) skip behavior
- 404 response handling
- Timeout handling (asyncio.TimeoutError)
- Sensor availability on persistent errors
- Recovery from error to loaded state
- Coordinator error state tracking (calendar_loaded/calendar_ready)

### Shared Test Infrastructure

**tests/integration/helpers.py**
- `FROZEN_TIME` (noon UTC) and `FROZEN_START_OF_DAY` (midnight UTC) constants
- `future_ics()` helper for generating ICS data relative to frozen time

### Key Design Decisions
- Time freezing via `patch.object(dt_util, ...)` for deterministic tests
- `FROZEN_START_OF_DAY` (midnight) used for `start_of_local_day` patches
- Sensor update requires two coordinator.update() cycles (sensors register after first)
- Multi-entry test uses version=7 to avoid migration unique_id collision
- Uses `extra_state_attributes` public API for door code assertions

### Test Results
```
249 tests passing (228 prior + 21 new)
All linting clean (ruff check/format, mypy, interrogate)
All pre-commit hooks passing
```