### PR TITLE
CI: Update to release-drafter v7.1.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -102,9 +102,9 @@ version-resolver:
   default: patch
 # yamllint disable rule:line-length
 template: |
-  [![Downloads for this release](https://img.shields.io/github/downloads/tykeal/homeassistant-rental-control/v$RESOLVED_VERSION/total.svg)](https://github.com/tykeal/homeassistant-rental-control/releases/v$RESOLVED_VERSION)
+  [![Downloads for this release](https://img.shields.io/github/downloads/$OWNER/$REPOSITORY/v$RESOLVED_VERSION/total.svg)](https://github.com/$OWNER/$REPOSITORY/releases/v$RESOLVED_VERSION)
 
   $CHANGES
 
   ## Links
-  - [Submit bugs/feature requests](https://github.com/tykeal/homeassistant-rental-control/issues)
+  - [Submit bugs/feature requests](https://github.com/$OWNER/$REPOSITORY/issues)

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -1,0 +1,53 @@
+---
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Autolabeler'
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions: {}
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: ${{ format('al-{0}-pr-{1}', github.event_name, github.event.pull_request.number) }}
+  cancel-in-progress: true
+
+jobs:
+  autolabel:
+    name: 'Autolabel PR'
+    # Run on pull_request_target for forks, pull_request for
+    # same-repo PRs to prevent duplicate runs
+    # yamllint disable rule:line-length
+    if: >
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork) ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
+    # yamllint enable rule:line-length
+    # SECURITY: pull_request_target with write permissions is safe
+    # here because the autolabeler action does NOT checkout any code
+    # from the PR — it only reads the PR title/body via GitHub API.
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 3
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: 'audit'
+
+      # yamllint disable-line rule:line-length
+      - uses: release-drafter/release-drafter/autolabeler@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2021 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
 # SPDX-License-Identifier: Apache-2.0
 
 name: 'Release Drafter'
@@ -9,47 +9,19 @@ on:
   push:
     branches:
       - main
-  # pull_request is required for autolabeler
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-  # pull_request_target is required for autolabeler on PRs from forks
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
 
 permissions: {}
 
 concurrency:
-  # yamllint disable-line rule:line-length
-  group: ${{ github.event.pull_request.number && format('rd-{0}-pr-{1}', github.event_name, github.event.pull_request.number) || format('rd-push-{0}', github.ref) }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   update_release_draft:
     name: 'Update Release Draft'
-    # Run on pull_request_target for forks, or pull_request for same-repo PRs
-    # This prevents duplicate runs for same-repo PRs
-    # yamllint disable rule:line-length
-    if: >
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork) ||
-      (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
-      github.event_name == 'push'
-    # yamllint enable rule:line-length
-    # SECURITY: pull_request_target with write permissions is safe here because:
-    # 1. This workflow does NOT checkout any code from the PR
-    # 2. The workflow code itself runs from the base branch (not the fork)
-    # 3. release-drafter only makes GitHub API calls (no code execution)
-    # 4. pull_request_target is needed ONLY for autolabeling fork PRs
     permissions:
-      # write permission is required to create releases
       contents: write
-      # write permission is required for autolabeler
-      pull-requests: write
+      pull-requests: read
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
@@ -59,21 +31,5 @@ jobs:
         with:
           egress-policy: 'audit'
 
-      - name: 'Show concurrency group'
-        shell: bash
-        # yamllint disable rule:line-length
-        run: |
-          # Show concurrency group
-          GROUP="${{ github.event.pull_request.number && format('rd-{0}-pr-{1}', github.event_name, github.event.pull_request.number) || format('rd-push-{0}', github.ref) }}"
-          {
-            echo '## Release Drafter'
-            echo "Concurrency group: ${GROUP}"
-          } >> "$GITHUB_STEP_SUMMARY"
-          echo "Concurrency group: ${GROUP}"
-        # yamllint enable rule:line-length
-
-      - name: 'Update draft release'
-        # yamllint disable-line rule:line-length
-        uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      # yamllint disable-line rule:line-length
+      - uses: release-drafter/release-drafter@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0


### PR DESCRIPTION
Release Drafter v7.0.0 broke the autolabeler out of the base workflow.
Therefore, we need to add a separate one to handle this as they need
different permissions and triggers.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
