### PR TITLE
Docs: add AGENTS.md and enforce 50-char subjects

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -29,8 +29,8 @@
 
 contrib=contrib-title-conventional-commits,contrib-body-requires-signed-off-by
 
-# [title-max-length]
-# line-length=80
+[title-max-length]
+line-length=50
 
 # [title-must-not-contain-word]
 # Comma-separated list of words that should not occur in the title. Matching is

--- a/.gitlint
+++ b/.gitlint
@@ -45,9 +45,8 @@ line-length=50
 # (e.g. title-must-not-contain-word).
 # regex=^US[0-9]*
 
-# [B1]
-# B1 = body-max-line-length
-# line-length=120
+[body-max-line-length]
+line-length=72
 
 # [body-min-length]
 # min-length=5

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -141,20 +141,21 @@ sign-off.
 
 **Required Commit Trailers**:
 Every agent-authored commit MUST include:
-1. **Co-Authored-By line**: Identifying the AI agent
+1. **Co-authored-by line**: Identifying the AI agent
    ```
-   Co-Authored-By: GitHub Copilot <copilot@github.com>
-   Co-Authored-By: Claude <claude@anthropic.com>
+   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+   Co-authored-by: Claude <claude@anthropic.com>
    ```
-   (Use appropriate agent name and a representative email address)
+   (Use appropriate agent name and email address)
 
 2. **DCO Sign-off line**: Added via `git commit -s`
    ```
    Signed-off-by: Human Author <human@email>
    ```
 
-**Execution**: Use `git commit -s` to automatically add DCO sign-off, then manually
-add Co-Authored-By trailer before finalizing commit.
+**Execution**: Use `git commit -s` to automatically add DCO sign-off. The
+Co-authored-by trailer goes in the commit message body; `git commit -s`
+appends Signed-off-by last.
 
 **Rationale**: Transparency in authorship is critical for:
 - Legal compliance (Developer Certificate of Origin)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Keep subjects concise. The hard limit is 50 characters.
 ### Rule 3: Capitalize the subject line
 
 The subject line MUST start with a capital letter. This project uses
-Conventional Commits with capitalized types which naturally satisfies this rule.
+Conventional Commits, whose capitalized types naturally satisfy this rule.
 
 - **Enforcement**: gitlint `contrib-title-conventional-commits` requires
   capitalized types.
@@ -76,7 +76,7 @@ Bad examples:
 Body text MUST be wrapped at 72 characters per line. Lines containing URLs
 MAY exceed this limit, but enforcement tooling has limitations.
 
-- **Enforcement**: gitlint `body-max-line-length` (default 72). The
+- **Enforcement**: gitlint `body-max-line-length` (configured to 72). The
   configured `ignore-by-body` rule disables this check for the entire
   commit body if any line matches the URL pattern, so you MUST still
   manually wrap non-URL lines to 72 characters.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,262 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Agent Development Guidelines
