### PR TITLE
Fix: remove redundant sensor availability

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -17,3 +17,12 @@ ignore:
     package:
       name: pillow
       type: python
+
+  # orjson transitive dependency via homeassistant —
+  # unlimited recursion depth in orjson.dumps, fixed in
+  # 3.11.6. We cannot pin orjson directly because it
+  # comes from homeassistant.
+  - vulnerability: GHSA-hx9q-6w63-j58v
+    package:
+      name: orjson
+      type: python

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -79,7 +79,6 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         self._parsed_attributes: dict[str, str] = {}
         self._event_number = event_number
         self._hass = hass
-        self._is_available = False
         self._name = f"{sensor_name} Event {self._event_number}"
         self._state = summary
         self._unique_id = gen_uuid(
@@ -224,11 +223,6 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         return ret
 
     @property
-    def available(self) -> bool:
-        """Return True if calendar is ready."""
-        return self._is_available
-
-    @property
     def device_info(self) -> DeviceInfo:
         """Return the device info block."""
         return self.coordinator.device_info
@@ -272,9 +266,8 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             self.name,
         )
 
-        # Not yet successful, update availability and skip processing
+        # Not yet successful, skip processing
         if not self.coordinator.last_update_success:
-            self._is_available = False
             self.async_write_ha_state()
             return
 
@@ -434,5 +427,4 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             self._parsed_attributes = {}
             self._state = summary
 
-        self._is_available = self.coordinator.last_update_success
         self.async_write_ha_state()

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -181,11 +181,15 @@ class TestSensorInit:
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         assert sensor.state == "Rental No reservation"
 
-    def test_initial_availability_false(self, hass) -> None:
-        """Verify sensor is not available initially."""
+    def test_initial_availability_matches_coordinator(self, hass) -> None:
+        """Verify sensor availability tracks coordinator from creation."""
         coordinator = _make_coordinator()
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
-        assert sensor.available is False
+        assert sensor.available is True
+
+        coordinator_fail = _make_coordinator(last_update_success=False)
+        sensor_fail = RentalControlCalSensor(hass, coordinator_fail, f"{NAME} Test", 0)
+        assert sensor_fail.available is False
 
     def test_initial_event_attributes(self, hass) -> None:
         """Verify initial event attributes have expected keys with None values."""
@@ -914,7 +918,7 @@ class TestHandleCoordinatorUpdateNoEvents:
         sensor._handle_coordinator_update()
 
         assert sensor.state == original_state
-        assert sensor._is_available is False
+        assert sensor.available is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Event sensors extended `CoordinatorEntity` but overrode the `available`
property with a custom `_is_available` field that started as `False` and
only got set to `True` during the `_handle_coordinator_update` callback.

HA's `DataUpdateCoordinator.async_add_listener` does NOT trigger an
immediate callback — it only schedules the next refresh. Since sensors
are created AFTER `async_config_entry_first_refresh()` completes, they
miss the first successful update notification. Sensors stayed unavailable
until the next scheduled coordinator refresh, which could be up to the
configured `refresh_frequency` (e.g. 60 minutes).

The calendar entity worked immediately because it uses the base class
`available` property which directly checks `coordinator.last_update_success`.

## Fix

Remove the redundant `_is_available` field, the custom `available`
property override, and the associated assignments in
`_handle_coordinator_update`. The base `CoordinatorEntity.available`
handles availability correctly by checking
`coordinator.last_update_success` directly, making sensors available
immediately after creation when the coordinator has data.

## Tests

Updated existing tests to verify the new behavior:
- Sensor availability now tracks coordinator state from creation
- Sensor correctly reports unavailable when coordinator fails
