### PR TITLE
Fix(coordinator): Calendar failure resilience (Phase 2)

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -561,64 +561,66 @@ Please update Keymaster to at least v0.1.0-b0
             session = async_get_clientsession(self.hass, verify_ssl=self.verify_ssl)
             async with asyncio.timeout(REQUEST_TIMEOUT):
                 response = await session.get(self.url)
-            if response.status != 200:
-                _LOGGER.error(
-                    "%s returned %s - %s",
-                    self.url,
-                    response.status,
-                    response.reason,
+            try:
+                if response.status != 200:
+                    _LOGGER.error(
+                        "%s returned %s - %s",
+                        self.url,
+                        response.status,
+                        response.reason,
+                    )
+                    return
+                text = await response.text()
+            finally:
+                response.release()
+
+            # Some calendars are for some reason filled with NULL-bytes.
+            # They break the parsing, so we get rid of them
+            event_list = Calendar.from_ical(text.replace("\x00", ""))
+
+            # If the calendar is using a non-standard timezone definition,
+            # convert it to a standard one
+            if "X-WR-TIMEZONE" in event_list:
+                event_list = await self.hass.async_add_executor_job(
+                    x_wr_timezone.to_standard, event_list
+                )
+
+            start_of_events = dt.start_of_local_day()
+            end_of_events = dt.start_of_local_day() + timedelta(days=self.days)
+
+            new_calendar: list[CalendarEvent] = await self._ical_parser(
+                event_list, start_of_events, end_of_events
+            )
+
+            if (
+                len(self.calendar) > 0
+                and len(new_calendar) == 0
+                and self.num_misses < self.max_misses
+            ):
+                self.num_misses += 1
+                _LOGGER.warning(
+                    "No events found in calendar %s, but %d in previous. Miss %d of %d",
+                    self.name,
+                    len(self.calendar),
+                    self.num_misses,
+                    self.max_misses,
                 )
                 return
             else:
-                text = await response.text()
-                # Some calendars are for some reason filled with NULL-bytes.
-                # They break the parsing, so we get rid of them
-                event_list = Calendar.from_ical(text.replace("\x00", ""))
-
-                # If the calendar is using a non-standard timezone definition,
-                # convert it to a standard one
-                if "X-WR-TIMEZONE" in event_list:
-                    event_list = await self.hass.async_add_executor_job(
-                        x_wr_timezone.to_standard, event_list
-                    )
-
-                start_of_events = dt.start_of_local_day()
-                end_of_events = dt.start_of_local_day() + timedelta(days=self.days)
-
-                new_calendar: list[CalendarEvent] = await self._ical_parser(
-                    event_list, start_of_events, end_of_events
+                _LOGGER.debug(
+                    "Found %d events in calendar %s",
+                    len(new_calendar),
+                    self.name,
                 )
+                self.num_misses = 0
+                self.calendar = new_calendar
 
-                if (
-                    len(self.calendar) > 0
-                    and len(new_calendar) == 0
-                    and self.num_misses < self.max_misses
-                ):
-                    self.num_misses += 1
-                    _LOGGER.warning(
-                        "No events found in calendar %s,"
-                        " but %d in previous. Miss %d of %d",
-                        self.name,
-                        len(self.calendar),
-                        self.num_misses,
-                        self.max_misses,
-                    )
-                    return
-                else:
-                    _LOGGER.debug(
-                        "Found %d events in calendar %s",
-                        len(new_calendar),
-                        self.name,
-                    )
-                    self.num_misses = 0
-                    self.calendar = new_calendar
+            self.calendar_loaded = True
 
-                self.calendar_loaded = True
-
-                if not self.lockname:
-                    self.calendar_ready = True
-                elif self.event_overrides and self.event_overrides.ready:
-                    self.calendar_ready = True
+            if not self.lockname:
+                self.calendar_ready = True
+            elif self.event_overrides and self.event_overrides.ready:
+                self.calendar_ready = True
 
             if len(self.calendar) > 0:
                 found_next_event = False
@@ -641,7 +643,11 @@ Please update Keymaster to at least v0.1.0-b0
                 if isinstance(result, BaseException):
                     if isinstance(result, asyncio.CancelledError):
                         raise result
-                    _LOGGER.error("Sensor update failed: %s", result)
+                    _LOGGER.error(
+                        "Sensor update failed: %s",
+                        result,
+                        exc_info=(type(result), result, result.__traceback__),
+                    )
         except TimeoutError:
             _LOGGER.warning("Calendar refresh timed out for %s", self.name)
         except aiohttp.ClientError as err:

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -26,6 +26,7 @@ from typing import Any
 from typing import Dict
 from zoneinfo import ZoneInfo  # noreorder
 
+import aiohttp
 from homeassistant.components.button import DOMAIN as BUTTON
 from homeassistant.components.calendar import CalendarEvent
 from homeassistant.components.datetime import DOMAIN as DATETIME
@@ -557,80 +558,98 @@ Please update Keymaster to at least v0.1.0-b0
         """Update list of upcoming events."""
         _LOGGER.debug("Running RentalControl _refresh_calendar for %s", self.name)
 
-        session = async_get_clientsession(self.hass, verify_ssl=self.verify_ssl)
-        async with asyncio.timeout(REQUEST_TIMEOUT):
-            response = await session.get(self.url)
-        if response.status != 200:
-            _LOGGER.error(
-                "%s returned %s - %s", self.url, response.status, response.reason
-            )
-            return
-        else:
-            text = await response.text()
-            # Some calendars are for some reason filled with NULL-bytes.
-            # They break the parsing, so we get rid of them
-            event_list = Calendar.from_ical(text.replace("\x00", ""))
-
-            # If the calendar is using a non-standard timezone definition,
-            # convert it to a standard one
-            if "X-WR-TIMEZONE" in event_list:
-                event_list = await self.hass.async_add_executor_job(
-                    x_wr_timezone.to_standard, event_list
-                )
-
-            start_of_events = dt.start_of_local_day()
-            end_of_events = dt.start_of_local_day() + timedelta(days=self.days)
-
-            new_calendar: list[CalendarEvent] = await self._ical_parser(
-                event_list, start_of_events, end_of_events
-            )
-
-            if len(self.calendar) > 1 and len(new_calendar) == 0:
+        try:
+            session = async_get_clientsession(self.hass, verify_ssl=self.verify_ssl)
+            async with asyncio.timeout(REQUEST_TIMEOUT):
+                response = await session.get(self.url)
+            if response.status != 200:
                 _LOGGER.error(
-                    "No events found in calendar %s, but there are %d events in the old calendar",
-                    self.name,
-                    len(self.calendar),
-                )
-                return
-            elif (
-                len(self.calendar) == 1
-                and len(new_calendar) == 0
-                and self.num_misses < self.max_misses
-            ):
-                self.num_misses += 1
-                _LOGGER.warning(
-                    "No events found in calendar %s. Miss %d of %d",
-                    self.name,
-                    self.num_misses,
-                    self.max_misses,
+                    "%s returned %s - %s",
+                    self.url,
+                    response.status,
+                    response.reason,
                 )
                 return
             else:
-                _LOGGER.debug(
-                    "Found %d events in calendar %s", len(new_calendar), self.name
-                )
-                self.num_misses = 0
-                self.calendar = new_calendar
+                text = await response.text()
+                # Some calendars are for some reason filled with NULL-bytes.
+                # They break the parsing, so we get rid of them
+                event_list = Calendar.from_ical(text.replace("\x00", ""))
 
-            self.calendar_loaded = True
-
-            if self.lockname is None:
-                self.overrides_loaded = True
-
-            if self.overrides_loaded:
-                self.calendar_ready = True
-
-        if len(self.calendar) > 0:
-            found_next_event = False
-            for event in self.calendar:
-                if event.end > dt.now() and not found_next_event:
-                    _LOGGER.debug(
-                        "Event %s is the first event with end in the future: %s",
-                        event.summary,
-                        event.end,
+                # If the calendar is using a non-standard timezone definition,
+                # convert it to a standard one
+                if "X-WR-TIMEZONE" in event_list:
+                    event_list = await self.hass.async_add_executor_job(
+                        x_wr_timezone.to_standard, event_list
                     )
-                    self.event = event
-                    found_next_event = True
 
-        # signal an update to all the event sensors
-        await asyncio.gather(*[event.async_update() for event in self.event_sensors])
+                start_of_events = dt.start_of_local_day()
+                end_of_events = dt.start_of_local_day() + timedelta(days=self.days)
+
+                new_calendar: list[CalendarEvent] = await self._ical_parser(
+                    event_list, start_of_events, end_of_events
+                )
+
+                if len(self.calendar) > 1 and len(new_calendar) == 0:
+                    _LOGGER.error(
+                        "No events found in calendar %s, but there"
+                        " are %d events in the old calendar",
+                        self.name,
+                        len(self.calendar),
+                    )
+                    return
+                elif (
+                    len(self.calendar) == 1
+                    and len(new_calendar) == 0
+                    and self.num_misses < self.max_misses
+                ):
+                    self.num_misses += 1
+                    _LOGGER.warning(
+                        "No events found in calendar %s. Miss %d of %d",
+                        self.name,
+                        self.num_misses,
+                        self.max_misses,
+                    )
+                    return
+                else:
+                    _LOGGER.debug(
+                        "Found %d events in calendar %s",
+                        len(new_calendar),
+                        self.name,
+                    )
+                    self.num_misses = 0
+                    self.calendar = new_calendar
+
+                self.calendar_loaded = True
+
+                if self.lockname is None:
+                    self.overrides_loaded = True
+
+                if self.overrides_loaded:
+                    self.calendar_ready = True
+
+            if len(self.calendar) > 0:
+                found_next_event = False
+                for event in self.calendar:
+                    if event.end > dt.now() and not found_next_event:
+                        _LOGGER.debug(
+                            "Event %s is the first event with end in the future: %s",
+                            event.summary,
+                            event.end,
+                        )
+                        self.event = event
+                        found_next_event = True
+
+            # signal an update to all the event sensors
+            await asyncio.gather(
+                *[event.async_update() for event in self.event_sensors]
+            )
+        except TimeoutError:
+            _LOGGER.warning("Calendar refresh timed out for %s", self.name)
+        except aiohttp.ClientError as err:
+            _LOGGER.warning("Calendar fetch failed for %s: %s", self.name, err)
+        except Exception:
+            _LOGGER.exception(
+                "Unexpected error refreshing calendar for %s",
+                self.name,
+            )

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -562,18 +562,18 @@ Please update Keymaster to at least v0.1.0-b0
             session = async_get_clientsession(self.hass, verify_ssl=self.verify_ssl)
             async with asyncio.timeout(REQUEST_TIMEOUT):
                 response = await session.get(self.url)
-            try:
-                if response.status != 200:
-                    _LOGGER.error(
-                        "%s returned %s - %s",
-                        self.url,
-                        response.status,
-                        response.reason,
-                    )
-                    return
-                text = await response.text()
-            finally:
-                response.release()
+                try:
+                    if response.status != 200:
+                        _LOGGER.error(
+                            "%s returned %s - %s",
+                            self.url,
+                            response.status,
+                            response.reason,
+                        )
+                        return
+                    text = await response.text()
+                finally:
+                    response.release()
 
             # Some calendars are for some reason filled with NULL-bytes.
             # They break the parsing, so we get rid of them

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -641,9 +641,15 @@ Please update Keymaster to at least v0.1.0-b0
                         found_next_event = True
 
             # signal an update to all the event sensors
-            await asyncio.gather(
-                *[event.async_update() for event in self.event_sensors]
+            results = await asyncio.gather(
+                *[event.async_update() for event in self.event_sensors],
+                return_exceptions=True,
             )
+            for result in results:
+                if isinstance(result, BaseException):
+                    if isinstance(result, asyncio.CancelledError):
+                        raise result
+                    _LOGGER.error("Sensor update failed: %s", result)
         except TimeoutError:
             _LOGGER.warning("Calendar refresh timed out for %s", self.name)
         except aiohttp.ClientError as err:

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -72,6 +72,7 @@ from .const import STARTUP_REFRESH_DELAY
 from .const import VERSION
 from .event_overrides import EventOverrides
 from .sensors.calsensor import RentalControlCalSensor
+from .util import check_gather_results
 from .util import get_slot_name
 
 _LOGGER = logging.getLogger(__name__)
@@ -639,15 +640,7 @@ Please update Keymaster to at least v0.1.0-b0
                 *[event.async_update() for event in self.event_sensors],
                 return_exceptions=True,
             )
-            for result in results:
-                if isinstance(result, BaseException):
-                    if isinstance(result, asyncio.CancelledError):
-                        raise result
-                    _LOGGER.error(
-                        "Sensor update failed: %s",
-                        result,
-                        exc_info=(type(result), result, result.__traceback__),
-                    )
+            check_gather_results(results, "Sensor update")
         except TimeoutError:
             _LOGGER.warning("Calendar refresh timed out for %s", self.name)
         except aiohttp.ClientError as err:

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -640,7 +640,7 @@ Please update Keymaster to at least v0.1.0-b0
                 *[event.async_update() for event in self.event_sensors],
                 return_exceptions=True,
             )
-            check_gather_results(results, "Sensor update")
+            check_gather_results(results, "Sensor update", _LOGGER)
         except TimeoutError:
             _LOGGER.warning("Calendar refresh timed out for %s", self.name)
         except aiohttp.ClientError as err:

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -590,23 +590,17 @@ Please update Keymaster to at least v0.1.0-b0
                     event_list, start_of_events, end_of_events
                 )
 
-                if len(self.calendar) > 1 and len(new_calendar) == 0:
-                    _LOGGER.error(
-                        "No events found in calendar %s, but there"
-                        " are %d events in the old calendar",
-                        self.name,
-                        len(self.calendar),
-                    )
-                    return
-                elif (
-                    len(self.calendar) == 1
+                if (
+                    len(self.calendar) > 0
                     and len(new_calendar) == 0
                     and self.num_misses < self.max_misses
                 ):
                     self.num_misses += 1
                     _LOGGER.warning(
-                        "No events found in calendar %s. Miss %d of %d",
+                        "No events found in calendar %s,"
+                        " but %d in previous. Miss %d of %d",
                         self.name,
+                        len(self.calendar),
                         self.num_misses,
                         self.max_misses,
                     )

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -113,7 +113,6 @@ class RentalControlCoordinator:
         self.calendar: list[CalendarEvent] = []
         self.calendar_ready: bool = False
         self.calendar_loaded: bool = False
-        self.overrides_loaded: bool = False
         self.event_overrides: EventOverrides | None = (
             EventOverrides(self.start_slot, self.max_events) if self.lockname else None
         )
@@ -616,10 +615,9 @@ Please update Keymaster to at least v0.1.0-b0
 
                 self.calendar_loaded = True
 
-                if self.lockname is None:
-                    self.overrides_loaded = True
-
-                if self.overrides_loaded:
+                if not self.lockname:
+                    self.calendar_ready = True
+                elif self.event_overrides and self.event_overrides.ready:
                     self.calendar_ready = True
 
             if len(self.calendar) > 0:

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -205,9 +205,15 @@ class EventOverrides:
                 )
 
                 # signal an update to all the event sensors
-                await asyncio.gather(
-                    *[event.async_update() for event in coordinator.event_sensors]
+                results = await asyncio.gather(
+                    *[event.async_update() for event in coordinator.event_sensors],
+                    return_exceptions=True,
                 )
+                for result in results:
+                    if isinstance(result, BaseException):
+                        if isinstance(result, asyncio.CancelledError):
+                            raise result
+                        _LOGGER.error("Sensor update failed: %s", result)
 
     def get_slot_name(self, slot: int) -> str:
         """Return the slot name."""

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -210,7 +210,7 @@ class EventOverrides:
                     *[event.async_update() for event in coordinator.event_sensors],
                     return_exceptions=True,
                 )
-                check_gather_results(results, "Sensor update")
+                check_gather_results(results, "Sensor update", _LOGGER)
 
     def get_slot_name(self, slot: int) -> str:
         """Return the slot name."""

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -213,7 +213,15 @@ class EventOverrides:
                     if isinstance(result, BaseException):
                         if isinstance(result, asyncio.CancelledError):
                             raise result
-                        _LOGGER.error("Sensor update failed: %s", result)
+                        _LOGGER.error(
+                            "Sensor update failed: %s",
+                            result,
+                            exc_info=(
+                                type(result),
+                                result,
+                                result.__traceback__,
+                            ),
+                        )
 
     def get_slot_name(self, slot: int) -> str:
         """Return the slot name."""

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -26,6 +26,7 @@ from typing import TypedDict
 from homeassistant.util import dt
 
 from .util import async_fire_clear_code
+from .util import check_gather_results
 from .util import get_event_names
 
 _LOGGER = logging.getLogger(__name__)
@@ -209,19 +210,7 @@ class EventOverrides:
                     *[event.async_update() for event in coordinator.event_sensors],
                     return_exceptions=True,
                 )
