### PR TITLE
Fix(coordinator): populate CalendarEvent.uid

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -35,3 +35,19 @@ ignore:
     package:
       name: PyJWT
       type: python
+
+  # pyOpenSSL transitive dependency via homeassistant —
+  # use-after-free on connection shutdown
+  # (GHSA-5pwr-322w-8jr4) and low-severity issue
+  # (GHSA-vp96-hxj8-p424), fixed in 26.0.0. We cannot
+  # pin pyOpenSSL directly because it comes from
+  # homeassistant.
+  - vulnerability: GHSA-5pwr-322w-8jr4
+    package:
+      name: pyOpenSSL
+      type: python
+
+  - vulnerability: GHSA-vp96-hxj8-p424
+    package:
+      name: pyOpenSSL
+      type: python

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -603,12 +603,14 @@ Please update Keymaster to at least v0.1.0-b0
         )
         description = event.get("DESCRIPTION")
 
+        raw_uid = event.get("UID")
         cal_event = CalendarEvent(
             description=description,
             end=end.astimezone(self.timezone),
             location=event.get("LOCATION"),
             summary=event.get("SUMMARY", "Unknown"),
             start=start.astimezone(self.timezone),
+            uid=str(raw_uid) if raw_uid is not None else None,
         )
 
         _LOGGER.debug("Event to add: %s", cal_event)

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -130,6 +130,63 @@ END:VCALENDAR
 
         assert len(result) > 0
         assert result[0].summary == "Reserved: Test Guest"
+        assert result[0].uid == "test-event@example.com"
+
+
+async def test_coordinator_populates_uid_from_ical(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test that CalendarEvent.uid is populated from the iCal UID.
+
+    Verifies that events with a UID property have it passed through
+    to the CalendarEvent, and events missing a UID default to None.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+
+    future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+    future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+    future_start2 = (frozen_time + timedelta(days=15)).strftime("%Y%m%d")
+    future_end2 = (frozen_time + timedelta(days=20)).strftime("%Y%m%d")
+
+    ics_data = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test Calendar//EN
+BEGIN:VEVENT
+DTSTART:{future_start}T140000Z
+DTEND:{future_end}T110000Z
+UID:stable-id-123@booking.example
+SUMMARY:Reserved: Guest With UID
+STATUS:CONFIRMED
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:{future_start2}T140000Z
+DTEND:{future_end2}T110000Z
+SUMMARY:Reserved: Guest No UID
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(dt_util, "now", return_value=frozen_time),
+        patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+    ):
+        mock_session.get(
+            "https://example.com/calendar.ics",
+            status=200,
+            body=ics_data,
+        )
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+
+        result = await coordinator._async_update_data()
+
+        assert len(result) == 2
+        assert result[0].uid == "stable-id-123@booking.example"
+        assert result[1].uid is None
 
 
 async def test_coordinator_refresh_network_error(


### PR DESCRIPTION
## Summary

Populates `CalendarEvent.uid` from the iCal source `UID` property so downstream integrations have stable event identifiers that persist across calendar refreshes — even when event times change.

Closes #409

## Changes

- **`coordinator.py`**: Added `uid=str(raw_uid) if raw_uid is not None else None` to the `CalendarEvent` constructor in `_ical_event()`. Events with a UID get the string value; events missing UID get `None` (preserving `CalendarEvent` dataclass semantics).
- **`test_coordinator.py`**: Added UID assertion to existing success test; added dedicated test verifying UID is populated when present and defaults to `None` when absent.
- **`.grype.yaml`**: Added pyOpenSSL GHSA ignores (transitive dependency via homeassistant).

## Context

Home Assistant's `CalendarEvent` dataclass has an optional `uid` field (`str | None = None`) that calendar integrations can populate. The underlying icalendar parser preserves the RFC 5545 `UID` property. This is a non-breaking change — the field was already optional and defaulted to `None`.

## Testing

- 325 tests pass
- Linting clean