### PR TITLE
Refactor: Phase 5 code modernization (T010-T019)

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -29,7 +29,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_state_change_event
-import voluptuous as vol
 
 from .const import CONF_CODE_LENGTH
 from .const import CONF_CREATION_DATETIME
@@ -49,14 +48,6 @@ from .util import delete_rc_and_base_folder
 from .util import handle_state_change
 
 _LOGGER = logging.getLogger(__name__)
-
-
-CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
-
-
-def setup(hass, config):
-    """Set up this integration with config flow."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -54,7 +54,7 @@ _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
 
-def setup(hass, config):  # pylint: disable=unused-argument
+def setup(hass, config):
     """Set up this integration with config flow."""
     return True
 

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import functools
 import logging
 
@@ -109,13 +108,8 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         notification_id=notification_id,
     )
 
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(config_entry, component)
-                for component in PLATFORMS
-            ]
-        )
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        config_entry, PLATFORMS
     )
 
     if unload_ok:

--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -130,7 +130,6 @@ class RentalControlOptionsFlow(config_entries.OptionsFlow):
 
 def _available_lock_managers(
     hass: HomeAssistant,
-    # entry_id: str = None
 ) -> list:
     """Find lock manager configurations to use."""
 

--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -6,9 +6,6 @@
 import asyncio
 import logging
 from typing import Any
-from typing import Dict
-from typing import Optional
-from typing import Union
 from zoneinfo import available_timezones
 
 from homeassistant import config_entries
@@ -83,7 +80,7 @@ class RentalControlFlowHandler(config_entries.ConfigFlow):
         """Setup the RentalControlFlowHandler."""
         self.created = str(dt.now())
 
-    async def _get_unique_id(self, user_input) -> Dict[str, str]:
+    async def _get_unique_id(self, user_input) -> dict[str, str]:
         """Generate the unique_id."""
         existing_entry = await self.async_set_unique_id(
             gen_uuid(self.created), raise_on_progress=True
@@ -114,10 +111,10 @@ class RentalControlOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(
         self,
-        user_input: Optional[Dict[str, Any]] = None,
+        user_input: dict[str, Any] | None = None,
     ) -> Any:
         """Handle a flow initialized by the user."""
-        flow_data: Dict[str, Any] | None = None
+        flow_data: dict[str, Any] | None = None
         if self.config_entry.data:
             flow_data = dict(self.config_entry.data)
         return await _start_config_flow(
@@ -196,9 +193,9 @@ def _lock_entry_convert(hass: HomeAssistant, entry: str, to_entity: bool = True)
 
 def _get_schema(
     hass: HomeAssistant,
-    user_input: Optional[Dict[str, Any]],
-    default_dict: Optional[Dict[str, Any]],
-    entry_id: Optional[str] = None,
+    user_input: dict[str, Any] | None,
+    default_dict: dict[str, Any] | None,
+    entry_id: str | None = None,
 ) -> vol.Schema:
     """Gets a schema using the default_dict as a backup."""
     if user_input is None:
@@ -297,13 +294,13 @@ def _get_schema(
 
 
 def _show_config_form(
-    cls: Union[RentalControlFlowHandler, RentalControlOptionsFlow],
+    cls: RentalControlFlowHandler | RentalControlOptionsFlow,
     step_id: str,
-    user_input: Optional[Dict[str, Any]],
-    errors: Dict[str, str],
-    description_placeholders: Dict[str, str],
-    defaults: Optional[Dict[str, Any]] = None,
-    entry_id: Optional[str] = None,
+    user_input: dict[str, Any] | None,
+    errors: dict[str, str],
+    description_placeholders: dict[str, str],
+    defaults: dict[str, Any] | None = None,
+    entry_id: str | None = None,
 ) -> Any:
     """Show the configuration form to edit data."""
     return cls.async_show_form(
@@ -315,16 +312,16 @@ def _show_config_form(
 
 
 async def _start_config_flow(
-    cls: Union[RentalControlFlowHandler, RentalControlOptionsFlow],
+    cls: RentalControlFlowHandler | RentalControlOptionsFlow,
     step_id: str,
     title: str,
-    user_input: Optional[Dict[str, Any]],
-    defaults: Optional[Dict[str, Any]] = None,
-    entry_id: Optional[str] = None,
+    user_input: dict[str, Any] | None,
+    defaults: dict[str, Any] | None = None,
+    entry_id: str | None = None,
 ):
     """Start a config flow."""
-    errors: Dict[str, str] = {}
-    description_placeholders: Dict[str, str] = {}
+    errors: dict[str, str] = {}
+    description_placeholders: dict[str, str] = {}
 
     if user_input is not None:
         # Regular flow has an async function

--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -57,8 +57,9 @@ _LOGGER = logging.getLogger(__name__)
 sorted_tz = sorted(available_timezones())
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class RentalControlFlowHandler(config_entries.ConfigFlow):
+class RentalControlFlowHandler(  # type: ignore[call-arg]
+    config_entries.ConfigFlow, domain=DOMAIN
+):
     """Handle the config flow for Rental Control."""
 
     VERSION = 7

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -80,8 +80,6 @@ _LOGGER = logging.getLogger(__name__)
 class RentalControlCoordinator:
     """Get a list of events."""
 
-    # pylint: disable=too-many-instance-attributes
-
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry):
         """Set up a calendar object."""
         config = config_entry.data
@@ -197,7 +195,7 @@ Please update Keymaster to at least v0.1.0-b0
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
-    ) -> list[CalendarEvent]:  # pylint: disable=unused-argument
+    ) -> list[CalendarEvent]:
         """Get list of upcoming events."""
         _LOGGER.debug("Running RentalControl async_get_events")
         events = []

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -353,7 +353,6 @@ Please update Keymaster to at least v0.1.0-b0
         """Update the event overrides with the ServiceCall data."""
         _LOGGER.debug("In update_event_overrides")
 
-        # temporary call new_update_event_overrides
         if self.event_overrides:
             self.event_overrides.update(
                 slot,

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -23,7 +23,6 @@ from datetime import time
 from datetime import timedelta
 import logging
 from typing import Any
-from typing import Dict
 from zoneinfo import ZoneInfo  # noreorder
 
 import aiohttp
@@ -492,7 +491,7 @@ Please update Keymaster to at least v0.1.0-b0
         start: dt.dt.datetime,
         end: dt.dt.datetime,
         from_date: dt.dt.datetime,
-        event: Dict[Any, Any],
+        event: dict[Any, Any],
     ) -> CalendarEvent | None:
         """Ensure that events are within the start and end."""
         _LOGGER.debug(

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -11,7 +11,7 @@
 # Contributors:
 #   Andrew Grimberg - Initial implementation
 ##############################################################################
-"""Rental Control EventOVerrides."""
+"""Rental Control EventOverrides."""
 
 import asyncio
 from datetime import date

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -19,8 +19,6 @@ from datetime import datetime
 from datetime import time
 import logging
 import re
-from typing import Dict
-from typing import List
 from typing import TypedDict
 
 from homeassistant.util import dt
@@ -49,7 +47,7 @@ class EventOverrides:
 
         self._max_slots: int = max_slots
         self._next_slot: int | None = None
-        self._overrides: Dict[int, EventOverride | None] = {}
+        self._overrides: dict[int, EventOverride | None] = {}
         self._ready: bool = False
         self._start_slot: int = start_slot
 
@@ -64,7 +62,7 @@ class EventOverrides:
         return self._next_slot
 
     @property
-    def overrides(self) -> Dict[int, EventOverride | None]:
+    def overrides(self) -> dict[int, EventOverride | None]:
         """Return the overrides."""
         return self._overrides
 
@@ -117,13 +115,13 @@ class EventOverrides:
         # We should never hit this directly, but if we do, set our next to None
         self._next_slot = None
 
-    def __get_slots_with_values(self) -> List[int]:
+    def __get_slots_with_values(self) -> list[int]:
         """Get a sorted list of the keys that have values."""
         return sorted(
             k for k in self._overrides.keys() if self._overrides[k] is not None
         )
 
-    def __get_slots_without_values(self, max_slot: int = 0) -> List[int]:
+    def __get_slots_without_values(self, max_slot: int = 0) -> list[int]:
         """
         Get the sorted list of the keys that have no value greater than
         max_slot.

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -20,7 +20,7 @@ from collections.abc import Coroutine
 from collections.abc import Sequence
 import hashlib
 import logging