-                for result in results:
-                    if isinstance(result, BaseException):
-                        if isinstance(result, asyncio.CancelledError):
-                            raise result
-                        _LOGGER.error(
-                            "Sensor update failed: %s",
-                            result,
-                            exc_info=(
-                                type(result),
-                                result,
-                                result.__traceback__,
-                            ),
-                        )
+                check_gather_results(results, "Sensor update")
 
     def get_slot_name(self, slot: int) -> str:
         """Return the slot name."""

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -154,7 +154,11 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         if isinstance(result, BaseException):
             if isinstance(result, asyncio.CancelledError):
                 raise result
-            _LOGGER.error("Lock slot operation failed: %s", result)
+            _LOGGER.error(
+                "Lock slot operation failed: %s",
+                result,
+                exc_info=(type(result), result, result.__traceback__),
+            )
 
     coro.clear()
 
@@ -211,7 +215,11 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         if isinstance(result, BaseException):
             if isinstance(result, asyncio.CancelledError):
                 raise result
-            _LOGGER.error("Lock slot operation failed: %s", result)
+            _LOGGER.error(
+                "Lock slot operation failed: %s",
+                result,
+                exc_info=(type(result), result, result.__traceback__),
+            )
 
     # Turn on the slot
     coro.clear()
@@ -229,7 +237,11 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         if isinstance(result, BaseException):
             if isinstance(result, asyncio.CancelledError):
                 raise result