+
+This document codifies git and development practices for AI agents working on
+this repository. These practices are derived from the project constitution and
+established development conventions.
+
+## Constitution
+
+If `.specify/memory/constitution.md` exists in this repository, read it and
+follow its principles. The constitution takes precedence over this file if
+there is any conflict between the two documents.
+
+## Git Commit Message Rules
+
+This project follows the
+[seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/).
+Several rules are enforced automatically by **gitlint** (see `.gitlint`).
+
+### Rule 1: Separate subject from body with a blank line
+
+The blank line between the subject and body is critical. Git tools like `log`,
+`shortlog`, and `rebase` rely on this separation. Simple changes may omit the
+body entirely.
+
+- **Enforcement**: Git itself; gitlint validates structure.
+
+### Rule 2: Limit the subject line to 50 characters
+
+Keep subjects concise. The hard limit is 50 characters.
+
+- **Enforcement**: gitlint `title-max-length` (configured to 50).
+
+### Rule 3: Capitalize the subject line
+
+The subject line MUST start with a capital letter. This project uses
+Conventional Commits with capitalized types which naturally satisfies this rule.
+
+- **Enforcement**: gitlint `contrib-title-conventional-commits` requires
+  capitalized types.
+
+### Rule 4: Do not end the subject line with a period
+
+The subject line MUST NOT end with a period. Trailing space is precious
+when you are limited to 50 characters.
+
+- **Enforcement**: gitlint `title-trailing-punctuation` (T3, enabled by
+  default).
+
+### Rule 5: Use the imperative mood in the subject line
+
+Write the subject as if completing the sentence: "If applied, this commit
+will \_\_\_\_\_\_\_\_." The Conventional Commit type prefix naturally leads into
+imperative mood.
+
+Good examples:
+
+- `Fix: correct race condition in calendar refresh`
+- `Feat: add door code rotation support`
+- `Refactor: extract event parsing to helper`
+
+Bad examples:
+
+- ~~`Fix: fixed the race condition`~~ (past tense)
+- ~~`Feat: adds door code rotation`~~ (third person)
+- ~~`Refactor: extracting event parsing`~~ (gerund)
+
+- **Enforcement**: Manual discipline; not automatically enforceable.
+
+### Rule 6: Wrap the body at 72 characters
+
+Body text MUST be wrapped at 72 characters per line. Lines containing URLs
+are exempt from this limit.
+
+- **Enforcement**: gitlint `body-max-line-length` (default 72). The
+  `ignore-by-body` rule exempts lines containing URLs.
+
+### Rule 7: Use the body to explain what and why, not how
+
+The code diff shows _how_ a change was made. The commit body should explain
+_what_ problem is being solved and _why_ this approach was chosen. Include
+context that will help future developers understand the rationale.
+
+- **Enforcement**: Manual discipline; not automatically enforceable.
+
+## Conventional Commit Format
+
+This project uses **Conventional Commits** with **capitalized types**:
+
+```plaintext
+Type(scope): Short imperative description
+
+Body explaining what and why. Wrap at 72 characters.
+URLs on their own line are exempt from the wrap limit.
+
+Signed-off-by: Name <email>
+Co-authored-by: <AI Model Name> <appropriate-email@provider.com>
+```
+
+**Allowed types** (capitalized, enforced by gitlint):
+
+- `Fix` — Bug fixes
+- `Feat` — New features
+- `Chore` — Maintenance tasks
+- `Docs` — Documentation changes
+- `Style` — Code style/formatting (no logic change)
+- `Refactor` — Code refactoring (no behavior change)
+- `Perf` — Performance improvements
+- `Test` — Adding or updating tests
+- `Revert` — Reverting previous commits
+- `CI` — CI/CD configuration changes
+- `Build` — Build system changes
+
+### Commit Command
+
+Always use the `-s` flag for Developer Certificate of Origin sign-off:
+
+```bash
+git commit -s -m "Type(scope): Short imperative description
+
+Body explaining what changed and why.
+
+Co-authored-by: <AI Model> <email@provider.com>"
+```
+
+### Co-Authorship
+
+All AI-assisted commits MUST include a `Co-authored-by` trailer identifying
+the AI model used:
+
+| Model | Co-authored-by |
+| ------- | ---------------- |
+| Claude | `Co-authored-by: Claude <claude@anthropic.com>` |
+| ChatGPT | `Co-authored-by: ChatGPT <chatgpt@openai.com>` |
+| Gemini | `Co-authored-by: Gemini <gemini@google.com>` |
+| Copilot | `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` |
+
+This trailer goes at the end of the commit message body, after the
+`Signed-off-by` line.
+
+## Gitlint Enforcement Summary
+
+The following gitlint rules are active (see `.gitlint` for full config):
+
+| Rule | What it checks | Default |
+| ---- | -------------- | ------- |
+| `title-max-length` (T1) | Subject ≤50 chars | 50 |
+| `title-trailing-punctuation` (T3) | No trailing `.` `;` `:` etc. | Enabled |
+| `body-max-line-length` (B1) | Body lines ≤72 chars | 72 |
+| `contrib-title-conventional-commits` | Capitalized type prefix | Required |
+| `contrib-body-requires-signed-off-by` | DCO sign-off present | Required |
+| `ignore-by-body` | Exempt URL lines from B1 | Enabled |
+
+## Pre-Commit Hooks
+
+This repository uses pre-commit hooks that run automatically on `git commit`.
+The hooks enforce (non-exhaustive list):
+
+- **gitlint** — Commit message format validation (see rules above)
+- **reuse** — SPDX license header compliance
+- **ruff** — Python linting and formatting
+- **mypy** — Python type checking
+- **interrogate** — Docstring coverage (100% required)
+- **yamllint** — YAML linting
+- **actionlint** — GitHub Actions workflow validation
+
+Check `.pre-commit-config.yaml` for the complete list.
+
+### If Pre-Commit Fails
+
+**CRITICAL**: Do NOT use `git reset` after a failed commit attempt.
+
+1. Fix the issues identified by the pre-commit hooks
+2. Stage the fixes: `git add <files>`
+3. Attempt the commit again as if you hadn't tried before
+4. The pre-commit hooks will run again on the new attempt
+
+Pre-commit hooks may auto-fix some issues (e.g., ruff format). If files were
+modified by hooks, stage them and commit again.
+
+### Never Bypass Hooks
+
+Using `--no-verify` to bypass pre-commit hooks is **PROHIBITED**.
+
+## Atomic Commits
+
+Each commit MUST represent exactly one logical change:
+
+- ✅ One feature per commit
+- ✅ One bug fix per commit
+- ✅ One refactor per commit
+- ❌ Multiple unrelated changes in one commit
+
+### Task List Updates Are Separate Commits
+
+Changes to task tracking documents (e.g., `tasks.md`) MUST be committed
+separately from the code or documentation they track. Bundling a task
+list update into the same commit as the work it describes breaks commit
+atomicity — even when both changes are classified as documentation.
+
+- ✅ Commit 1: `Feat(core): Add HTTP client` (code + tests)
+- ✅ Commit 2: `Docs(tasks): Mark T015 complete` (tasks.md only)
+- ❌ Single commit with code changes **and** tasks.md update
+
+## SPDX License Headers
+
+All new source files MUST include SPDX headers:
+
+```python
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+```
+
+Check `REUSE.toml` for file-type-specific header requirements.
+
+## Testing Requirements
+
+The Python project lives under `custom_components/`. Run commands
+from the repository root using `uv`:
+
+- Run tests before committing: `uv run pytest tests/`
+- Run linting before committing: `uv run ruff check custom_components/ tests/`
+- All tests must pass before pushing
+- New features should include appropriate test coverage
+
+## Development Workflow Summary
+
+1. Make changes to code
+2. Run tests locally to verify: `uv run pytest tests/ -x -q`
+3. Run linting: `uv run ruff check custom_components/ tests/`
+4. Stage changes: `git add <files>`
+5. Commit with sign-off and co-authorship:
+
+   ```bash
+   git commit -s -m "Type(scope): Short imperative description
+
+   Body explaining what and why.
+
+   Co-authored-by: <AI Model> <email@provider.com>"
+   ```
+
+6. If pre-commit fails, fix issues and commit again (don't reset)
+7. Push when ready
+
+## Quick Reference
+
+| Requirement | Command/Format |
+| ------------ | ---------------- |
+| Sign-off | `git commit -s` |
+| Co-author | `Co-authored-by: <Model> <email>` |
+| Subject format | `Type(scope): imperative description` |
+| Type case | Capitalized (e.g., `Fix`, `Feat`) |
+| Subject length | ≤50 chars (enforced by gitlint) |
+| Body line length | ≤72 chars (URLs exempt) |
+| Subject punctuation | No trailing period |
+| Subject mood | Imperative ("Add", not "Added") |
+| Body content | Explain what and why, not how |
+| After failed commit | Fix and retry (no reset) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ The blank line between the subject and body is critical. Git tools like `log`,
 `shortlog`, and `rebase` rely on this separation. Simple changes may omit the
 body entirely.
 
-- **Enforcement**: Git itself; gitlint validates structure.
+- **Enforcement**: Convention and tooling; gitlint validates structure.
 
 ### Rule 2: Limit the subject line to 50 characters
 
@@ -74,10 +74,12 @@ Bad examples:
 ### Rule 6: Wrap the body at 72 characters
 
 Body text MUST be wrapped at 72 characters per line. Lines containing URLs
-are exempt from this limit.
+MAY exceed this limit, but enforcement tooling has limitations.
 
 - **Enforcement**: gitlint `body-max-line-length` (default 72). The
-  `ignore-by-body` rule exempts lines containing URLs.
+  configured `ignore-by-body` rule disables this check for the entire
+  commit body if any line matches the URL pattern, so you MUST still
+  manually wrap non-URL lines to 72 characters.
 
 ### Rule 7: Use the body to explain what and why, not how
 
@@ -97,8 +99,8 @@ Type(scope): Short imperative description
 Body explaining what and why. Wrap at 72 characters.
 URLs on their own line are exempt from the wrap limit.
 
-Signed-off-by: Name <email>
 Co-authored-by: <AI Model Name> <appropriate-email@provider.com>
+Signed-off-by: Name <email>
 ```
 
 **Allowed types** (capitalized, enforced by gitlint):
@@ -139,15 +141,17 @@ the AI model used:
 | Gemini | `Co-authored-by: Gemini <gemini@google.com>` |
 | Copilot | `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` |
 
-This trailer goes at the end of the commit message body, after the
-`Signed-off-by` line.
+This trailer goes at the end of the commit message body. Note that
+`git commit -s` appends the `Signed-off-by` line after all other
+content, so it will appear after the `Co-authored-by` trailer
+automatically.
 
 ## Gitlint Enforcement Summary
 
 The following gitlint rules are active (see `.gitlint` for full config):
 
-| Rule | What it checks | Default |
-| ---- | -------------- | ------- |
+| Rule | What it checks | Configured |
+| ---- | -------------- | ---------- |
 | `title-max-length` (T1) | Subject ≤50 chars | 50 |
 | `title-trailing-punctuation` (T3) | No trailing `.` `;` `:` etc. | Enabled |
 | `body-max-line-length` (B1) | Body lines ≤72 chars | 72 |

--- a/specs/001-test-coverage/plan.md
+++ b/specs/001-test-coverage/plan.md
@@ -58,7 +58,7 @@ Each commit will be independently runnable.
 
 ### Principle V: Agent Co-Authorship & DCO Requirements
 **Status**: ✅ PASS
-**Notes**: Commits will include `Co-Authored-By: GitHub Copilot <copilot@github.com>` and DCO sign-off via `git commit -s`.
+**Notes**: Commits will include `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` and DCO sign-off via `git commit -s`.
 
 ### Principle VI: User Experience Consistency
 **Status**: ✅ PASS

--- a/specs/001-test-coverage/quickstart.md
+++ b/specs/001-test-coverage/quickstart.md
@@ -206,7 +206,7 @@ git commit -s -m "Test: add tests for <module_name>
 - Cover <edge cases>
 - Achieve <coverage percentage>% coverage
 
-Co-Authored-By: GitHub Copilot <copilot@github.com>"
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 ```
 
 ---


### PR DESCRIPTION
## Summary

Add comprehensive agent development guidelines and enforce stricter commit message standards.

### Changes

**AGENTS.md** (new file):
- Codifies the [seven rules of a great git commit message](https://chris.beams.io/posts/git-commit/)
- Each rule mapped to its enforcement mechanism (gitlint rule or manual discipline)
- Includes imperative mood good/bad examples
- Gitlint enforcement summary table
- Fixed Copilot Co-authored-by to use `Copilot <223556219+Copilot@users.noreply.github.com>`
- Documents pre-commit hooks, atomic commit policy, SPDX headers, testing workflow

**.gitlint**:
- Enable `title-max-length` with `line-length=50` (was using default 72)
- Explicitly configure `body-max-line-length` to 72 (was relying on gitlint default)

**.specify/memory/constitution.md**:
- Align Co-authored-by trailer format and Copilot email with AGENTS.md

**specs/001-test-coverage/{plan,quickstart}.md**:
- Update legacy Co-Authored-By references to current format