### PR TITLE
Docs(specs): add checkin tracking plan

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -19,6 +19,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-12
 - Storage: N/A — Home Assistant config entries (002-code-health)
 - Python ≥3.13.2 + Home Assistant ≥ 2025.8.0, icalendar ≥6.1.0, x-wr-timezone ≥2.0.0 (003-coordinator-migration)
 - N/A (all state in-memory, config via HA config entries) (003-coordinator-migration)
+- Python ≥3.13.2 (per pyproject.toml `requires-python = ">=3.13.2"`) + homeassistant ≥ 2025.8.0, icalendar ≥ 6.1.0, x-wr-timezone ≥ 2.0.0 (004-checkin-tracking)
+- Home Assistant RestoreEntity state persistence (built-in HA mechanism) (004-checkin-tracking)
 
 ## Project Structure
 
@@ -37,6 +39,7 @@ uv run ruff check custom_components/ tests/
 Python ≥3.13.2: Follow standard conventions, ruff formatting
 
 ## Recent Changes
+- 004-checkin-tracking: Added Python ≥3.13.2 (per pyproject.toml `requires-python = ">=3.13.2"`) + homeassistant ≥ 2025.8.0, icalendar ≥ 6.1.0, x-wr-timezone ≥ 2.0.0
 - 003-coordinator-migration: Added Python ≥3.13.2 + Home Assistant ≥ 2025.8.0, icalendar ≥6.1.0, x-wr-timezone ≥2.0.0
 - 002-code-health: Added Python ≥3.13.2 + icalendar ≥6.1.0, x-wr-timezone ≥2.0.0
 

--- a/specs/004-checkin-tracking/contracts/checkout-service.md
+++ b/specs/004-checkin-tracking/contracts/checkout-service.md
@@ -1,0 +1,62 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# HA Service Schema: checkout
+
+**Feature Branch**: `004-checkin-tracking`
+**Date**: 2025-07-15
+
+## Service Definition
+
+**Domain**: `rental_control`
+**Service name**: `checkout`
+**Registered via**: `async_register_entity_service()` in `sensor.py`
+
+## Schema
+
+```yaml
+# No input parameters — the service targets the entity directly via entity_id
+service: rental_control.checkout
+target:
+  entity_id: sensor.rental_control_{calendar_name}_checkin
+```
+
+## Guard Conditions (FR-019)
+
+The service handler validates the following before executing:
+
+1. **State check**: Sensor must be in `checked_in` state
+   - Error: `"Checkout is only available when the guest is checked in (current state: {state})"`
+
+2. **Date check**: Current date must be within the tracked event's date range (inclusive)
+   - Error: `"Checkout is only available during the reservation dates (current date: {current_date}, allowed: {start_date}–{end_date})"`
+
+3. **Time check**: Current time must be before the tracked event's end time
+   - Error: `"Checkout is not available after the event end time; automatic checkout should have occurred"`
+
+## Success Response
+
+- Sensor transitions to `checked_out`
+- `rental_control_checkout` event fires with `source: manual`
+- If early checkout expiry is enabled and keymaster is configured:
+  - Keymaster slot end time updated to `min(now + 15min, original_event_end)`
+
+## Error Response
+
+- Raises `ServiceValidationError` with descriptive message
+- No state change occurs
+- No events fired
+
+## Integration with Entity Service Registration
+
+```python
+# In sensor.py async_setup_entry():
+platform = entity_platform.async_get_current_platform()
+platform.async_register_entity_service(
+    "checkout",
+    {},  # Empty schema — no parameters
+    "async_checkout",  # Method name on CheckinTrackingSensor
+)
+```

--- a/specs/004-checkin-tracking/contracts/events.md
+++ b/specs/004-checkin-tracking/contracts/events.md
@@ -1,0 +1,91 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# HA Event Bus Contracts
+
+**Feature Branch**: `004-checkin-tracking`
+**Date**: 2025-07-15
+
+## Event: rental_control_checkin
+
+**Fired when**: Sensor transitions from `awaiting_checkin` to `checked_in`
+
+### Event Data Schema
+
+```python
+{
+    "entity_id": str,      # e.g., "sensor.rental_control_my_calendar_checkin"
+    "summary": str,        # Event summary from calendar
+    "start": str,          # ISO 8601 datetime string
+    "end": str,            # ISO 8601 datetime string
+    "guest_name": str,     # Extracted slot name / guest identifier
+    "source": str,         # "keymaster" | "automatic"
+}
+```
+
+### Source Values
+
+| Value | Trigger |
+|-------|---------|
+| `"keymaster"` | Keymaster unlock event detected with matching code slot |
+| `"automatic"` | Event start time reached (time-based mode or fallback) |
+
+### Example
+
+```python
+hass.bus.async_fire(
+    "rental_control_checkin",
+    {
+        "entity_id": "sensor.rental_control_beach_house_checkin",
+        "summary": "Reserved - John Smith",
+        "start": "2025-07-20T16:00:00-04:00",
+        "end": "2025-07-25T11:00:00-04:00",
+        "guest_name": "John Smith",
+        "source": "keymaster",
+    },
+)
+```
+
+---
+
+## Event: rental_control_checkout
+
+**Fired when**: Sensor transitions from `checked_in` to `checked_out`
+
+### Event Data Schema
+
+```python
+{
+    "entity_id": str,      # e.g., "sensor.rental_control_my_calendar_checkin"
+    "summary": str,        # Event summary from calendar
+    "start": str,          # ISO 8601 datetime string
+    "end": str,            # ISO 8601 datetime string
+    "guest_name": str,     # Extracted slot name / guest identifier
+    "source": str,         # "manual" | "automatic"
+}
+```
+
+### Source Values
+
+| Value | Trigger |
+|-------|---------|
+| `"manual"` | User invoked the `rental_control.checkout` action |
+| `"automatic"` | Event end time reached |
+
+### Example
+
+```python
+hass.bus.async_fire(
+    "rental_control_checkout",
+    {
+        "entity_id": "sensor.rental_control_beach_house_checkin",
+        "summary": "Reserved - John Smith",
+        "start": "2025-07-20T16:00:00-04:00",
+        "end": "2025-07-25T11:00:00-04:00",
+        "guest_name": "John Smith",
+        "source": "manual",
+    },
+)
+```

