### PR TITLE
Fix: slugify Keymaster lockname for entity IDs

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -43,6 +43,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt
+from homeassistant.util import slugify
 from icalendar import Calendar
 import x_wr_timezone
 
@@ -94,7 +95,10 @@ class RentalControlCoordinator(DataUpdateCoordinator[list[CalendarEvent]]):
         self.checkin: time = cv.time(config.get(CONF_CHECKIN))
         self.checkout: time = cv.time(config.get(CONF_CHECKOUT))
         self.start_slot: int = int(str(config.get(CONF_START_SLOT)))
-        self.lockname: str | None = config.get(CONF_LOCK_ENTRY)
+        lockname_raw = config.get(CONF_LOCK_ENTRY)
+        self.lockname: str | None = (
+            slugify(lockname_raw) if lockname_raw and lockname_raw.strip() else None
+        )
         self.max_events: int = int(str(config.get(CONF_MAX_EVENTS)))
         self.max_misses: int = DEFAULT_MAX_MISSES
         self.num_misses: int = 0
@@ -132,9 +136,7 @@ class RentalControlCoordinator(DataUpdateCoordinator[list[CalendarEvent]]):
 
         entity_registry = er.async_get(hass)
         if self.lockname:
-            reset_entity = (
-                f"{BUTTON}.{self.lockname.lower()}_code_slot_{self.start_slot}_reset"
-            )
+            reset_entity = f"{BUTTON}.{self.lockname}_code_slot_{self.start_slot}_reset"
             has_reset = entity_registry.async_get(reset_entity)
             if has_reset is None:
                 error_msg = """
@@ -376,8 +378,28 @@ Please update Keymaster to at least v0.1.0-b0
         # just use cv.time to get the parsed time object
         self.checkin = cv.time(config[CONF_CHECKIN])
         self.checkout = cv.time(config[CONF_CHECKOUT])
-        self.lockname = config.get(CONF_LOCK_ENTRY)
-        self.max_events = config[CONF_MAX_EVENTS]
+        lockname_raw = config.get(CONF_LOCK_ENTRY)
+        previous_lockname = self.lockname
+        previous_max_events = self.max_events
+        previous_start_slot = self.start_slot
+        self.lockname = (
+            slugify(lockname_raw) if lockname_raw and lockname_raw.strip() else None
+        )
+        self.max_events = int(str(config.get(CONF_MAX_EVENTS)))
+        self.start_slot = int(str(config.get(CONF_START_SLOT)))
+        # Keep event_overrides in sync with config changes
+        if self.lockname:
+            overrides_stale = (
+                self.event_overrides is None
+                or self.lockname != previous_lockname
+                or self.max_events != previous_max_events
+                or self.start_slot != previous_start_slot
+            )
+            if overrides_stale:
+                self.event_overrides = EventOverrides(self.start_slot, self.max_events)
+                await self.async_setup_keymaster_overrides()
+        else:
+            self.event_overrides = None
         self.days = config[CONF_DAYS]
         self.code_generator = config.get(CONF_CODE_GENERATION, DEFAULT_CODE_GENERATION)
         self.should_update_code = bool(config.get(CONF_SHOULD_UPDATE_CODE))

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -379,6 +379,9 @@ async def handle_state_change(
     coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
     lockname = coordinator.lockname
 
+    if not lockname or not coordinator.event_overrides:
+        return
+
     # we can get state changed storms when a slot (or multiple slots) clear and
     # a new code is set, put in a small sleep to let things settle
     await asyncio.sleep(0.1)

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -20,6 +20,8 @@ from homeassistant.util import dt
 import homeassistant.util.dt as dt_util
 import pytest
 
+from custom_components.rental_control.const import CONF_LOCK_ENTRY
+from custom_components.rental_control.const import CONF_MAX_EVENTS
 from custom_components.rental_control.const import CONF_REFRESH_FREQUENCY
 from custom_components.rental_control.const import DEFAULT_REFRESH_FREQUENCY
 from custom_components.rental_control.coordinator import RentalControlCoordinator
@@ -853,3 +855,269 @@ class TestSlotBootstrapping:
         call_args = mock_update.call_args[0]
         assert call_args[1] == ""
         assert call_args[2] == ""
+
+
+# ---------------------------------------------------------------------------
+# Lockname slugification tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocknameSlugification:
+    """Verify lockname is slugified when assigned to coordinator."""
+
+    async def test_init_slugifies_lockname_with_spaces(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify lockname with spaces is slugified during init."""
+        mock_config_entry.add_to_hass(hass)
+
+        data = dict(mock_config_entry.data)
+        data[CONF_LOCK_ENTRY] = "Front Door"
+        hass.config_entries.async_update_entry(mock_config_entry, data=data)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+
+        assert coordinator.lockname == "front_door"
+
+    async def test_init_slugifies_lockname_with_mixed_case(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify mixed-case lockname is lowered and slugified."""
+        mock_config_entry.add_to_hass(hass)
+
+        data = dict(mock_config_entry.data)
+        data[CONF_LOCK_ENTRY] = "Dining Room Lock"
+        hass.config_entries.async_update_entry(mock_config_entry, data=data)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+
+        assert coordinator.lockname == "dining_room_lock"
+
+    async def test_init_preserves_none_lockname(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify None lockname stays None after init."""
+        mock_config_entry.add_to_hass(hass)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+
+        assert coordinator.lockname is None
+
+    async def test_init_treats_whitespace_lockname_as_none(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify whitespace-only lockname becomes None."""
+        data = dict(mock_config_entry.data)
+        data[CONF_LOCK_ENTRY] = "   "
+        mock_config_entry.add_to_hass(hass)
+        hass.config_entries.async_update_entry(mock_config_entry, data=data)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+
+        assert coordinator.lockname is None
+
+    async def test_init_preserves_already_slugified_lockname(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify pre-slugified lockname passes through unchanged."""
+        mock_config_entry.add_to_hass(hass)
+
+        data = dict(mock_config_entry.data)
+        data[CONF_LOCK_ENTRY] = "front_door"
+        hass.config_entries.async_update_entry(mock_config_entry, data=data)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+
+        assert coordinator.lockname == "front_door"
+
+    async def test_update_config_slugifies_lockname(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify lockname is slugified during options update."""
+        mock_config_entry.add_to_hass(hass)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+        assert coordinator.lockname is None
+
+        config = dict(mock_config_entry.data)
+        config.update(mock_config_entry.options)
+        config[CONF_LOCK_ENTRY] = "Back Patio Door"
+
+        with patch.object(
+            coordinator,
+            "async_request_refresh",
+            new_callable=AsyncMock,
+        ):
+            await coordinator.update_config(config)
+
+        assert coordinator.lockname == "back_patio_door"
+
+    async def test_update_config_creates_event_overrides_when_lock_added(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify event_overrides is created when lockname is set."""
+        mock_config_entry.add_to_hass(hass)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+        assert coordinator.lockname is None
+        assert coordinator.event_overrides is None
+
+        config = dict(mock_config_entry.data)
+        config.update(mock_config_entry.options)
+        config[CONF_LOCK_ENTRY] = "Front Door"
+
+        with (
+            patch.object(
+                coordinator,
+                "async_request_refresh",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                coordinator,
+                "async_setup_keymaster_overrides",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await coordinator.update_config(config)
+
+        assert coordinator.event_overrides is not None
+
+    async def test_update_config_clears_event_overrides_when_lock_removed(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify event_overrides is cleared when lockname removed."""
+        mock_config_entry.add_to_hass(hass)
+
+        data = dict(mock_config_entry.data)
+        data[CONF_LOCK_ENTRY] = "Front Door"
+        hass.config_entries.async_update_entry(mock_config_entry, data=data)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+        assert coordinator.lockname == "front_door"
+        assert coordinator.event_overrides is not None
+
+        config = dict(mock_config_entry.data)
+        config.update(mock_config_entry.options)
+        config.pop(CONF_LOCK_ENTRY, None)
+
+        with patch.object(
+            coordinator,
+            "async_request_refresh",
+            new_callable=AsyncMock,
+        ):
+            await coordinator.update_config(config)
+
+        assert coordinator.lockname is None
+        assert coordinator.event_overrides is None
+
+    async def test_update_config_recreates_overrides_on_max_events_change(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify event_overrides is recreated when max_events changes."""
+        data = dict(mock_config_entry.data)
+        data[CONF_LOCK_ENTRY] = "Front Door"
+        mock_config_entry.add_to_hass(hass)
+        hass.config_entries.async_update_entry(mock_config_entry, data=data)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+        assert coordinator.event_overrides is not None
+        original_overrides = coordinator.event_overrides
+
+        config = dict(mock_config_entry.data)
+        config.update(mock_config_entry.options)
+        config[CONF_MAX_EVENTS] = coordinator.max_events + 1
+
+        with (
+            patch.object(
+                coordinator,
+                "async_request_refresh",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                coordinator,
+                "async_setup_keymaster_overrides",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await coordinator.update_config(config)
+
+        assert coordinator.event_overrides is not original_overrides
+
+    async def test_update_config_bootstraps_overrides_after_recreation(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify overrides are bootstrapped from HA state after recreation."""
+        mock_config_entry.add_to_hass(hass)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+
+        config = dict(mock_config_entry.data)
+        config.update(mock_config_entry.options)
+        config[CONF_LOCK_ENTRY] = "Front Door"
+
+        with (
+            patch.object(
+                coordinator,
+                "async_request_refresh",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                coordinator,
+                "async_setup_keymaster_overrides",
+                new_callable=AsyncMock,
+            ) as mock_bootstrap,
+        ):
+            await coordinator.update_config(config)
+
+        mock_bootstrap.assert_called_once()
+
+    async def test_bootstrap_uses_slugified_lockname_for_entity_ids(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify entity ID lookups use slugified lockname."""
+        mock_config_entry.add_to_hass(hass)
+
+        data = dict(mock_config_entry.data)
+        data[CONF_LOCK_ENTRY] = "Front Door"
+        hass.config_entries.async_update_entry(mock_config_entry, data=data)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+        mock_overrides = MagicMock()
+        mock_overrides.ready = False
+        mock_overrides.async_check_overrides = AsyncMock()
+        coordinator.event_overrides = mock_overrides
+        mock_update = AsyncMock()
+        object.__setattr__(coordinator, "update_event_overrides", mock_update)
+
+        # Set states using slugified name (what HA would actually have)
+        hass.states.async_set("text.front_door_code_slot_10_pin", "1234")
+        hass.states.async_set("text.front_door_code_slot_10_name", "Guest")
+
+        await coordinator.async_setup_keymaster_overrides()
+
+        mock_update.assert_awaited_once()
+        call_args = mock_update.call_args[0]
+        assert call_args[1] == "1234"
+        assert call_args[2] == "Guest"

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1233,3 +1233,169 @@ class TestAsyncFireUpdateTimes:
             await async_fire_update_times(coordinator, self._make_event())
 
         assert "Lock slot operation" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Slugified lockname entity ID construction tests
+# ---------------------------------------------------------------------------
+
+
+class TestSlugifiedLocknameEntityIds:
+    """Verify entity IDs use slugified locknames throughout util."""
+
+    async def test_set_code_constructs_slugified_entity_ids(
+        self,
+    ) -> None:
+        """Verify async_fire_set_code builds correct entity IDs.
+
+        When the coordinator lockname has already been slugified from
+        a friendly name like 'Front Door' to 'front_door', all entity
+        IDs in service calls must use the slugified form.
+        """
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.hass.services.async_call = AsyncMock()
+
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": "Guest",
+            "slot_code": "1234",
+            "start": "2025-01-15T16:00:00",
+            "end": "2025-01-17T11:00:00",
+        }
+
+        await async_fire_set_code(coordinator, event, 10)
+
+        calls = coordinator.hass.services.async_call.await_args_list
+        entity_ids = []
+        for call in calls:
+            target = call.kwargs.get("target", {})
+            eid = target.get("entity_id", "")
+            if eid:
+                entity_ids.append(eid)
+
+        assert entity_ids, "Expected at least one service call with entity_id"
+        for eid in entity_ids:
+            assert "front_door" in eid
+            assert " " not in eid
+
+    async def test_clear_code_constructs_slugified_entity_id(
+        self,
+    ) -> None:
+        """Verify async_fire_clear_code uses slugified lockname."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        await async_fire_clear_code(coordinator, 10)
+
+        call = coordinator.hass.services.async_call.await_args
+        entity_id = call.kwargs["target"]["entity_id"]
+        assert entity_id == "button.front_door_code_slot_10_reset"
+        assert " " not in entity_id
+
+    async def test_state_change_matches_slugified_entity_ids(
+        self,
+    ) -> None:
+        """Verify handle_state_change finds states with slugified IDs.
+
+        Simulates a lock originally named 'Front Door' that has been
+        slugified to 'front_door' by the coordinator. The entity IDs
+        in Home Assistant use the slugified form, and the state change
+        handler must look up those same IDs.
+        """
+        lockname = "front_door"
+        slot_num = 10
+
+        mock_slot_code = MagicMock()
+        mock_slot_code.state = "5678"
+        mock_slot_name = MagicMock()
+        mock_slot_name.state = "Visitor"
+        mock_slot_enabled = MagicMock()
+        mock_slot_enabled.state = "on"
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = lockname
+        mock_coordinator.event_overrides = MagicMock()
+        mock_coordinator.event_overrides.async_check_overrides = AsyncMock()
+        mock_coordinator.update_event_overrides = AsyncMock()
+
+        def states_get(entity_id: str) -> MagicMock | None:
+            """Return mock states keyed by slugified entity IDs."""
+            assert " " not in entity_id, f"Entity ID contains spaces: {entity_id}"
+            if "enabled" in entity_id:
+                return mock_slot_enabled
+            if "pin" in entity_id:
+                return mock_slot_code
+            if "name" in entity_id:
+                return mock_slot_name
+            if "use_date_range" in entity_id:
+                return None
+            return None
+
+        hass = MagicMock()
+        hass.data = {
+            DOMAIN: {
+                "entry_id": {COORDINATOR: mock_coordinator},
+            }
+        }
+        hass.states.get = states_get
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock(spec=Event)
+        event.data = {"entity_id": (f"switch.{lockname}_code_slot_{slot_num}_enabled")}
+
+        with patch(
+            "custom_components.rental_control.util.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await handle_state_change(hass, config_entry, event)
+
+        mock_coordinator.update_event_overrides.assert_awaited_once()
+        call_args = mock_coordinator.update_event_overrides.call_args[0]
+        assert call_args[1] == "5678"
+        assert call_args[2] == "Visitor"
+
+    async def test_state_change_returns_early_when_no_lockname(
+        self,
+    ) -> None:
+        """Verify handle_state_change exits early when lockname is None."""
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = None
+        mock_coordinator.event_overrides = MagicMock()
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_id": {COORDINATOR: mock_coordinator}}}
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock(spec=Event)
+        event.data = {"entity_id": "switch.test_code_slot_1_enabled"}
+
+        await handle_state_change(hass, config_entry, event)
+
+        mock_coordinator.event_overrides.update.assert_not_called()
+
+    async def test_state_change_returns_early_when_no_event_overrides(
+        self,
+    ) -> None:
+        """Verify handle_state_change exits early when event_overrides is None."""
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = "front_door"
+        mock_coordinator.event_overrides = None
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_id": {COORDINATOR: mock_coordinator}}}
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock(spec=Event)
+        event.data = {"entity_id": "switch.front_door_code_slot_1_enabled"}
+
+        await handle_state_change(hass, config_entry, event)


### PR DESCRIPTION
## Problem

Keymaster stores lock names as friendly names that may contain spaces and
capitals (e.g. "Front Door"). The coordinator used this raw value to
construct Home Assistant entity IDs, producing invalid IDs like
`text.Front Door_code_slot_1_pin` instead of `text.front_door_code_slot_1_pin`.

This caused all Keymaster entity lookups, state tracking, and service calls
from Rental Control to silently fail for locks with non-slug-safe names.
Door codes would not be set or cleared.

## Fix

Apply `slugify()` at both coordinator lockname assignment points
(`__init__` and `update_config`) so `self.lockname` is always normalized.
Remove the redundant `.lower()` that was inconsistently applied at only
one of 30+ usage sites.

Additionally, `update_config()` now keeps `event_overrides` in sync with
configuration changes. When the lockname, `max_events`, or `start_slot`
changes via the options flow, the `EventOverrides` instance is recreated
and bootstrapped from current HA state. When the lock is removed,
`event_overrides` is cleared. The `start_slot` and `max_events` fields
are also coerced to `int` consistently with `__init__`.

## Tests

14 new tests covering:
- Coordinator init slugifies lockname with spaces
- Coordinator init slugifies mixed-case lockname
- Coordinator init treats whitespace-only lockname as None
- Coordinator init preserves None lockname
- Coordinator init is idempotent on pre-slugified names
- Options update path slugifies lockname
- Event overrides created when lock added via options
- Event overrides cleared when lock removed via options
- Event overrides recreated on max_events change
- Event overrides bootstrapped after recreation
- Entity ID construction uses slugified lockname for slot bootstrap
- `async_fire_set_code` entity ID verification
- `async_fire_clear_code` entity ID verification
- `handle_state_change` entity ID verification
