### PR TITLE
Fix: align version placeholder to 0.0.0

### DIFF
--- a/custom_components/rental_control/const.py
+++ b/custom_components/rental_control/const.py
@@ -7,7 +7,7 @@
 NAME = "Rental Control"
 DOMAIN = "rental_control"
 DOMAIN_DATA = f"{DOMAIN}_DATA"
-VERSION = "0.0.1"
+VERSION = "0.0.0"
 LOCK_MANAGER = "keymaster"
 
 ISSUE_URL = "https://github.com/tykeal/homeassistant-rental-control/issues"

--- a/custom_components/rental_control/manifest.json
+++ b/custom_components/rental_control/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tykeal/homeassistant-rental-control/issues",
   "requirements": ["icalendar>=6.1.0", "x-wr-timezone>=2.0.0"],
-  "version": "v0.0.0"
+  "version": "0.0.0"
 }


### PR DESCRIPTION
## Summary

Align the version placeholder in both `const.py` and `manifest.json` to `"0.0.0"`.

### Changes

- **const.py**: Changed `VERSION` from `"0.0.1"` to `"0.0.0"`
- **manifest.json**: Changed `version` from `"v0.0.0"` to `"0.0.0"`

The actual version is set by the release workflow based on the repository tag, which determines whether the `v` prefix is included. The placeholder values should be consistent and not imply a released version.

### Testing
- All 275 tests pass