-            _LOGGER.error("Lock slot operation failed: %s", result)
+            _LOGGER.error(
+                "Lock slot operation failed: %s",
+                result,
+                exc_info=(type(result), result, result.__traceback__),
+            )
 
 
 async def async_fire_update_times(coordinator, event) -> None:
@@ -266,7 +278,11 @@ async def async_fire_update_times(coordinator, event) -> None:
         if isinstance(result, BaseException):
             if isinstance(result, asyncio.CancelledError):
                 raise result
-            _LOGGER.error("Lock slot operation failed: %s", result)
+            _LOGGER.error(
+                "Lock slot operation failed: %s",
+                result,
+                exc_info=(type(result), result, result.__traceback__),
+            )
 
 
 def get_event_names(rc) -> List[str]:

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -58,12 +58,14 @@ def check_gather_results(
 ) -> None:
     """Check asyncio.gather results for exceptions.
 
-    Re-raises CancelledError and logs other exceptions with
-    traceback so failures are actionable from logs.
+    Re-raises BaseException subclasses that should not be
+    swallowed (CancelledError, SystemExit, KeyboardInterrupt)
+    and logs ordinary Exception instances with traceback so
+    failures are actionable from logs.
     """
     for result in results:
         if isinstance(result, BaseException):
-            if isinstance(result, asyncio.CancelledError):
+            if not isinstance(result, Exception):
                 raise result
             logger.error(
                 "%s failed: %s",

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -20,10 +20,11 @@ import hashlib
 import logging
 import os
 import re
-from typing import Any  # noqa: F401
+from typing import Any
 from typing import Coroutine
 from typing import Dict
 from typing import List
+from typing import Sequence
 import uuid
 
 from homeassistant.components.automation import DOMAIN as AUTO_DOMAIN
@@ -51,7 +52,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def check_gather_results(
-    results: list[BaseException | Any],
+    results: Sequence[object],
     context: str,
     logger: logging.Logger = _LOGGER,
 ) -> None:

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -149,7 +149,12 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         f"{SWITCH}.{lockname}_code_slot_{slot}_enabled",
         {},
     )
