### PR TITLE
CI: Always run build on PRs

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -18,12 +18,6 @@ on:
     types: [opened, reopened, synchronize]
     branches:
       - main
-    paths:
-      - '**'
-      - '!.github/**'
-      - '!.*'
-      - '.grype.yaml'
-      - '!tox.ini'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"


### PR DESCRIPTION
Allowing some paths to be omitted for Python build validation means that
the workflow cannot be made a required workflow. Make it run on all PRs
until a better way can be found to effectively skip when it isn't
neeeded.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