-import os
+from pathlib import Path
 import re
 from typing import Any
 import uuid
@@ -96,33 +96,31 @@ def add_call(
 
 def delete_rc_and_base_folder(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Delete packages folder for RC and base rental_control folder if empty."""
-    base_path = os.path.join(
-        hass.config.path(), config_entry.data.get(CONF_PATH, DEFAULT_PATH)
-    )
+    base_path = Path(hass.config.path(), config_entry.data.get(CONF_PATH, DEFAULT_PATH))
     rc_name_slug = slugify(config_entry.data.get(CONF_NAME))
 
     delete_folder(base_path, rc_name_slug)
     # It is possible that the path may not exist because of RCs not
     # being connected to Keymaster configurations
-    if os.path.exists(base_path):
-        if not os.listdir(base_path):
-            os.rmdir(base_path)
+    if base_path.exists():
+        if not any(base_path.iterdir()):
+            base_path.rmdir()
 
 
-def delete_folder(absolute_path: str, *relative_paths: str) -> None:
+def delete_folder(absolute_path: str | Path, *relative_paths: str) -> None:
     """Recursively delete folder and all children files and folders (depth first)."""
-    path = os.path.join(absolute_path, *relative_paths)
+    path = Path(absolute_path, *relative_paths)
 
     # RC that doesn't manage a lock has no files to purge
-    if not os.path.exists(path):
+    if not path.exists():
         return
 
-    if os.path.isfile(path):
-        os.remove(path)
+    if path.is_file():
+        path.unlink()
     else:
-        for file_or_dir in os.listdir(path):
-            delete_folder(path, file_or_dir)
-        os.rmdir(path)
+        for child in path.iterdir():
+            delete_folder(child)
+        path.rmdir()
 
 
 async def async_fire_clear_code(coordinator, slot: int) -> None:

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -16,15 +16,13 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
+from collections.abc import Sequence
 import hashlib
 import logging
 import os
 import re
 from typing import Any
-from typing import Coroutine
-from typing import Dict
-from typing import List
-from typing import Sequence
 import uuid
 
 from homeassistant.components.automation import DOMAIN as AUTO_DOMAIN
@@ -77,12 +75,12 @@ def check_gather_results(
 
 def add_call(
     hass: HomeAssistant,
-    coro: List[Coroutine],
+    coro: list[Coroutine],
     domain: str,
     service: str,
     target: str,
-    data: Dict[str, Any],
-) -> List[Coroutine]:
+    data: dict[str, Any],
+) -> list[Coroutine]:
     """Append a new async_call to the coro list."""
     coro.append(
         hass.services.async_call(
@@ -154,7 +152,7 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
     _LOGGER.debug("Slot: %s", slot)
 
     lockname: str = coordinator.lockname
-    coro: List[Coroutine] = []
+    coro: list[Coroutine] = []
 
     if not lockname:
         return
@@ -251,7 +249,7 @@ async def async_fire_update_times(coordinator, event) -> None:
     """Update times on slot."""
 
     lockname: str = coordinator.lockname
-    coro: List[Coroutine] = []
+    coro: list[Coroutine] = []
     slot_name: str = event.extra_state_attributes["slot_name"]
     slot = coordinator.event_overrides.get_slot_key_by_name(slot_name)
 
@@ -280,7 +278,7 @@ async def async_fire_update_times(coordinator, event) -> None:
     check_gather_results(results, "Lock slot operation")
 
 
-def get_event_names(rc) -> List[str]:
+def get_event_names(rc) -> list[str]:
     """Get the current event names."""
     event_names = [
         e.extra_state_attributes["slot_name"]

--- a/specs/002-code-health/tasks.md
+++ b/specs/002-code-health/tasks.md
@@ -181,7 +181,7 @@ typing import with no built-in replacement.)
 
 ### Implementation for User Story 5
 
-- [ ] T010 [US5] Replace legacy `typing` module imports (`Dict`,
+- [x] T010 [US5] Replace legacy `typing` module imports (`Dict`,
   `List`, `Optional`, `Union`, `Coroutine`) with built-in
   generic equivalents (`dict`, `list`, `X | None`, `X | Y`,
   `collections.abc.Coroutine`) in:

--- a/specs/002-code-health/tasks.md
+++ b/specs/002-code-health/tasks.md
@@ -194,7 +194,7 @@ typing import with no built-in replacement.)
   task touches all four files and must complete before the
   remaining US5 tasks.
   **FR**: FR-011
-- [ ] T011 [P] [US5] Remove the stale `# noqa: F401` suppression
+- [x] T011 [P] [US5] Remove the stale `# noqa: F401` suppression
   on the `Any` import in
   `custom_components/rental_control/util.py`. The import is
   actually used (`dict[str, Any]` after T010, `# type: Any`
@@ -202,47 +202,47 @@ typing import with no built-in replacement.)
   `# type: Any` comment on line 289 if it becomes redundant
   after T010 modernization. See code review §5.1.
   **FR**: FR-012
-- [ ] T012 [P] [US5] Remove the stale "temporary call" comment
+- [x] T012 [P] [US5] Remove the stale "temporary call" comment
   (line 356) in
   `custom_components/rental_control/coordinator.py`. See code
   review §5.2.
   **FR**: FR-013
-- [ ] T013 [US5] Remove all inert `# pylint: disable=` directive
+- [x] T013 [US5] Remove all inert `# pylint: disable=` directive
   comments across all source files in
   `custom_components/rental_control/`. The project uses ruff,
   not pylint — these directives have no effect. See code review
   §5.3.
   **FR**: FR-014
-- [ ] T014 [P] [US5] Remove the empty `CONFIG_SCHEMA` variable
+- [x] T014 [P] [US5] Remove the empty `CONFIG_SCHEMA` variable
   and the synchronous `setup()` function in
   `custom_components/rental_control/__init__.py`. The integration
   is config-flow only (declared in `manifest.json`), so these
   are unnecessary. See research.md R6.
   **FR**: FR-015
-- [ ] T015 [P] [US5] Remove the legacy
+- [x] T015 [P] [US5] Remove the legacy
   `@config_entries.HANDLERS.register(DOMAIN)` decorator from the
   config flow class in
   `custom_components/rental_control/config_flow.py`. The manifest
   `config_flow: true` key handles registration. See research.md
   R6.
   **FR**: FR-016
-- [ ] T016 [US5] Replace the `asyncio.gather` loop of individual
+- [x] T016 [US5] Replace the `asyncio.gather` loop of individual
   `async_forward_entry_unload()` calls with a single
   `hass.config_entries.async_unload_platforms(entry, PLATFORMS)`
   call in `custom_components/rental_control/__init__.py`. See
   research.md R6 for the correct API signature.
   **FR**: FR-017
-- [ ] T017 [US5] Convert all `os.path` calls to `pathlib.Path`
+- [x] T017 [US5] Convert all `os.path` calls to `pathlib.Path`
   operations in `custom_components/rental_control/util.py`. The
   test suite already uses `pathlib` via `tmp_path` fixtures. See
   research.md R7.
   **FR**: FR-018
-- [ ] T018 [P] [US5] Remove the commented-out function parameter
+- [x] T018 [P] [US5] Remove the commented-out function parameter
   (line 135) in
   `custom_components/rental_control/config_flow.py`. See code
   review §5.5.
   **FR**: FR-019
-- [ ] T019 [P] [US5] Fix the "EventOVerrides" docstring typo
+- [x] T019 [P] [US5] Fix the "EventOVerrides" docstring typo
   (capitalization error) in
   `custom_components/rental_control/event_overrides.py`. See
   code review §5.6.


### PR DESCRIPTION
## Summary

Phase 5 of Feature 002 (Code Health): code modernization and
cleanup tasks T010 through T019.

### Changes

- **T010**: Replace legacy `typing` imports with modern builtins
  and `collections.abc` equivalents across all source files
- **T011**: No-op — `# noqa: F401` already removed during T010;
  `# type: Any` comment intentionally kept (mypy needs it)
- **T012**: Remove stale "temporary call" comment in coordinator
- **T013**: Remove 3 inert `# pylint: disable=` directives
- **T014**: Remove empty `CONFIG_SCHEMA` and sync `setup()`
- **T015**: Replace `HANDLERS.register` decorator with `domain=`
  kwarg on ConfigFlow
- **T016**: Replace `asyncio.gather` unload loop with
  `async_unload_platforms()`
- **T017**: Migrate `os.path` to `pathlib.Path` in util.py
- **T018**: Remove commented-out `entry_id` parameter
- **T019**: Fix "EventOVerrides" docstring typo

### Testing

All 278 tests pass. No behavioral changes — purely structural
modernization.

**Feature**: 002-code-health
**Spec**: specs/002-code-health/