-    await asyncio.gather(*coro)
+    results = await asyncio.gather(*coro, return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            _LOGGER.error("Lock slot operation failed: %s", result)
 
     coro.clear()
 
@@ -201,7 +206,12 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         {"value": slot_name},
     )
     # Update the slot details
-    await asyncio.gather(*coro)
+    results = await asyncio.gather(*coro, return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            _LOGGER.error("Lock slot operation failed: %s", result)
 
     # Turn on the slot
     coro.clear()
@@ -214,7 +224,12 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         {},
     )
 
-    await asyncio.gather(*coro)
+    results = await asyncio.gather(*coro, return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            _LOGGER.error("Lock slot operation failed: %s", result)
 
 
 async def async_fire_update_times(coordinator, event) -> None:
@@ -246,7 +261,12 @@ async def async_fire_update_times(coordinator, event) -> None:
         {"datetime": event.extra_state_attributes["start"]},
     )
     # Update the slot details
-    await asyncio.gather(*coro)
+    results = await asyncio.gather(*coro, return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            _LOGGER.error("Lock slot operation failed: %s", result)
 
 
 def get_event_names(rc) -> List[str]:

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -50,6 +50,28 @@ from .const import NAME
 _LOGGER = logging.getLogger(__name__)
 
 
+def check_gather_results(
+    results: list[BaseException | Any],
+    context: str,
+    logger: logging.Logger = _LOGGER,
+) -> None:
+    """Check asyncio.gather results for exceptions.
+
+    Re-raises CancelledError and logs other exceptions with
+    traceback so failures are actionable from logs.
+    """
+    for result in results:
+        if isinstance(result, BaseException):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            logger.error(
+                "%s failed: %s",
+                context,
+                result,
+                exc_info=(type(result), result, result.__traceback__),
+            )
+
+
 def add_call(
     hass: HomeAssistant,
     coro: List[Coroutine],
@@ -150,15 +172,7 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         {},
     )
     results = await asyncio.gather(*coro, return_exceptions=True)
-    for result in results:
-        if isinstance(result, BaseException):
-            if isinstance(result, asyncio.CancelledError):
-                raise result
-            _LOGGER.error(
-                "Lock slot operation failed: %s",
-                result,
-                exc_info=(type(result), result, result.__traceback__),
-            )
+    check_gather_results(results, "Lock slot operation")
 
     coro.clear()
 
@@ -211,15 +225,7 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
     )
     # Update the slot details
     results = await asyncio.gather(*coro, return_exceptions=True)