--- a/specs/004-checkin-tracking/contracts/switch-entities.md
+++ b/specs/004-checkin-tracking/contracts/switch-entities.md
@@ -1,0 +1,97 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Entity Contracts: Switch Platform
+
+**Feature Branch**: `004-checkin-tracking`
+**Date**: 2025-07-15
+
+## KeymasterMonitoringSwitch
+
+**Entity ID pattern**: `switch.rental_control_{calendar_name}_keymaster_monitoring`
+**Conditional**: Only created when `coordinator.lockname` is truthy (keymaster configured)
+
+### State
+
+| State | Description |
+|-------|-------------|
+| `on` | Keymaster unlock events trigger check-in detection |
+| `off` | Time-based auto check-in only (default) |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `async_turn_on()` | Enable keymaster monitoring |
+| `async_turn_off()` | Disable keymaster monitoring |
+| `turn_on()` | Sync wrapper (required by SwitchEntity) |
+| `turn_off()` | Sync wrapper (required by SwitchEntity) |
+
+### Restore Behavior
+
+On HA restart, restores last known on/off state via `RestoreEntity`. If no
+prior state exists, defaults to `off`.
+
+---
+
+## EarlyCheckoutExpirySwitch
+
+**Entity ID pattern**: `switch.rental_control_{calendar_name}_early_checkout_expiry`
+**Conditional**: Only created when `coordinator.lockname` is truthy (keymaster configured)
+
+### State
+
+| State | Description |
+|-------|-------------|
+| `on` | Manual checkout updates keymaster slot end to `min(now+15m, event_end)` |
+| `off` | Manual checkout does not modify keymaster slot dates (default) |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `async_turn_on()` | Enable early lock code expiry |
+| `async_turn_off()` | Disable early lock code expiry |
+| `turn_on()` | Sync wrapper (required by SwitchEntity) |
+| `turn_off()` | Sync wrapper (required by SwitchEntity) |
+
+### Restore Behavior
+
+On HA restart, restores last known on/off state via `RestoreEntity`. If no
+prior state exists, defaults to `off`.
+
+---
+
+## Platform Registration
+
+The `switch` platform is added to `PLATFORMS` in `const.py`:
+
+```python
+PLATFORMS = [CALENDAR, SENSOR, SWITCH]
+```
+
+Platform setup in `switch.py`:
+
+```python
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> bool:
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
+
+    entities: list[SwitchEntity] = []
+
+    if coordinator.lockname:
+        entities.append(
+            KeymasterMonitoringSwitch(coordinator, config_entry)
+        )
+        entities.append(
+            EarlyCheckoutExpirySwitch(coordinator, config_entry)
+        )
+
+    async_add_entities(entities)
+    return True
+```

