### PR TITLE
Fix: address 4 bugs found during code review

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -242,8 +242,11 @@ Please update Keymaster to at least v0.1.0-b0
                 _LOGGER.debug("Slot code: '%s'", slot_code)
                 if slot_code is None:
                     continue
-                if slot_code.state == "unknown" or slot_code.state == "unavailable":
-                    slot_code.state = ""
+                slot_code_value = (
+                    ""
+                    if slot_code.state in ("unknown", "unavailable")
+                    else slot_code.state
+                )
 
                 slot_name = self.hass.states.get(
                     f"{TEXT}.{self.lockname}_code_slot_{i}_name"
@@ -251,8 +254,11 @@ Please update Keymaster to at least v0.1.0-b0
                 _LOGGER.debug("Slot name: '%s'", slot_name)
                 if slot_name is None:
                     continue
-                if slot_name.state == "unknown" or slot_name.state == "unavailable":
-                    slot_name.state = ""
+                slot_name_value = (
+                    ""
+                    if slot_name.state in ("unknown", "unavailable")
+                    else slot_name.state
+                )
 
                 use_date_range = self.hass.states.get(
                     f"{SWITCH}.{self.lockname}_code_slot_{i}_use_date_range_limits"
@@ -289,16 +295,16 @@ Please update Keymaster to at least v0.1.0-b0
                 _LOGGER.debug(
                     "Slot %d: %s, %s, %s, %s",
                     i,
-                    slot_code.state,
-                    slot_name.state,
+                    slot_code_value,
+                    slot_name_value,
                     start_time,
                     end_time,
                 )
                 _LOGGER.debug("Updating event overrides")
                 await self.update_event_overrides(
                     i,
-                    slot_code.state,
-                    slot_name.state,
+                    slot_code_value,
+                    slot_name_value,
                     start_time,
                     end_time,
                 )

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -538,11 +538,11 @@ Please update Keymaster to at least v0.1.0-b0
             """Return the date from a datetime or date object."""
 
             _LOGGER.debug("In _get_date: %s", day)
-            if isinstance(day, date):
-                _LOGGER.debug("Returning date: %s", day)
-                return day
-            _LOGGER.debug("Returning date: %s", day.date())
-            return day.date()
+            if isinstance(day, datetime):
+                _LOGGER.debug("Returning date: %s", day.date())
+                return day.date()
+            _LOGGER.debug("Returning date: %s", day)
+            return day
 
         cal = self.calendar
         days = dt.start_of_local_day() + timedelta(days=self.days)

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -412,9 +412,15 @@ async def handle_state_change(
             end_time = p_end_time
 
     _LOGGER.debug(
-        f"updating overrides for {lockname} slot {slot_num}. ",
-        f"slot_name: '{slot_name}', slot_code: '{slot_code}', ",
-        f"start_time: '{start_time}', end_time: '{end_time}'",
+        "updating overrides for %s slot %s. "
+        "slot_name: '%s', slot_code: '%s', "
+        "start_time: '%s', end_time: '%s'",
+        lockname,
+        slot_num,
+        slot_name,
+        slot_code,
+        start_time,
+        end_time,
     )
     await coordinator.update_event_overrides(
         slot_num,

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -390,12 +390,14 @@ async def handle_state_change(
 
     if slot_code is None:
         return
-    if slot_code.state == "unknown" or slot_code.state == "unavailable":
-        slot_code.state = ""
+    slot_code_value = (
+        "" if slot_code.state in ("unknown", "unavailable") else slot_code.state
+    )
     if slot_name is None:
         return
-    if slot_name.state == "unknown" or slot_name.state == "unavailable":
-        slot_name.state = ""
+    slot_name_value = (
+        "" if slot_name.state in ("unknown", "unavailable") else slot_name.state
+    )
 
     if g_start_time is None:
         start_time = dt.start_of_local_day()
@@ -417,15 +419,15 @@ async def handle_state_change(
         "start_time: '%s', end_time: '%s'",
         lockname,
         slot_num,
-        slot_name,
-        slot_code,
+        slot_name_value,
+        slot_code_value,
         start_time,
         end_time,
     )
     await coordinator.update_event_overrides(
         slot_num,
-        slot_code.state,
-        slot_name.state,
+        slot_code_value,
+        slot_name_value,
         start_time,
         end_time,
     )

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -399,16 +399,15 @@ async def handle_state_change(
         "" if slot_name.state in ("unknown", "unavailable") else slot_name.state
     )
 
-    if g_start_time is None:
-        start_time = dt.start_of_local_day()
-    else:
+    start_time = dt.start_of_local_day()
+    end_time = dt.start_of_local_day()
+
+    if g_start_time is not None:
         p_start_time = dt.parse_datetime(g_start_time.state)
         if p_start_time:
             start_time = p_start_time
 
-    if g_end_time is None:
-        end_time = dt.start_of_local_day()
-    else:
+    if g_end_time is not None:
         p_end_time = dt.parse_datetime(g_end_time.state)
         if p_end_time:
             end_time = p_end_time

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -96,8 +96,6 @@ async def test_coordinator_scheduled_refresh(
     Verifies that the coordinator automatically refreshes calendar data
     when the scheduled interval elapses using async_fire_time_changed.
     """
-    from datetime import timedelta
-
     from homeassistant.util import dt
     from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
@@ -144,7 +142,6 @@ async def test_coordinator_refresh_success(
     Verifies that coordinator successfully fetches ICS data from URL,
     parses events, and updates internal calendar state.
     """
-    from datetime import timedelta
     from unittest.mock import patch
 
     import homeassistant.util.dt as dt_util
@@ -282,7 +279,6 @@ async def test_coordinator_state_management(
     Verifies that coordinator properly maintains calendar state,
     tracks events, and updates next event reference.
     """
-    from datetime import timedelta
     from unittest.mock import patch
 
     import homeassistant.util.dt as dt_util

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
@@ -49,7 +50,6 @@ async def test_coordinator_first_refresh(
     Verifies that async_config_entry_first_refresh properly fetches
     and processes calendar data on initial load.
     """
-    from datetime import datetime
     from unittest.mock import patch
 
     import homeassistant.util.dt as dt_util
@@ -144,7 +144,6 @@ async def test_coordinator_refresh_success(
     Verifies that coordinator successfully fetches ICS data from URL,
     parses events, and updates internal calendar state.
     """
-    from datetime import datetime
     from datetime import timedelta
     from unittest.mock import patch
 
@@ -283,7 +282,6 @@ async def test_coordinator_state_management(
     Verifies that coordinator properly maintains calendar state,
     tracks events, and updates next event reference.
     """
-    from datetime import datetime
     from datetime import timedelta
     from unittest.mock import patch
 
@@ -546,3 +544,121 @@ async def test_coordinator_update_event_overrides_without_overrides(
 
     assert coordinator.calendar_ready is True
     assert coordinator.next_refresh <= dt.now()
+
+
+# ---------------------------------------------------------------------------
+# _refresh_event_dict._get_date isinstance ordering tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetDateIsinstance:
+    """Tests for the _get_date helper inside _refresh_event_dict.
+
+    Before the fix, isinstance(day, date) was checked first in _get_date.
+    Since datetime is a subclass of date, this always matched for
+    datetime objects, making the datetime branch dead code.  The helper
+    then returned a datetime instead of a plain date, causing a
+    TypeError when the list-comprehension compared datetime <= date.
+    """
+
+    async def test_datetime_events_filtered_without_error(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify _refresh_event_dict handles datetime starts.
+
+        With the old isinstance ordering, passing a timezone-aware
+        datetime to _get_date returned a datetime object.  The
+        subsequent ``datetime <= date`` comparison in the list
+        comprehension would raise TypeError.  After the fix,
+        _get_date converts datetime to date first so the comparison
+        succeeds.
+        """
+        mock_config_entry.add_to_hass(hass)
+        with aioresponses() as mock_session:
+            mock_session.get(
+                mock_config_entry.data["url"],
+                body=calendar_data.AIRBNB_ICS_CALENDAR,
+            )
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            await coordinator.update()
+
+        # Create an event with a timezone-aware datetime start that is
+        # within the configured max_days window so it should be included.
+        now = dt.now()
+        event = CalendarEvent(
+            start=now,
+            end=now + timedelta(hours=1),
+            summary="datetime event",
+        )
+        coordinator.calendar = [event]
+
+        # Before the fix this raised TypeError; after, it filters fine
+        result = coordinator._refresh_event_dict()  # noqa: SLF001
+        assert len(result) == 1
+        assert result[0].summary == "datetime event"
+
+    async def test_plain_date_events_filtered_correctly(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify that plain date events pass through filtering.
+
+        _get_date should return the date directly when the input is
+        not a datetime instance, and the filtering comparison should
+        work without error.
+        """
+        mock_config_entry.add_to_hass(hass)
+        with aioresponses() as mock_session:
+            mock_session.get(
+                mock_config_entry.data["url"],
+                body=calendar_data.AIRBNB_ICS_CALENDAR,
+            )
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            await coordinator.update()
+
+        today = dt.start_of_local_day().date()
+        event = CalendarEvent(
+            start=today,
+            end=today + timedelta(days=1),
+            summary="date event",
+        )
+        coordinator.calendar = [event]
+
+        result = coordinator._refresh_event_dict()  # noqa: SLF001
+        assert len(result) == 1
+        assert result[0].summary == "date event"
+
+    async def test_past_datetime_event_excluded(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify a datetime event far in the future is excluded.
+
+        Events whose start date exceeds the configured max_days window
+        should be filtered out, confirming the date comparison works
+        correctly for datetime values after the isinstance fix.
+        """
+        mock_config_entry.add_to_hass(hass)
+        with aioresponses() as mock_session:
+            mock_session.get(
+                mock_config_entry.data["url"],
+                body=calendar_data.AIRBNB_ICS_CALENDAR,
+            )
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            await coordinator.update()
+
+        # Event well beyond the max_days window
+        far_future = dt.now() + timedelta(days=coordinator.days + 100)
+        event = CalendarEvent(
+            start=far_future,
+            end=far_future + timedelta(hours=1),
+            summary="far future",
+        )
+        coordinator.calendar = [event]
+
+        result = coordinator._refresh_event_dict()  # noqa: SLF001
+        assert len(result) == 0

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -631,7 +631,7 @@ class TestGetDateIsinstance:
         assert len(result) == 1
         assert result[0].summary == "date event"
 
-    async def test_past_datetime_event_excluded(
+    async def test_far_future_datetime_event_excluded(
         self,
         hass: HomeAssistant,
         mock_config_entry: MockConfigEntry,

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 from homeassistant.const import CONF_NAME
 from homeassistant.core import Event
 from homeassistant.exceptions import ServiceNotFound
+from homeassistant.util import dt as dt_util
 import pytest
 
 from custom_components.rental_control.const import COORDINATOR
@@ -828,8 +829,6 @@ class TestHandleStateChangeUnboundVars:
         mock_coordinator.update_event_overrides.assert_awaited_once()
         call_args = mock_coordinator.update_event_overrides.call_args
         # start_time and end_time should be start_of_local_day defaults
-        from homeassistant.util import dt as dt_util
-
         expected_default = dt_util.start_of_local_day()
         assert call_args[0][3] == expected_default  # start_time
         assert call_args[0][4] == expected_default  # end_time

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -562,7 +562,6 @@ class TestAddCall:
 class TestHandleStateChangeLogging:
     """Tests for handle_state_change debug logging correctness."""
 
-    @pytest.mark.asyncio
     async def test_debug_log_contains_all_override_fields(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -651,7 +650,6 @@ class TestHandleStateChangeLogging:
 class TestHandleStateChangeStateMutation:
     """Tests that handle_state_change does not mutate HA State objects."""
 
-    @pytest.mark.asyncio
     async def test_unknown_slot_code_not_mutated(self) -> None:
         """Verify State.state is not mutated when slot_code is 'unknown'.
 
@@ -705,7 +703,6 @@ class TestHandleStateChangeStateMutation:
         call_args = mock_coordinator.update_event_overrides.call_args
         assert call_args[0][1] == ""  # slot_code_value should be ""
 
-    @pytest.mark.asyncio
     async def test_unavailable_slot_name_not_mutated(self) -> None:
         """Verify State.state is not mutated when slot_name is 'unavailable'.
 
@@ -768,7 +765,6 @@ class TestHandleStateChangeStateMutation:
 class TestHandleStateChangeUnboundVars:
     """Tests that handle_state_change does not raise UnboundLocalError."""
 
-    @pytest.mark.asyncio
     async def test_unparseable_start_time_uses_default(self) -> None:
         """Verify start_time defaults when parse_datetime returns None.
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -5,14 +5,19 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from homeassistant.const import CONF_NAME
+from homeassistant.core import Event
 from homeassistant.exceptions import ServiceNotFound
 import pytest
 
+from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DEFAULT_PATH
+from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.const import NAME
 from custom_components.rental_control.util import add_call
 from custom_components.rental_control.util import async_reload_package_platforms
@@ -21,6 +26,7 @@ from custom_components.rental_control.util import delete_rc_and_base_folder
 from custom_components.rental_control.util import gen_uuid
 from custom_components.rental_control.util import get_event_names
 from custom_components.rental_control.util import get_slot_name
+from custom_components.rental_control.util import handle_state_change
 
 # ---------------------------------------------------------------------------
 # gen_uuid tests
@@ -546,3 +552,92 @@ class TestAddCall:
         add_call(hass, coro_list, "switch", "turn_off", "switch.b", {})
 
         assert len(coro_list) == 2
+
+
+# ---------------------------------------------------------------------------
+# handle_state_change logging tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleStateChangeLogging:
+    """Tests for handle_state_change debug logging correctness."""
+
+    @pytest.mark.asyncio
+    async def test_debug_log_contains_all_override_fields(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Verify the override update log message includes all fields.
+
+        Prior to the fix, extra f-string arguments were passed as
+        positional *args to _LOGGER.debug() and silently dropped.
+        This test ensures lockname, slot_num, slot_name, slot_code,
+        start_time, and end_time all appear in the emitted message.
+        """
+        lockname = "test_lock"
+        slot_num = 10
+        mock_slot_code_state = MagicMock()
+        mock_slot_code_state.state = "1234"
+        mock_slot_name_state = MagicMock()
+        mock_slot_name_state.state = "Guest Name"
+        mock_slot_enabled = MagicMock()
+        mock_slot_enabled.state = "on"
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = lockname
+        mock_coordinator.event_overrides = MagicMock()
+        mock_coordinator.event_overrides.async_check_overrides = AsyncMock()
+        mock_coordinator.update_event_overrides = AsyncMock()
+
+        def states_get(entity_id: str) -> MagicMock | None:
+            """Return mock states for various entities."""
+            if "enabled" in entity_id:
+                return mock_slot_enabled
+            if "pin" in entity_id:
+                return mock_slot_code_state
+            if "name" in entity_id:
+                return mock_slot_name_state
+            if "use_date_range" in entity_id:
+                return None
+            return None
+
+        hass = MagicMock()
+        hass.data = {
+            DOMAIN: {
+                "entry_id": {COORDINATOR: mock_coordinator},
+            }
+        }
+        hass.states.get = states_get
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock(spec=Event)
+        event.data = {"entity_id": f"switch.{lockname}_code_slot_{slot_num}_enabled"}
+
+        with (
+            patch("custom_components.rental_control.util.asyncio.sleep"),
+            caplog.at_level(
+                logging.DEBUG, logger="custom_components.rental_control.util"
+            ),
+        ):
+            await handle_state_change(hass, config_entry, event)
+
+        log_messages = " ".join(caplog.messages)
+        assert lockname in log_messages
+        assert str(slot_num) in log_messages
+        # Verify slot_name and slot_code objects appear (as repr strings)
+        assert "slot_name:" in log_messages
+        assert "slot_code:" in log_messages
+        # Verify start_time and end_time appear in the same message
+        assert "start_time:" in log_messages
+        assert "end_time:" in log_messages
+        # The critical assertion: all fields must be in a SINGLE log message.
+        # The original bug caused slot_name/slot_code/start_time/end_time to
+        # be silently dropped because they were separate f-string *args.
+        override_msgs = [m for m in caplog.messages if "updating overrides for" in m]
+        assert len(override_msgs) == 1
+        single_msg = override_msgs[0]
+        assert "slot_name:" in single_msg
+        assert "slot_code:" in single_msg
+        assert "start_time:" in single_msg
+        assert "end_time:" in single_msg

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -641,3 +641,120 @@ class TestHandleStateChangeLogging:
         assert "slot_code:" in single_msg
         assert "start_time:" in single_msg
         assert "end_time:" in single_msg
+
+
+# ---------------------------------------------------------------------------
+# handle_state_change state mutation tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleStateChangeStateMutation:
+    """Tests that handle_state_change does not mutate HA State objects."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_code_not_mutated(self) -> None:
+        """Verify State.state is not mutated when slot_code is 'unknown'.
+
+        The original code directly set slot_code.state = "" which mutates
+        Home Assistant internal State objects. The fix uses local variables.
+        """
+        lockname = "test_lock"
+        slot_num = 10
+        mock_slot_code_state = MagicMock()
+        mock_slot_code_state.state = "unknown"
+        mock_slot_name_state = MagicMock()
+        mock_slot_name_state.state = "Guest"
+        mock_slot_enabled = MagicMock()
+        mock_slot_enabled.state = "on"
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = lockname
+        mock_coordinator.event_overrides = MagicMock()
+        mock_coordinator.event_overrides.async_check_overrides = AsyncMock()
+        mock_coordinator.update_event_overrides = AsyncMock()
+
+        def states_get(entity_id: str) -> MagicMock | None:
+            """Return mock states for various entities."""
+            if "enabled" in entity_id:
+                return mock_slot_enabled
+            if "pin" in entity_id:
+                return mock_slot_code_state
+            if "name" in entity_id:
+                return mock_slot_name_state
+            if "use_date_range" in entity_id:
+                return None
+            return None
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_id": {COORDINATOR: mock_coordinator}}}
+        hass.states.get = states_get
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock(spec=Event)
+        event.data = {"entity_id": f"switch.{lockname}_code_slot_{slot_num}_enabled"}
+
+        with patch("custom_components.rental_control.util.asyncio.sleep"):
+            await handle_state_change(hass, config_entry, event)
+
+        # State object must NOT have been mutated
+        assert mock_slot_code_state.state == "unknown"
+        # But update_event_overrides should have been called with ""
+        mock_coordinator.update_event_overrides.assert_awaited_once()
+        call_args = mock_coordinator.update_event_overrides.call_args
+        assert call_args[0][1] == ""  # slot_code_value should be ""
+
+    @pytest.mark.asyncio
+    async def test_unavailable_slot_name_not_mutated(self) -> None:
+        """Verify State.state is not mutated when slot_name is 'unavailable'.
+
+        The original code directly set slot_name.state = "" which mutates
+        Home Assistant internal State objects. The fix uses local variables.
+        """
+        lockname = "test_lock"
+        slot_num = 10
+        mock_slot_code_state = MagicMock()
+        mock_slot_code_state.state = "1234"
+        mock_slot_name_state = MagicMock()
+        mock_slot_name_state.state = "unavailable"
+        mock_slot_enabled = MagicMock()
+        mock_slot_enabled.state = "on"
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = lockname
+        mock_coordinator.event_overrides = MagicMock()
+        mock_coordinator.event_overrides.async_check_overrides = AsyncMock()
+        mock_coordinator.update_event_overrides = AsyncMock()
+
+        def states_get(entity_id: str) -> MagicMock | None:
+            """Return mock states for various entities."""
+            if "enabled" in entity_id:
+                return mock_slot_enabled
+            if "pin" in entity_id:
+                return mock_slot_code_state
+            if "name" in entity_id:
+                return mock_slot_name_state
+            if "use_date_range" in entity_id:
+                return None
+            return None
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_id": {COORDINATOR: mock_coordinator}}}
+        hass.states.get = states_get
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock(spec=Event)
+        event.data = {"entity_id": f"switch.{lockname}_code_slot_{slot_num}_enabled"}
+
+        with patch("custom_components.rental_control.util.asyncio.sleep"):
+            await handle_state_change(hass, config_entry, event)
+
+        # State object must NOT have been mutated
+        assert mock_slot_name_state.state == "unavailable"
+        # But update_event_overrides should have been called with ""
+        mock_coordinator.update_event_overrides.assert_awaited_once()
+        call_args = mock_coordinator.update_event_overrides.call_args
+        assert call_args[0][2] == ""  # slot_name_value should be ""

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -758,3 +758,82 @@ class TestHandleStateChangeStateMutation:
         mock_coordinator.update_event_overrides.assert_awaited_once()
         call_args = mock_coordinator.update_event_overrides.call_args
         assert call_args[0][2] == ""  # slot_name_value should be ""
+
+
+# ---------------------------------------------------------------------------
+# handle_state_change unbound variable tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleStateChangeUnboundVars:
+    """Tests that handle_state_change does not raise UnboundLocalError."""
+
+    @pytest.mark.asyncio
+    async def test_unparseable_start_time_uses_default(self) -> None:
+        """Verify start_time defaults when parse_datetime returns None.
+
+        When use_date_range is on but the start time state cannot be
+        parsed, start_time must fall back to start_of_local_day instead
+        of raising UnboundLocalError.
+        """
+        lockname = "test_lock"
+        slot_num = 10
+
+        mock_slot_code_state = MagicMock()
+        mock_slot_code_state.state = "1234"
+        mock_slot_name_state = MagicMock()
+        mock_slot_name_state.state = "Guest"
+        mock_slot_enabled = MagicMock()
+        mock_slot_enabled.state = "on"
+        mock_use_date_range = MagicMock()
+        mock_use_date_range.state = "on"
+        mock_start_time = MagicMock()
+        mock_start_time.state = "not-a-datetime"
+        mock_end_time = MagicMock()
+        mock_end_time.state = "not-a-datetime"
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = lockname
+        mock_coordinator.event_overrides = MagicMock()
+        mock_coordinator.event_overrides.async_check_overrides = AsyncMock()
+        mock_coordinator.update_event_overrides = AsyncMock()
+
+        def states_get(entity_id: str) -> MagicMock | None:
+            """Return mock states for various entities."""
+            if "enabled" in entity_id:
+                return mock_slot_enabled
+            if "pin" in entity_id:
+                return mock_slot_code_state
+            if "name" in entity_id and "date_range" not in entity_id:
+                return mock_slot_name_state
+            if "use_date_range" in entity_id:
+                return mock_use_date_range
+            if "date_range_start" in entity_id:
+                return mock_start_time
+            if "date_range_end" in entity_id:
+                return mock_end_time
+            return None
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_id": {COORDINATOR: mock_coordinator}}}
+        hass.states.get = states_get
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock(spec=Event)
+        event.data = {"entity_id": f"switch.{lockname}_code_slot_{slot_num}_enabled"}
+
+        # This must not raise UnboundLocalError
+        with patch("custom_components.rental_control.util.asyncio.sleep"):
+            await handle_state_change(hass, config_entry, event)
+
+        # update_event_overrides should still be called with default times
+        mock_coordinator.update_event_overrides.assert_awaited_once()
+        call_args = mock_coordinator.update_event_overrides.call_args
+        # start_time and end_time should be start_of_local_day defaults
+        from homeassistant.util import dt as dt_util
+
+        expected_default = dt_util.start_of_local_day()
+        assert call_args[0][3] == expected_default  # start_time
+        assert call_args[0][4] == expected_default  # end_time


### PR DESCRIPTION
## Summary

Fixes four bugs identified during a comprehensive code review:

### Bug 1: `_LOGGER.debug` multi-arg f-strings (util.py)
Extra f-string positional args passed to `_LOGGER.debug()` were silently dropped. Combined into a single `%s`-style format string.

### Bug 2: Mutating HA State objects directly (util.py, coordinator.py)
`slot_code.state = ""` directly mutated HA internal State objects, which is unsupported. Replaced with local variables.

### Bug 3: Unbound `start_time`/`end_time` (util.py)
When `parse_datetime()` returned None, `start_time` and `end_time` were never assigned but used later, causing `UnboundLocalError`. Added default initialization before conditionals.

### Bug 4: `_get_date` isinstance ordering (coordinator.py)
`isinstance(day, date)` was checked before `isinstance(day, datetime)`. Since `datetime` is a subclass of `date`, the datetime branch was dead code, causing `TypeError` when comparing datetime to date. Swapped the isinstance checks.

### Testing
- Added comprehensive tests for all 4 fixes
- All 273 tests pass
- Each fix is an atomic commit with DCO sign-off