### PR TITLE
Fix: process coordinator data on sensor init

### DIFF
--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -85,6 +85,16 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             f"{self.coordinator.unique_id} sensor {self._event_number}"
         )
 
+    async def async_added_to_hass(self) -> None:
+        """Register listener and process existing coordinator data."""
+        await super().async_added_to_hass()
+        # The first coordinator refresh completes before sensors are
+        # created, so the listener registered above will not fire until
+        # the next scheduled refresh.  Process the data that is already
+        # available so the sensor shows current events immediately.
+        if self.coordinator.last_update_success and self.coordinator.data is not None:
+            self._handle_coordinator_update()
+
     def _extract_email(self) -> str | None:
         """Extract guest email from a description"""
         if self._event_attributes["description"] is None:

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -207,6 +207,48 @@ class TestSensorInit:
         assert attrs["slot_name"] is None
         assert attrs["slot_code"] is None
 
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    async def test_async_added_to_hass_processes_existing_data(self, hass) -> None:
+        """Verify sensor processes coordinator data on registration."""
+        event = _make_event()
+        coordinator = _make_coordinator(data=[event], last_update_success=True)
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+        sensor.async_on_remove = MagicMock()
+        coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+
+        await sensor.async_added_to_hass()
+
+        assert "Reserved - John Doe" in sensor.state
+
+    async def test_async_added_to_hass_skips_when_no_data(self, hass) -> None:
+        """Verify sensor skips processing when coordinator has no data."""
+        coordinator = _make_coordinator(data=None, last_update_success=True)
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+        sensor.async_on_remove = MagicMock()
+        coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+
+        await sensor.async_added_to_hass()
+
+        assert sensor.state == "No reservation"
+
+    async def test_async_added_to_hass_skips_when_not_successful(self, hass) -> None:
+        """Verify sensor skips processing when coordinator failed."""
+        event = _make_event()
+        coordinator = _make_coordinator(data=[event], last_update_success=False)
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+        sensor.async_on_remove = MagicMock()
+        coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+
+        await sensor.async_added_to_hass()
+
+        assert sensor.state == "No reservation"
+
 
 class TestSensorProperties:
     """Tests for RentalControlCalSensor property accessors."""


### PR DESCRIPTION
## Problem

The first coordinator refresh completes before sensors are created
(`async_config_entry_first_refresh` runs in `__init__.py` before
`async_forward_entry_setups`). When sensors register as listeners via
`async_added_to_hass`, HA's `async_add_listener` does NOT trigger an
immediate callback — it only schedules the next refresh.

This meant sensors showed "No reservation" with stale default state
until the next scheduled coordinator refresh (up to `refresh_frequency`
minutes, e.g. 60 minutes), even though the coordinator already had
valid event data.

## Fix

Override `async_added_to_hass` to call `_handle_coordinator_update()`
after listener registration when the coordinator has data
(`last_update_success` is True and `data` is not None). This ensures
sensors process existing event data immediately.

## Tests

3 new tests:
- Sensor processes existing coordinator data on registration
- Sensor skips processing when coordinator has no data
- Sensor skips processing when coordinator update failed