--- a/specs/004-checkin-tracking/data-model.md
+++ b/specs/004-checkin-tracking/data-model.md
@@ -1,0 +1,240 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Data Model: Guest Check-in/Check-out Tracking
+
+**Feature Branch**: `004-checkin-tracking`
+**Date**: 2025-07-15
+
+## Entities
+
+### CheckinTrackingSensor
+
+**Type**: `SensorEntity` + `CoordinatorEntity` + `RestoreEntity`
+**Domain**: `sensor`
+**One per**: Integration instance (config entry)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_attr_native_value` | `str` | Current state: `no_reservation`, `awaiting_checkin`, `checked_in`, `checked_out` |
+| `_tracked_event_summary` | `str \| None` | Summary of the currently tracked event |
+| `_tracked_event_start` | `datetime \| None` | Start time of tracked event |
+| `_tracked_event_end` | `datetime \| None` | Original end time of tracked event (frozen at association) |
+| `_tracked_event_slot_name` | `str \| None` | Guest name/reservation ID from slot extraction |
+| `_checkin_source` | `str \| None` | How check-in occurred: `keymaster`, `automatic`, or `None` |
+| `_checkout_source` | `str \| None` | How check-out occurred: `manual`, `automatic`, or `None` |
+| `_checkout_time` | `datetime \| None` | Actual time the checkout transition occurred |
+| `_transition_target_time` | `datetime \| None` | Scheduled time for next state transition |
+| `_checked_out_event_key` | `str \| None` | Identity key of the event we checked out from (for FR-007) |
+
+**State Attributes** (exposed via `extra_state_attributes`):
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `state` | `str` | Redundant with native_value for automation access |
+| `summary` | `str \| None` | Tracked event summary |
+| `start` | `str \| None` | Event start time (ISO 8601) |
+| `end` | `str \| None` | Event end time (ISO 8601) |
+| `guest_name` | `str \| None` | Extracted guest name / slot name |
+| `checkin_source` | `str \| None` | Source of last check-in |
+| `checkout_source` | `str \| None` | Source of last check-out |
+| `checkout_time` | `str \| None` | When checkout occurred (ISO 8601) |
+| `next_transition` | `str \| None` | When next state transition is scheduled (ISO 8601) |
+
+**Unique ID**: `gen_uuid(f"{coordinator.unique_id} checkin_tracking")`
+**Entity ID**: `sensor.rental_control_{calendar_name}_checkin`
+**Device**: Linked to existing integration device
+
+**Restore State Data** (persisted via `RestoreEntity`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `state` | `str` | Last known state |
+| `tracked_event_summary` | `str \| None` | Event being tracked |
+| `tracked_event_start` | `str \| None` | ISO 8601 start time |
+| `tracked_event_end` | `str \| None` | ISO 8601 original end time |
+| `tracked_event_slot_name` | `str \| None` | Guest name |
+| `checkin_source` | `str \| None` | Last checkin source |
+| `checkout_source` | `str \| None` | Last checkout source |
+| `checkout_time` | `str \| None` | ISO 8601 checkout time |
+| `transition_target_time` | `str \| None` | ISO 8601 next transition |
+| `checked_out_event_key` | `str \| None` | Event identity key |
+
+---
+
+### KeymasterMonitoringSwitch
+
+**Type**: `SwitchEntity` + `RestoreEntity`
+**Domain**: `switch`
+**One per**: Integration instance (only when keymaster configured)
+**Condition**: `coordinator.lockname` is not empty
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_attr_is_on` | `bool` | Whether keymaster unlock monitoring is active |
+
+**Unique ID**: `gen_uuid(f"{coordinator.unique_id} keymaster_monitoring")`
+**Entity ID**: `switch.rental_control_{calendar_name}_keymaster_monitoring`
+**Device**: Linked to existing integration device
+**Default**: `False` (off)
+
+---
+
+### EarlyCheckoutExpirySwitch
+
+**Type**: `SwitchEntity` + `RestoreEntity`
+**Domain**: `switch`
+**One per**: Integration instance (only when keymaster configured)
+**Condition**: `coordinator.lockname` is not empty
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_attr_is_on` | `bool` | Whether early checkout triggers lock code expiry |
+
+**Unique ID**: `gen_uuid(f"{coordinator.unique_id} early_checkout_expiry")`
+**Entity ID**: `switch.rental_control_{calendar_name}_early_checkout_expiry`
+**Device**: Linked to existing integration device
+**Default**: `False` (off)
+
+---
+
+## State Machine
+
+### States
+
+| State | Value | Description |
+|-------|-------|-------------|
+| No Reservation | `no_reservation` | No relevant event; property idle |
+| Awaiting Check-in | `awaiting_checkin` | Event identified; waiting for guest |
+| Checked In | `checked_in` | Guest has arrived |
+| Checked Out | `checked_out` | Guest has departed; linger period active |
+
+### Transitions
+
+```text
+┌──────────────────┐
+│  no_reservation   │
+└────────┬─────────┘
+         │ Event identified by coordinator
+         ▼
+┌──────────────────┐
+│ awaiting_checkin  │◄────────────────────────────────┐
+└────────┬─────────┘                                  │
+         │ Time-based (event start)                   │
+         │ OR keymaster unlock detected               │
+         ▼                                            │
+┌──────────────────┐                                  │
+│   checked_in     │                                  │
+└────────┬─────────┘                                  │
+         │ Time-based (event end)                     │
+         │ OR manual checkout action                  │
+         ▼                                            │
+┌──────────────────┐                                  │
+│  checked_out     │──────────────────────────────────┘
+└────────┬─────────┘  (same-day: half-gap → awaiting)
+         │
+         │ (no follow-on: cleaning window → no_reservation)
+         │ (different-day: midnight → no_reservation)
+         ▼
+┌──────────────────┐
+│  no_reservation   │
+└──────────────────┘
+```
+
+### Transition Rules
+
+| From | To | Trigger | Condition |
+|------|----|---------|-----------|
+| `no_reservation` | `awaiting_checkin` | Coordinator update | Relevant event found |
+| `awaiting_checkin` | `checked_in` | Timer (event start) | Keymaster monitoring disabled |
+| `awaiting_checkin` | `checked_in` | Keymaster unlock event | Monitoring enabled, matching slot, `code_slot_num != 0` |
+| `checked_in` | `checked_out` | Timer (event end) | Automatic transition |
+| `checked_in` | `checked_out` | Manual checkout action | Guards pass: `checked_in`, same day, before end |
+| `checked_out` | `awaiting_checkin` | Timer (half-gap) | Same-day turnover (FR-006a) |
+| `checked_out` | `no_reservation` | Timer (cleaning window) | No follow-on reservation (FR-006b) |
+| `checked_out` | `no_reservation` | Timer (midnight boundary) | Next reservation on different day (FR-006c) |
+| `no_reservation` | `awaiting_checkin` | Timer (00:00 event start day) | After FR-006c midnight transition |
+
+---
+
+## Event Identity
+
+Events are identified by a composite key for FR-007 tracking:
+
+```python
+def _event_key(
+    summary: str, start: datetime, end: datetime
+) -> str:
+    """Generate a unique identity key for an event.
+
+    The original end time is included so that extensions
+    (same summary + start but later end) are detected as
+    the same event rather than a new one.
+    """
+    return (
+        f"{summary}|{start.isoformat()}"
+        f"|{end.isoformat()}"
+    )
+```
+
+The `end` parameter captures the **original** end time at first
+association. This key is stored when the sensor first associates
+with an event and is used to:
+- Detect the same event with a modified end time (key matches → no re-transition)
+- Detect a genuinely new event (key differs → allow new cycle)
+
+---
+
+## Configuration
+
+### New Config Options
+
+| Key | Type | Default | Description | Flow |
+|-----|------|---------|-------------|------|
+| `CONF_CLEANING_WINDOW` | `float` | `6.0` | Hours to linger in checked_out when no follow-on (FR-008) | Options |
+
+**Note**: The cleaning window is the only new configuration option. The keymaster
+monitoring toggle (FR-013) and early checkout expiry toggle (FR-021) are runtime
+switch entities, not config flow options.
+
+### Existing Config Used
+
+| Key | Current Use | New Use |
+|-----|-------------|---------|
+| `CONF_LOCK_ENTRY` | Keymaster lock entity | Determines if toggle entities are created |
+| `CONF_START_SLOT` | First keymaster slot | Defines managed slot range for unlock detection |
+| `CONF_MAX_EVENTS` | Number of event sensors | Defines managed slot range upper bound |
+| `CONF_CHECKIN` | Default check-in time | Used for time-based auto check-in |
+| `CONF_CHECKOUT` | Default check-out time | Used for automatic checkout timing |
+
+---
+
+## HA Event Bus Events
+
+### rental_control_checkin
+
+Fired when sensor transitions to `checked_in`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entity_id` | `str` | Sensor entity ID |
+| `summary` | `str` | Event summary |
+| `start` | `str` | Event start (ISO 8601) |
+| `end` | `str` | Event end (ISO 8601) |
+| `guest_name` | `str` | Extracted guest name |
+| `source` | `str` | `"keymaster"` or `"automatic"` |
+
+### rental_control_checkout
+
+Fired when sensor transitions to `checked_out`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entity_id` | `str` | Sensor entity ID |
+| `summary` | `str` | Event summary |
+| `start` | `str` | Event start (ISO 8601) |
+| `end` | `str` | Event end (ISO 8601) |
+| `guest_name` | `str` | Extracted guest name |
+| `source` | `str` | `"manual"` or `"automatic"` |

--- a/specs/004-checkin-tracking/plan.md
+++ b/specs/004-checkin-tracking/plan.md
@@ -1,0 +1,207 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Implementation Plan: Guest Check-in/Check-out Tracking
+
+**Branch**: `004-checkin-tracking` | **Date**: 2025-07-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/004-checkin-tracking/spec.md`
+
+## Summary
+
+Add a guest check-in/check-out tracking sensor to the Rental Control integration
+that monitors occupancy state via a four-state state machine (`no_reservation` →
+`awaiting_checkin` → `checked_in` → `checked_out`). The sensor transitions
+automatically based on calendar event timing, optionally using keymaster unlock
+detection for check-in. It supports manual early check-out with optional lock
+code expiry, persists state across HA restarts, fires event bus events on
+transitions, and handles same-day turnovers with configurable post-checkout
+linger timing.
+
+**Technical approach**: New `CheckinTrackingSensor` as a `CoordinatorEntity` +
+`RestoreEntity`, timer-scheduled transitions via `async_track_point_in_time()`,
+keymaster event bus listener for unlock detection, new `switch` platform for
+toggle entities, and a registered entity service for manual checkout.
+
+## Technical Context
+
+**Language/Version**: Python 3.13.2+ (per pyproject.toml `requires-python = ">=3.13.2"`)
+**Primary Dependencies**: homeassistant ≥ 2025.8.0, icalendar ≥ 6.1.0, x-wr-timezone ≥ 2.0.0
+**Storage**: Home Assistant RestoreEntity state persistence (built-in HA mechanism)
+**Testing**: pytest + pytest-homeassistant-custom-component + aioresponses; markers: `unit`, `integration`
+**Target Platform**: Home Assistant custom integration (runs on HA Core instances)
+**Project Type**: Single HA custom integration (`custom_components/rental_control/`)
+**Performance Goals**: State transitions within one coordinator update cycle of the relevant time boundary (SC-001); event bus events fired synchronously with transitions (SC-002)
+**Constraints**: Must not block HA event loop (async patterns required); must work on resource-constrained hardware (Raspberry Pi); lock code generation must complete within 30s sensor update cycle
+**Scale/Scope**: One check-in sensor per integration instance; handles 1–5 concurrent event slots per calendar; one optional keymaster event listener per instance
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Gate (Phase 0 Entry)
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| **I: Code Quality & Testing** | ✅ PASS | Plan includes unit + integration tests for all new code; type hints required; docstrings enforced by interrogate |
+| **II: Atomic Commit Discipline** | ✅ PASS | Implementation will be broken into logical atomic commits (constants, sensor, switch, service, config flow, tests) |
+| **III: Licensing & Attribution** | ✅ PASS | All new files will include SPDX headers; existing files modified will retain headers |
+| **IV: Pre-Commit Integrity** | ✅ PASS | All commits must pass ruff, mypy, interrogate, reuse-tool, gitlint |
+| **V: Agent Co-Authorship & DCO** | ✅ PASS | Agent commits will include Co-authored-by trailer and DCO sign-off via `git commit -s` |
+| **VI: User Experience Consistency** | ✅ PASS | Entity naming follows `sensor.rental_control_{name}_checkin` convention; config follows HA config flow patterns; entities linked to existing device |
+| **VII: Performance Requirements** | ✅ PASS | Timer-based transitions avoid polling overhead; async patterns throughout; no blocking I/O |
+
+### Post-Design Gate (Phase 1 Exit)
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| **I: Code Quality & Testing** | ✅ PASS | Data model defines all entities with types; contracts define service schemas and event payloads; test files identified in quickstart |
+| **II: Atomic Commit Discipline** | ✅ PASS | Source structure supports incremental implementation: constants → state machine → persistence → keymaster → toggles → service → config |
+| **VI: User Experience Consistency** | ✅ PASS | Entity IDs follow existing `rental_control_{name}_*` pattern; state values are lowercase snake_case matching HA conventions; switch entities only created when keymaster configured (no orphan entities) |
+| **VII: Performance Requirements** | ✅ PASS | `async_track_point_in_time()` for precise transitions avoids frequent polling; coordinator updates serve as fault-tolerance backup; no additional HTTP requests |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-checkin-tracking/
+├── plan.md                          # This file
+├── research.md                      # Phase 0: Research findings and decisions
+├── data-model.md                    # Phase 1: Entity definitions, state machine, events
+├── quickstart.md                    # Phase 1: Dev setup and verification commands
+├── checklists/                      # Pre-existing checklists from spec
+├── contracts/
+│   ├── checkout-service.md          # Phase 1: checkout action schema and guards
+│   ├── events.md                    # Phase 1: HA event bus event schemas
+│   └── switch-entities.md           # Phase 1: Switch entity contracts
+└── tasks.md                         # Phase 2: Generated by /speckit.tasks (not this command)
+```
+
+### Source Code (repository root)
+
+```text
+custom_components/rental_control/
+├── __init__.py                      # MODIFY: Add keymaster event bus listener
+├── config_flow.py                   # MODIFY: Add cleaning_window to options flow
+├── const.py                         # MODIFY: Add new constants
+├── coordinator.py                   # (no changes — data source stays the same)
+├── sensor.py                        # MODIFY: Add CheckinTrackingSensor, register checkout service
+├── switch.py                        # NEW: Switch platform setup + toggle entities
+├── strings.json                     # MODIFY: Add new entity/config translations
+├── translations/
+│   └── en.json                      # MODIFY: English translations for new items
+├── sensors/
+│   ├── calsensor.py                 # (no changes — existing sensor unaffected)
+│   └── checkinsensor.py             # NEW: CheckinTrackingSensor implementation
+├── calendar.py                      # (no changes)
+├── event_overrides.py               # (no changes)
+├── util.py                          # MODIFY: Add early expiry helper function
+└── manifest.json                    # (no changes — no new requirements)
+
+tests/
+├── conftest.py                      # MODIFY: Add checkin-specific fixtures
+├── fixtures/
+│   ├── calendar_data.py             # (may add new test calendar data)
+│   └── checkin_data.py              # NEW: Test data for checkin scenarios
+├── unit/
+│   ├── test_checkin_sensor.py       # NEW: State machine unit tests
+│   └── test_switch.py               # NEW: Toggle entity unit tests
+└── integration/
+    └── test_checkin_tracking.py     # NEW: Full lifecycle integration tests
+```
+
+**Structure Decision**: Follows the existing single-integration structure at
+`custom_components/rental_control/`. New sensor goes in `sensors/` subdirectory
+(matching `calsensor.py` pattern). New `switch.py` at the platform level follows
+HA convention for platform modules. No new directories beyond `contracts/` in
+the spec folder.
+
+## Complexity Tracking
+
+> No constitution violations identified. All design decisions align with
+> existing project patterns and constitutional principles.
+
+## Design Decisions
+
+### D-001: Sensor Architecture
+
+The `CheckinTrackingSensor` inherits from both `CoordinatorEntity` and
+`RestoreEntity`. It receives coordinator data updates via
+`_handle_coordinator_update()` (same as existing `RentalControlCalSensor`)
+but maintains internal state machine logic rather than deriving state purely
+from event data.
+
+**Key behaviors**:
+- On coordinator update: identifies the "most relevant" event (event 0 from
+  sorted coordinator data) and evaluates whether a state transition is needed
+- On timer fire: executes scheduled transitions (auto check-in, auto
+  check-out, post-checkout linger expiry)
+- On keymaster event: processes unlock detection when monitoring is enabled
+- On service call: handles manual checkout with guard validation
+
+### D-002: Event Relevance Determination
+
+The sensor uses `coordinator.data[0]` (first/nearest event from sorted list)
+as the "most relevant" event. This aligns with the spec's FR-002 requirement
+and leverages the coordinator's existing sorting and filtering logic without
+additional calendar queries.
+
+When the sensor is in `checked_out`, it also examines `coordinator.data[1]`
+(if available) to determine which FR-006 post-checkout scenario applies:
+- If `data[1]` starts on the same day → FR-006a (same-day turnover)
+- If `data[1]` starts on a different day → FR-006c (midnight boundary)
+- If no `data[1]` → FR-006b (cleaning window)
+
+### D-003: Keymaster Event Bus Integration
+
+The keymaster integration fires `keymaster_lock_state_changed` events on the
+HA event bus with data including `lockname`, `state`, and `code_slot_num`.
+
+The listener is registered in `__init__.py` when `coordinator.lockname` is
+configured. It filters events by:
+1. `lockname` matches `coordinator.lockname`
+2. `state` is `"unlocked"`
+3. `code_slot_num != 0` (exclude manual/RF unlocks)
+4. `code_slot_num` is in range `[start_slot, start_slot + max_events)`
+
+When a matching event is detected, the listener checks whether the keymaster
+monitoring switch is `on` and the sensor is in `awaiting_checkin`, then
+triggers the check-in transition.
+
+### D-004: Early Lock Code Expiry
+
+When manual checkout occurs and the `EarlyCheckoutExpirySwitch` is `on`:
+1. Look up the keymaster slot assigned to the current guest via
+   `event_overrides.get_slot_key_by_name(slot_name)`
+2. Compute `expiry_time = min(now + timedelta(minutes=15), original_event_end)`
+3. Update the slot's date range end using the existing `add_call()` pattern
+   from `util.py` (same approach as `async_fire_update_times()`)
+
+This reuses the established Keymaster interaction patterns.
+
+### D-005: Config Flow Changes
+
+Only one new config option is added: `cleaning_window` (float, default 6.0
+hours) in the options flow. This is minimal because the keymaster monitoring
+and early checkout expiry controls are runtime toggle switches, not config
+options — they can be changed instantly without integration reload.
+
+The options flow schema in `config_flow.py` adds:
+```python
+vol.Optional(CONF_CLEANING_WINDOW, default=6.0): vol.All(
+    vol.Coerce(float), vol.Range(min=0.5, max=48.0)
+)
+```
+
+## References
+
+- **Spec**: [specs/004-checkin-tracking/spec.md](spec.md)
+- **Research**: [specs/004-checkin-tracking/research.md](research.md)
+- **Data Model**: [specs/004-checkin-tracking/data-model.md](data-model.md)
+- **Quickstart**: [specs/004-checkin-tracking/quickstart.md](quickstart.md)
+- **Contracts**:
+  - [contracts/checkout-service.md](contracts/checkout-service.md)
+  - [contracts/events.md](contracts/events.md)
+  - [contracts/switch-entities.md](contracts/switch-entities.md)

--- a/specs/004-checkin-tracking/quickstart.md
+++ b/specs/004-checkin-tracking/quickstart.md
@@ -1,0 +1,111 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart: Guest Check-in/Check-out Tracking
+
+**Feature Branch**: `004-checkin-tracking`
+**Date**: 2025-07-15
+
+## Prerequisites
+
+- Python 3.13.2+ (per pyproject.toml)
+- uv package manager installed
+- Home Assistant development environment (`homeassistant>=2025.8.0`)
+
+## Development Setup
+
+```bash
+# Clone and enter worktree
+git clone https://github.com/tykeal/homeassistant-rental-control.git
+cd homeassistant-rental-control
+git switch 004-checkin-tracking
+
+# Install dependencies
+uv sync --all-extras
+
+# Run existing tests to verify baseline
+uv run pytest tests/ -v
+```
+
+## New Files to Create
+
+### Core Implementation
+
+| File | Purpose |
+|------|---------|
+| `custom_components/rental_control/sensors/checkinsensor.py` | Check-in tracking sensor entity (state machine, persistence, transitions) |
+| `custom_components/rental_control/switch.py` | Switch platform setup + KeymasterMonitoringSwitch + EarlyCheckoutExpirySwitch |
+
+### Tests
+
+| File | Purpose |
+|------|---------|
+| `tests/unit/test_checkin_sensor.py` | Unit tests for state machine transitions, event identity, attribute exposure |
+| `tests/unit/test_switch.py` | Unit tests for toggle entities, conditional creation, restore |
+| `tests/integration/test_checkin_tracking.py` | Integration tests for full lifecycle including keymaster interaction |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `custom_components/rental_control/const.py` | Add `CONF_CLEANING_WINDOW`, new event names, checkin state constants |
+| `custom_components/rental_control/sensor.py` | Add `CheckinTrackingSensor` creation, register checkout service |
+| `custom_components/rental_control/__init__.py` | Add keymaster event bus listener, store reference for sensor access |
+| `custom_components/rental_control/config_flow.py` | Add cleaning window option to options flow |
+| `custom_components/rental_control/strings.json` | Add translations for new entities and config options |
+| `custom_components/rental_control/translations/en.json` | English translations |
+
+## Architecture Overview
+
+```text
+                    ┌─────────────────────────┐
+                    │   Coordinator (existing) │
+                    │   - Calendar fetch       │
+                    │   - Event parsing        │
+                    │   - Override management  │
+                    └────────┬────────────────┘
+                             │ data updates
+                    ┌────────▼────────────────┐
+                    │  CheckinTrackingSensor   │
+                    │  (NEW - one per instance)│
+                    │  - State machine         │
+                    │  - Timer scheduling      │
+                    │  - Event identity        │
+                    │  - RestoreEntity         │
+                    └────────┬────────────────┘
+                             │
+              ┌──────────────┼──────────────┐
+              │              │              │
+     ┌────────▼──┐   ┌──────▼──────┐  ┌───▼──────────┐
+     │ HA Events │   │ Keymaster   │  │  Toggle       │
+     │ checkin/  │   │ Event Bus   │  │  Switches     │
+     │ checkout  │   │ Listener    │  │  (NEW)        │
+     └───────────┘   └─────────────┘  └──────────────┘
+```
+
+## Quick Verification
+
+After implementation, verify with:
+
+```bash
+# Run all tests
+uv run pytest tests/ -v
+
+# Run only new tests
+uv run pytest tests/unit/test_checkin_sensor.py tests/unit/test_switch.py -v
+
+# Run with coverage
+uv run pytest tests/ --cov=custom_components/rental_control --cov-report=term-missing
+
+# Lint check
+uv run ruff check custom_components/rental_control/
+uv run ruff format --check custom_components/rental_control/
+
+# Type check
+uv run mypy custom_components/rental_control/
+
+# Full pre-commit
+pre-commit run --all-files
+```

--- a/specs/004-checkin-tracking/research.md
+++ b/specs/004-checkin-tracking/research.md
@@ -1,0 +1,207 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Research: Guest Check-in/Check-out Tracking
+
+**Feature Branch**: `004-checkin-tracking`
+**Date**: 2025-07-15
+
+## Research Tasks
+
+### RT-001: State Persistence via RestoreEntity
+
+**Context**: The spec requires the check-in tracking sensor to survive HA restarts
+(FR-011, FR-012). The existing `RentalControlCalSensor` is stateless — it
+derives state purely from coordinator data on every update. The check-in sensor
+has internal state (which event is tracked, whether we've already checked out)
+that cannot be re-derived purely from calendar data.
+
+**Decision**: Use Home Assistant's `RestoreEntity` mixin combined with
+`CoordinatorEntity`.
+
+**Rationale**:
+- `RestoreEntity` provides `async_get_last_state()` and
+  `async_get_last_extra_data()` for persisting arbitrary state across restarts
+- The sensor class will inherit from both `CoordinatorEntity` and `RestoreSensor`
+  (the sensor-specific variant that provides `SensorExtraStoredData`)
+- On startup, restored state is validated against current time and coordinator
+  data, transitioning if stale (FR-012)
+- This is the standard HA pattern for sensors that need persistent state
+
+**Alternatives considered**:
+- **Coordinator-only (current pattern)**: Rejected — the check-in sensor has
+  state that cannot be derived from calendar data alone (e.g., "was checkout
+  already triggered for this event?")
+- **Config entry extra data**: Rejected — not designed for frequently-changing
+  sensor state; would couple sensor state to config entry lifecycle
+- **Custom file storage**: Rejected — unnecessary complexity; RestoreEntity
+  is the HA-blessed approach
+
+---
+
+### RT-002: Toggle Entity Implementation (SwitchEntity)
+
+**Context**: FR-013 and FR-021 require toggle entities for keymaster monitoring
+and early check-out expiry. The integration currently has no SwitchEntity
+implementations — only Sensor and Calendar platforms.
+
+**Decision**: Implement toggle entities as `SwitchEntity` subclasses with
+`RestoreEntity` mixin, registered under a new `switch` platform.
+
+**Rationale**:
+- `SwitchEntity` is the standard HA entity for user-controllable on/off state
+- `RestoreEntity` mixin persists toggle state across restarts
+- Adding the `SWITCH` platform to `PLATFORMS` in `const.py` follows existing
+  patterns
+- Conditional creation (FR-026, FR-027): only instantiate when
+  `coordinator.lockname` is not empty (keymaster is configured)
+
+**Alternatives considered**:
+- **BinarySensorEntity**: Rejected — binary sensors are read-only; toggles need
+  user control
+- **InputBoolean helper**: Rejected — would be external to the integration;
+  cannot be conditionally created per instance
+- **Config option**: Rejected — options flow changes require reload; toggles
+  should be instant
+
+---
+
+### RT-003: Manual Check-out Action Registration
+
+**Context**: FR-018 requires a checkout action invocable on the sensor entity.
+Home Assistant supports entity-level actions via
+`async_register_entity_service()`.
+
+**Decision**: Register a `checkout` action on the sensor platform using
+`async_register_entity_service()` in `sensor.py`'s `async_setup_entry()`.
+
+**Rationale**:
+- `async_register_entity_service()` binds the action to specific entity classes
+- The action handler lives on the `CheckinTrackingSensor` class itself
+- Guard conditions (FR-019, FR-020) are validated in the handler method
+- This follows the HA convention for entity-specific actions (e.g.,
+  `climate.set_temperature`, `light.turn_on`)
+- The service schema is empty (no parameters needed — entity_id is implicit)
+
+**Alternatives considered**:
+- **Domain-level service** (`hass.services.async_register`): Rejected — would
+  require passing entity_id as a parameter; entity services are cleaner
+- **Button entity**: Rejected — buttons are fire-and-forget with no error
+  feedback; actions can raise `ServiceValidationError`
+
+---
+
+### RT-004: Timer-Based State Transitions
+
+**Context**: The state machine requires transitions at specific times: event
+start, event end, half-gap point (FR-006a), cleaning window expiry (FR-006b),
+and midnight boundary (FR-006c). These cannot rely solely on coordinator refresh
+cycles (default 2 min).
+
+**Decision**: Use Home Assistant's `async_track_point_in_time()` to schedule
+precise transition callbacks, combined with coordinator update processing.
+
+**Rationale**:
+- `async_track_point_in_time()` fires a callback at a specific `datetime`,
+  integrating with HA's event loop
+- The sensor schedules the next transition time whenever it enters a new state
+- If HA restarts, the timer is re-scheduled during state restoration
+- Coordinator updates still trigger `_handle_coordinator_update()` which can
+  detect missed transitions and correct state
+- This dual approach (timers + coordinator updates) provides both precision and
+  fault tolerance
+
+**Alternatives considered**:
+- **Coordinator-only polling**: Rejected — with 2-minute default refresh, state
+  transitions could be delayed up to 2 minutes; spec says "within one coordinator
+  update cycle" (SC-001) but precise timing improves UX
+- **asyncio.sleep**: Rejected — does not survive HA restarts; harder to cancel
+  and reschedule
+- **async_call_later**: Similar to `async_track_point_in_time` but takes a
+  duration rather than absolute time; less readable for calendar-based scheduling
+
+---
+
+### RT-005: Keymaster Lock State Changed Event Handling
+
+**Context**: FR-014 requires listening for `keymaster_lock_state_changed` events
+on the HA event bus. The current integration listens for state changes on
+keymaster _entities_ (switches, text, datetime) but not for the keymaster event
+bus event.
+
+**Decision**: Register an event bus listener for `keymaster_lock_state_changed`
+in `__init__.py`'s `async_setup_entry()` when keymaster is configured.
+
+**Rationale**:
+- `hass.bus.async_listen()` is the standard pattern for HA event bus listening
+- The listener callback validates: event state is "unlocked",
+  `code_slot_num != 0`, and `code_slot_num` falls within the managed range
+  `[start_slot, start_slot + max_events)`
+- The callback then delegates to the check-in sensor to attempt state transition
+- The unsubscribe function is stored in `UNSUB_LISTENERS` for cleanup
+- The event data expected: `{"lockname": str, "state": str, "code_slot_num": int}`
+
+**Alternatives considered**:
+- **Reuse existing state change listener**: Rejected — the existing listener
+  tracks entity state changes (switch on/off, text value); the keymaster event
+  is a different mechanism fired by the keymaster integration itself
+- **Poll keymaster entities**: Rejected — event-driven detection is immediate;
+  polling would add latency
+
+---
+
+### RT-006: Post-Checkout Linger Timing Strategy
+
+**Context**: FR-006 defines three post-checkout linger scenarios with different
+timing rules. The sensor must track which scenario applies and schedule the
+correct transition.
+
+**Decision**: When entering `checked_out`, compute the target transition time
+based on the scenario and schedule via `async_track_point_in_time()`. Store the
+target time and scenario in sensor state for persistence.
+
+**Rationale**:
+- **FR-006a (same-day turnover)**: `checkout_time + (next_start - checkout_time) / 2`
+- **FR-006b (no follow-on)**: `checkout_time + cleaning_window_hours`
+- **FR-006c (different-day)**: midnight after checkout day (00:00 next day)
+- The "checkout time" is the actual transition time, not the event end time
+  (important for manual checkouts)
+- Storing the computed target in `extra_restore_state_data` ensures correct
+  resumption after restart
+
+**Alternatives considered**:
+- **Re-compute on every coordinator update**: Rejected — would work but adds
+  complexity to `_handle_coordinator_update`; pre-computed timers are cleaner
+- **Fixed duration for all scenarios**: Rejected — spec explicitly defines
+  different rules per scenario
+
+---
+
+### RT-007: Event Identity Tracking for FR-007
+
+**Context**: FR-007 requires that once checked out for an event, the sensor does
+NOT re-transition even if the event is extended. This means the sensor must
+track which specific event it has already processed.
+
+**Decision**: Track the currently managed event by storing a composite identity
+key: `(event_summary, original_start_time, original_end_time)` as persisted
+state. When an event update arrives, compare against the stored identity to
+detect "same event with modified end time" vs "completely new event".
+
+**Rationale**:
+- Calendar events don't have stable unique IDs in iCalendar format (UIDs are
+  optional and often missing from booking platforms)
+- The combination of summary + original start time provides a sufficiently
+  unique key for the rental use case (same guest, same start date)
+- The `original_end_time` is stored at first association to detect extensions
+- Once `checked_out` is set for an event identity, only a new event identity
+  can trigger re-entry to `awaiting_checkin`
+
+**Alternatives considered**:
+- **iCalendar UID**: Rejected — not reliably present in all calendar sources;
+  coordinator doesn't expose it
+- **Event index only**: Rejected — event indices shift as events are added/removed
+- **Summary only**: Rejected — insufficient; same guest name could appear in
+  multiple events


### PR DESCRIPTION
## Checkin Tracking Implementation Plan

Adds comprehensive planning artifacts for the guest check-in/check-out tracking feature (spec 004).

### Contents

- **plan.md** — Phased implementation plan covering data model, checkout service, switch entities, event system, and UI integration
- **research.md** — Research on Home Assistant patterns for switches, events, and restore-on-restart behavior
- **data-model.md** — Data model design for tracking check-in state per rental unit
- **quickstart.md** — Quick-start guide for developers implementing this feature
- **contracts/** — Interface contracts:
  - `checkout-service.md` — Checkout coordination service contract
  - `events.md` — Event bus event definitions
  - `switch-entities.md` — Switch entity specifications

### Key Design Decisions

- Check-in state modeled as a per-unit boolean switch with restore-on-restart
- Checkout triggers coordinated through a central service to manage lock code cleanup
- Events fired on state transitions for automation hooks
- Agent instructions updated with architecture context