### PR TITLE
Build(versioning): Derive version from git tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "homeassistant-rental-control"
-version = "0.0.0"
+dynamic = ["version"]
 description = "Home Assistant integration for managing rental properties with calendar and door code management"
 readme = "README.md"
 requires-python = ">=3.13.2"
@@ -45,8 +45,12 @@ Repository = "https://github.com/tykeal/homeassistant-rental-control"
 Issues = "https://github.com/tykeal/homeassistant-rental-control/issues"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "v(?P<version>.*)"
 
 [tool.hatch.build.targets.wheel]
 packages = ["custom_components"]

--- a/uv.lock
+++ b/uv.lock
@@ -1386,7 +1386,6 @@ wheels = [
 
 [[package]]
 name = "homeassistant-rental-control"
-version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "icalendar" },


### PR DESCRIPTION
## Summary

Replace the static `version = "0.0.0"` in `pyproject.toml` with dynamic versioning via `hatch-vcs`. The package version is now derived from git tags at build time, ensuring the built artifact always matches the release tag.

### Changes

- `pyproject.toml`: Replace `version` with `dynamic = ["version"]`, add `hatch-vcs` build dependency, add `[tool.hatch.version]` config
- `uv.lock`: Auto-updated (static version removed)

### Why

The release workflow's `python-build-action` validates that the package version matches the git tag. With a hardcoded `0.0.0`, this check always fails on tagged releases.