-    for result in results:
-        if isinstance(result, BaseException):
-            if isinstance(result, asyncio.CancelledError):
-                raise result
-            _LOGGER.error(
-                "Lock slot operation failed: %s",
-                result,
-                exc_info=(type(result), result, result.__traceback__),
-            )
+    check_gather_results(results, "Lock slot operation")
 
     # Turn on the slot
     coro.clear()
@@ -233,15 +239,7 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
     )
 
     results = await asyncio.gather(*coro, return_exceptions=True)
-    for result in results:
-        if isinstance(result, BaseException):
-            if isinstance(result, asyncio.CancelledError):
-                raise result
-            _LOGGER.error(
-                "Lock slot operation failed: %s",
-                result,
-                exc_info=(type(result), result, result.__traceback__),
-            )
+    check_gather_results(results, "Lock slot operation")
 
 
 async def async_fire_update_times(coordinator, event) -> None:
@@ -274,15 +272,7 @@ async def async_fire_update_times(coordinator, event) -> None:
     )
     # Update the slot details
     results = await asyncio.gather(*coro, return_exceptions=True)
-    for result in results:
-        if isinstance(result, BaseException):
-            if isinstance(result, asyncio.CancelledError):
-                raise result
-            _LOGGER.error(
-                "Lock slot operation failed: %s",
-                result,
-                exc_info=(type(result), result, result.__traceback__),
-            )
+    check_gather_results(results, "Lock slot operation")
 
 
 def get_event_names(rc) -> List[str]:

--- a/specs/002-code-health/tasks.md
+++ b/specs/002-code-health/tasks.md
@@ -88,7 +88,7 @@ available with its previous calendar state.
   count so that multi-event calendars track empty refreshes
   identically to single-event calendars. See research.md R3.
   **FR**: FR-005
-- [ ] T005 [US1] Simplify the `overrides_loaded` readiness tracking
+- [x] T005 [US1] Simplify the `overrides_loaded` readiness tracking
   in `custom_components/rental_control/coordinator.py`. Ensure
   there is a single clear code path for determining when the
   coordinator is ready to process events, regardless of whether a

--- a/specs/002-code-health/tasks.md
+++ b/specs/002-code-health/tasks.md
@@ -58,7 +58,7 @@ available with its previous calendar state.
 
 ### Implementation for User Story 1
 
-- [ ] T002 [US1] Wrap the entire `_refresh_calendar` method body
+- [x] T002 [US1] Wrap the entire `_refresh_calendar` method body
   in a try/except in
   `custom_components/rental_control/coordinator.py`. Catch
   `asyncio.TimeoutError` (log warning), `aiohttp.ClientError`

--- a/specs/002-code-health/tasks.md
+++ b/specs/002-code-health/tasks.md
@@ -81,7 +81,7 @@ available with its previous calendar state.
   separately in T016 (FR-017). See research.md R2 and quickstart.md
   gather pattern for the `BaseException` / `CancelledError` idiom.
   **FR**: FR-004
