### PR TITLE
Refactor: Phase 6 constant max_misses (T020)

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -55,7 +55,6 @@ from .const import CONF_EVENT_PREFIX
 from .const import CONF_IGNORE_NON_RESERVED
 from .const import CONF_LOCK_ENTRY
 from .const import CONF_MAX_EVENTS
-from .const import CONF_MAX_MISSES
 from .const import CONF_REFRESH_FREQUENCY
 from .const import CONF_SHOULD_UPDATE_CODE
 from .const import CONF_START_SLOT
@@ -103,7 +102,7 @@ class RentalControlCoordinator:
         self.start_slot: int = int(str(config.get(CONF_START_SLOT)))
         self.lockname: str | None = config.get(CONF_LOCK_ENTRY)
         self.max_events: int = int(str(config.get(CONF_MAX_EVENTS)))
-        self.max_misses: int = int(str(config.get(CONF_MAX_MISSES, DEFAULT_MAX_MISSES)))
+        self.max_misses: int = DEFAULT_MAX_MISSES
         self.num_misses: int = 0
         self.days: int = int(str(config.get(CONF_DAYS)))
         self.ignore_non_reserved: bool = bool(config.get(CONF_IGNORE_NON_RESERVED))

--- a/specs/002-code-health/tasks.md
+++ b/specs/002-code-health/tasks.md
@@ -264,7 +264,7 @@ as an internal constant (not read from config entry data).
 
 ### Implementation for User Story 6
 
-- [ ] T020 [US6] Make `CONF_MAX_MISSES` a pure internal constant.
+- [x] T020 [US6] Make `CONF_MAX_MISSES` a pure internal constant.
   In `custom_components/rental_control/const.py`, ensure it is
   defined as a plain constant. In
   `custom_components/rental_control/coordinator.py`, remove any


### PR DESCRIPTION
## Summary

Phase 6 of Feature 002 (Code Health): configuration consistency
for the miss-tracking threshold.

### Changes

- **T020**: Replace `config.get(CONF_MAX_MISSES, DEFAULT_MAX_MISSES)`
  with a direct reference to `DEFAULT_MAX_MISSES` in the coordinator.
  The value was never exposed in the config flow UI, making the
  runtime config read unnecessary. Remove the unused
  `CONF_MAX_MISSES` import from coordinator.py.

### Testing

All 278 tests pass. No behavioral change — the default value was
always used since `max_misses` was never stored in config entry
data.

**Feature**: 002-code-health
**Spec**: specs/002-code-health/