### PR TITLE
Fix(overrides): clear slots beyond max_events

### DIFF
--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -156,7 +156,10 @@ class EventOverrides:
             return
 
         _LOGGER.debug(self._overrides)
-        event_names = get_event_names(coordinator, calendar=cal)
+        # Only consider events within the sensor boundary so that
+        # slots tied to events beyond max_events get cleared.
+        sensor_cal = cal[: coordinator.max_events]
+        event_names = get_event_names(coordinator, calendar=sensor_cal)
         _LOGGER.debug("event_names = %s", event_names)
 
         assigned_slots = self.__get_slots_with_values()

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -791,3 +791,58 @@ class TestEdgeCases:
         ):
             await eo.async_check_overrides(coordinator)
             mock_fire.assert_not_called()
+
+    async def test_clears_slot_beyond_max_events_boundary(self) -> None:
+        """Verify slot is cleared when its event is beyond max_events.
+
+        When the calendar has more events than max_events, only the
+        first max_events events are managed by sensors. A slot tied
+        to an event beyond that boundary should be cleared even though
+        the event name still exists in the full calendar.
+        """
+        eo = EventOverrides(start_slot=1, max_slots=2)
+        today = _make_dt(2025, 7, 1)
+
+        # Slot 1: assigned to "Current Guest" (will be within boundary)
+        eo.update(
+            1,
+            "1234",
+            "Current Guest",
+            _make_dt(2025, 7, 5),
+            _make_dt(2025, 7, 10),
+        )
+        # Slot 2: assigned to "Old Guest" (will be beyond boundary)
+        eo.update(
+            2,
+            "5678",
+            "Old Guest",
+            _make_dt(2025, 7, 12),
+            _make_dt(2025, 7, 18),
+        )
+
+        # Calendar: 3 events, but max_events=2 so sensors only see
+        # the first 2. "Old Guest" is at index 2 (beyond sensors).
+        events = [
+            _make_event(_make_dt(2025, 7, 10), "Current Guest"),
+            _make_event(_make_dt(2025, 7, 20), "New Guest"),
+            _make_event(_make_dt(2025, 7, 25), "Old Guest"),
+        ]
+        coordinator = _make_coordinator(
+            calendar_events=events,
+            max_events=2,
+        )
+
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new_callable=AsyncMock,
+            ) as mock_fire,
+            patch.object(dt_util, "start_of_local_day", return_value=today),
+        ):
+            await eo.async_check_overrides(coordinator)
+            # "Old Guest" at index 2 is beyond max_events=2, clear it
+            mock_fire.assert_called_once_with(coordinator, 2)
+            assert eo.overrides[2] is None
+            # "Current Guest" at index 0 stays
+            assert eo.overrides[1] is not None
+            assert eo.overrides[1]["slot_name"] == "Current Guest"


### PR DESCRIPTION
## Problem

`async_check_overrides` compared slot names against the **full** calendar event list, which can exceed `max_events`. Sensors only process the first `max_events` events, so when an event gets pushed beyond that boundary (e.g., position 6 in a 5-sensor setup), its slot was never identified as orphaned and never cleared. This prevented new events from being assigned to a slot.

## Root Cause

`get_event_names(coordinator, calendar=cal)` was called with the untruncated calendar. Events at positions beyond `max_events` still had their names in the event list, causing the slot-name check (`slot_name not in event_names`) to pass—keeping the orphaned slot allocated.

## Fix

Truncate the calendar to `max_events` before building the event names list:

```python
sensor_cal = cal[:coordinator.max_events]
event_names = get_event_names(coordinator, calendar=sensor_cal)
```

Python's slice safely handles empty lists and lists shorter than `max_events`.

## Testing

- Added `test_clears_slot_beyond_max_events_boundary`: verifies that a slot assigned to an event beyond position `max_events` is cleared when checked
- All 324 tests pass
- Linting clean