-- [ ] T004 [US1] Remove the conditional that skips miss tracking
+- [x] T004 [US1] Remove the conditional that skips miss tracking
   when `len(calendar) > 1` in
   `custom_components/rental_control/coordinator.py`. Apply the
   same `max_misses` tracking logic regardless of calendar event

--- a/specs/002-code-health/tasks.md
+++ b/specs/002-code-health/tasks.md
@@ -67,7 +67,7 @@ available with its previous calendar state.
   `self.calendar` data. See research.md R1 and quickstart.md key
   patterns for the exact exception hierarchy.
   **FR**: FR-001, FR-002, FR-003
-- [ ] T003 [US1] Add `return_exceptions=True` to all
+- [x] T003 [US1] Add `return_exceptions=True` to all
   `asyncio.gather` call sites and add result-checking logic that
   re-raises `asyncio.CancelledError` and logs other exceptions.
   Files:

--- a/specs/002-code-health/tasks.md
+++ b/specs/002-code-health/tasks.md
@@ -40,7 +40,7 @@ tests/integration/                  # Integration tests
 
 **Purpose**: Verify baseline before making any changes
 
-- [ ] T001 Verify baseline: run `uv run pytest tests/ -x -q` (all
+- [x] T001 Verify baseline: run `uv run pytest tests/ -x -q` (all
   tests pass) and `uv run ruff check custom_components/ tests/`
   (zero findings) to confirm a clean starting state
 

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -271,7 +271,7 @@ async def test_coordinator_error_state(
     After a failed fetch the coordinator should keep calendar_loaded as
     False and calendar_ready as False. After a successful fetch both
     should become True (ready depends on overrides, which are not
-    configured here so overrides_loaded defaults to True on first load).
+    configured here so calendar_ready is set directly on first load).
     """
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -241,15 +241,12 @@ async def test_coordinator_refresh_network_error(
 async def test_coordinator_refresh_invalid_ics(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test coordinator behavior with malformed ICS content.
+    """Test coordinator handles malformed ICS content gracefully.
 
-    Note: Currently the coordinator does not have try/except around
-    Calendar.from_ical(), so malformed ICS raises ValueError.
-    This test documents current behavior. Future enhancement could
-    add graceful error handling to log and continue without crashing.
+    The coordinator wraps _refresh_calendar in try/except, so
+    malformed ICS data is caught, logged, and the previous calendar
+    state is preserved without crashing.
     """
-    import pytest
-
     mock_config_entry.add_to_hass(hass)
 
     with aioresponses() as mock_session:
@@ -262,13 +259,16 @@ async def test_coordinator_refresh_invalid_ics(
 
         coordinator = RentalControlCoordinator(hass, mock_config_entry)
 
-        # Current behavior: malformed ICS raises ValueError from icalendar parser
-        # TODO: Consider adding try/except in coordinator._refresh_calendar()
-        # to handle gracefully (log error, keep calendar_loaded=False)
-        with pytest.raises(ValueError):
-            await coordinator.update()
+        # Graceful handling: malformed ICS is caught, logged,
+        # and the coordinator preserves its previous calendar state
+        await coordinator.update()
 
         await hass.async_block_till_done()
+
+        # Calendar should remain empty (initial state) since the
+        # malformed data could not be parsed
+        assert coordinator.calendar == []
+        assert coordinator.calendar_loaded is False
 
 
 async def test_coordinator_state_management(


### PR DESCRIPTION
## Summary

Phase 2 of Feature 002 (Code Health). Implements US1: Integration
Survives Calendar Failures.

## Changes

- **T002**: Wrap `_refresh_calendar` in try/except to catch
  `TimeoutError`, `aiohttp.ClientError`, and unexpected exceptions.
  On error, preserve existing calendar state and log without crashing.
- **T003**: Add `return_exceptions=True` to all `asyncio.gather`
  calls across coordinator.py, util.py, and event_overrides.py. Check
  results for exceptions: re-raise `CancelledError`, log others.
- **T004**: Unify miss tracking — remove the `len(calendar) > 1`
  special case so multi-event calendars track empty refreshes the
  same as single-event calendars.
- **T005**: Remove the `overrides_loaded` intermediary flag. Determine
  `calendar_ready` directly based on lock manager configuration,
  matching the pattern already used in `handle_state_change`.

## Testing

All 278 existing tests pass. The `test_coordinator_refresh_invalid_ics`
test was updated to expect graceful error handling instead of a
propagated `ValueError`.

## References

- Feature spec: specs/002-code-health/spec.md
- Tasks: specs/002-code-health/tasks.md (T001–T005 marked complete)
- Research decisions: R1 (error handling), R2 (gather), R3 (miss
  tracking), R4 (readiness simplification)
