### PR TITLE
Chore: remove redundant requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2021 Andrew Grimberg <tykeal@bardicgrove.org>
-# SPDX-License-Identifier: Apache-2.0
-
-icalendar
-x-wr-timezone

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2021 Andrew Grimberg <tykeal@bardicgrove.org>
-# SPDX-License-Identifier: Apache-2.0
-
--r requirements.txt
-homeassistant

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2021 Andrew Grimberg <tykeal@bardicgrove.org>
-# SPDX-License-Identifier: Apache-2.0
-
--r requirements_dev.txt
-aioresponses
-pytest-homeassistant-custom-component


### PR DESCRIPTION
## Summary

Remove `requirements.txt`, `requirements_dev.txt`, and `requirements_test.txt` as their contents are already fully defined in `pyproject.toml`:

| File | pyproject.toml equivalent |
|------|--------------------------|
| `requirements.txt` | `[project].dependencies` |
| `requirements_dev.txt` | `[project.optional-dependencies].dev` |
| `requirements_test.txt` | `[project.optional-dependencies].test` |

The LF RelEng CI workflows install dependencies via `pip install .[test]` from pyproject.toml, making these files unused.