### PR TITLE
Refactor: remove obsolete v1 and v2 config migrations

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -29,14 +29,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.util import dt
 import voluptuous as vol
 
-from .config_flow import _lock_entry_convert as lock_entry_convert
 from .const import CONF_CODE_LENGTH
 from .const import CONF_CREATION_DATETIME
 from .const import CONF_GENERATE
-from .const import CONF_LOCK_ENTRY
 from .const import CONF_PATH
 from .const import CONF_SHOULD_UPDATE_CODE
 from .const import COORDINATOR
@@ -49,7 +46,6 @@ from .const import UNSUB_LISTENERS
 from .coordinator import RentalControlCoordinator
 from .util import async_reload_package_platforms
 from .util import delete_rc_and_base_folder
-from .util import gen_uuid
 from .util import handle_state_change
 
 _LOGGER = logging.getLogger(__name__)
@@ -156,40 +152,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
     version = config_entry.version
 
-    # 1 -> 2: Migrate keys
-    if version == 1:
-        _LOGGER.debug("Migrating from version %s", version)
-        data = config_entry.data.copy()
-
-        data[CONF_CREATION_DATETIME] = str(dt.now())
-        hass.config_entries.async_update_entry(
-            entry=config_entry,
-            unique_id=gen_uuid(data[CONF_CREATION_DATETIME]),
-            data=data,
-            version=2,
+    # Versions 1 and 2 are no longer supported (oldest supported: v0.9.0 = version 3)
+    if version < 3:
+        _LOGGER.error(
+            "Config entry version %s is too old to migrate; "
+            "please remove and re-add the integration",
+            version,
         )
-        version = 2
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
-
-    # 2 -> 3: Migrate lock
-    if version == 2:
-        _LOGGER.debug("Migrating from version %s", version)
-        if (
-            CONF_LOCK_ENTRY in config_entry.data
-            and config_entry.data[CONF_LOCK_ENTRY] is not None
-        ):
-            data = config_entry.data.copy()
-            convert = lock_entry_convert(hass, config_entry.data[CONF_LOCK_ENTRY], True)
-            data[CONF_LOCK_ENTRY] = convert
-            hass.config_entries.async_update_entry(
-                entry=config_entry,
-                unique_id=config_entry.unique_id,
-                data=data,
-                version=3,
-            )
-
-        version = 3
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
+        return False
 
     # 3 -> 4: Migrate code length
     if version == 3:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,8 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="Test Rental",
+        version=7,
+        unique_id="test-unique-id",
         data={
             "name": "Test Rental",
             "url": "https://example.com/calendar.ics",
@@ -92,6 +94,8 @@ def mock_config_entry_full() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="Complete Rental",
+        version=7,
+        unique_id="test-full-unique-id",
         data={
             "name": "Complete Rental",
             "url": "https://example.com/calendar.ics",

--- a/tests/integration/test_full_setup.py
+++ b/tests/integration/test_full_setup.py
@@ -86,6 +86,8 @@ async def test_integration_setup_complete_config(
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Complete Rental",
+        version=7,
+        unique_id="test-complete-unique-id",
         data={
             "name": "Complete Rental",
             "url": "https://example.com/calendar.ics",

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -246,6 +246,8 @@ async def test_door_code_generation_on_refresh(
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Code Test",
+        version=7,
+        unique_id="test-code-unique-id",
         data={
             "name": "Code Test",
             "url": "https://example.com/calendar.ics",

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -252,7 +252,6 @@ async def test_migrate_entry_rejects_version_below_3(
 
 async def test_migrate_entry_v3_to_v7(
     hass: HomeAssistant,
-    mock_aiohttp_session,
 ) -> None:
     """Verify a version-3 entry migrates through all steps to version 7.
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.rental_control.const import CONF_CODE_LENGTH
+from custom_components.rental_control.const import CONF_GENERATE
+from custom_components.rental_control.const import CONF_PATH
+from custom_components.rental_control.const import CONF_SHOULD_UPDATE_CODE
 from custom_components.rental_control.const import COORDINATOR
+from custom_components.rental_control.const import DEFAULT_CODE_LENGTH
+from custom_components.rental_control.const import DEFAULT_GENERATE
 from custom_components.rental_control.const import DOMAIN
 
 if TYPE_CHECKING:
@@ -212,3 +218,112 @@ async def test_async_setup_entry_failure(
     assert DOMAIN in hass.data
     assert mock_config_entry.entry_id in hass.data[DOMAIN]
     assert COORDINATOR in hass.data[DOMAIN][mock_config_entry.entry_id]
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_entry_rejects_version_below_3(
+    hass: HomeAssistant,
+) -> None:
+    """Verify entries at version 1 or 2 are rejected with an error.
+
+    Versions 1 and 2 are no longer supported because the oldest known
+    installation (v0.9.0) ships at config version 3.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Old Entry",
+        version=1,
+        unique_id="old-v1-entry",
+        data={
+            "name": "Old Entry",
+            "url": "https://example.com/calendar.ics",
+        },
+        entry_id="old_v1_entry",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.async_setup(entry.entry_id)
+    assert result is False
+
+
+async def test_migrate_entry_v3_to_v7(
+    hass: HomeAssistant,
+    mock_aiohttp_session,
+) -> None:
+    """Verify a version-3 entry migrates through all steps to version 7.
+
+    The migration chain 3→4→5→6→7 adds code_length, generate_package,
+    removes packages_path, and adds should_update_code.
+    """
+    from custom_components.rental_control import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="V3 Entry",
+        version=3,
+        unique_id="v3-migration-test",
+        data={
+            "name": "V3 Entry",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "America/New_York",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            "start_slot": 10,
+            "max_events": 3,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "packages_path": "/config/packages",
+        },
+        entry_id="v3_entry",
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 7
+    assert entry.data[CONF_CODE_LENGTH] == DEFAULT_CODE_LENGTH
+    assert entry.data[CONF_GENERATE] == DEFAULT_GENERATE
+    assert CONF_PATH not in entry.data
+    assert entry.data[CONF_SHOULD_UPDATE_CODE] is False
+
+
+async def test_migrate_entry_v6_to_v7(
+    hass: HomeAssistant,
+) -> None:
+    """Verify a version-6 entry only runs the v6→7 step."""
+    from custom_components.rental_control import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="V6 Entry",
+        version=6,
+        unique_id="v6-migration-test",
+        data={
+            "name": "V6 Entry",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "America/New_York",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            "start_slot": 10,
+            "max_events": 3,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "code_length": 4,
+            "generate_package": True,
+        },
+        entry_id="v6_entry",
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 7
+    assert entry.data[CONF_SHOULD_UPDATE_CODE] is False

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.rental_control.const import CONF_CODE_LENGTH
@@ -225,8 +226,10 @@ async def test_async_setup_entry_failure(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("old_version", [1, 2])
 async def test_migrate_entry_rejects_version_below_3(
     hass: HomeAssistant,
+    old_version: int,
 ) -> None:
     """Verify entries at version 1 or 2 are rejected with an error.
 
@@ -236,13 +239,13 @@ async def test_migrate_entry_rejects_version_below_3(
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Old Entry",
-        version=1,
-        unique_id="old-v1-entry",
+        version=old_version,
+        unique_id=f"old-v{old_version}-entry",
         data={
             "name": "Old Entry",
             "url": "https://example.com/calendar.ics",
         },
-        entry_id="old_v1_entry",
+        entry_id=f"old_v{old_version}_entry",
     )
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
## Summary

Remove config entry migration paths for versions 1→2 and 2→3. The oldest
known installation (v0.9.0) ships at config version 3, making these
migration paths dead code.

## Changes

1. **Test fixtures** — All MockConfigEntry instances now specify `version=7`
   and a unique `unique_id`, ensuring tests represent real config entries
   rather than relying on migration side-effects.
2. **Migration cleanup** — Remove v1→2 (add creation_datetime/unique_id) and
   v2→3 (convert lock entry name→entity) migration blocks. Add a guard that
   rejects entries below version 3 with a clear error message. Remove
   now-unused imports (lock_entry_convert, gen_uuid, dt, CONF_LOCK_ENTRY).
3. **Migration tests** — Add three unit tests covering the version guard,
   full v3→7 chain, and v6→7 partial migration. Tests call
   `async_migrate_entry` directly to isolate migration logic.

## Coverage Impact

- `__init__.py`: 72% → 98% (37 missed → 3 missed)
- Overall: 84% → 86%

## Testing

- 265 tests passing (3 new migration tests)
- Pre-commit hooks clean on all commits
- Coverage above 85% threshold