### PR TITLE
Feat(checkin): Add setup constants and fixtures

### DIFF
--- a/custom_components/rental_control/const.py
+++ b/custom_components/rental_control/const.py
@@ -37,9 +37,12 @@ UNSUB_LISTENERS = "unsub_listeners"
 # Platforms
 CALENDAR = "calendar"
 SENSOR = "sensor"
+SWITCH = "switch"
 PLATFORMS = [CALENDAR, SENSOR]
 
 # Events
+EVENT_RENTAL_CONTROL_CHECKIN = "rental_control_checkin"
+EVENT_RENTAL_CONTROL_CHECKOUT = "rental_control_checkout"
 EVENT_RENTAL_CONTROL_CLEAR_CODE = "rental_control_clear_code"
 EVENT_RENTAL_CONTROL_REFRESH = "rental_control_refresh"
 EVENT_RENTAL_CONTROL_SET_CODE = "rental_control_set_code"
@@ -55,6 +58,7 @@ ATTR_SLOT_NAME = "slot_name"
 # Config
 CONF_CHECKIN = "checkin"
 CONF_CHECKOUT = "checkout"
+CONF_CLEANING_WINDOW = "cleaning_window"
 CONF_CODE_GENERATION = "code_generation"
 CONF_CODE_LENGTH = "code_length"
 CONF_CREATION_DATETIME = "creation_datetime"
@@ -74,6 +78,7 @@ CONF_TIMEZONE = "timezone"
 # Defaults
 DEFAULT_CHECKIN = "16:00"
 DEFAULT_CHECKOUT = "11:00"
+DEFAULT_CLEANING_WINDOW = 6.0
 DEFAULT_CODE_GENERATION = "date_based"
 DEFAULT_CODE_LENGTH = 4
 DEFAULT_DAYS = 365
@@ -102,3 +107,12 @@ If you have any issues with this you need to open an issue here:
 {ISSUE_URL}
 -------------------------------------------------------------------
 """
+
+# Check-in tracking state constants
+CHECKIN_STATE_NO_RESERVATION = "no_reservation"
+CHECKIN_STATE_AWAITING = "awaiting_checkin"
+CHECKIN_STATE_CHECKED_IN = "checked_in"
+CHECKIN_STATE_CHECKED_OUT = "checked_out"
+
+# Early checkout grace period in minutes
+EARLY_CHECKOUT_GRACE_MINUTES = 15

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from datetime import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
-from unittest.mock import PropertyMock
 
 from aioresponses import aioresponses
 import pytest
@@ -208,7 +207,7 @@ def mock_checkin_coordinator(
     coordinator.checkin = time(16, 0)
     coordinator.checkout = time(11, 0)
     coordinator.event_prefix = ""
-    type(coordinator).unique_id = PropertyMock(return_value="test-checkin-unique-id")
+    coordinator.unique_id = "test-checkin-unique-id"
     coordinator.name = "Test Rental"
     coordinator.device_info = {
         "identifiers": {(DOMAIN, "test-checkin-unique-id")},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,13 +5,18 @@
 
 from __future__ import annotations
 
+from datetime import time
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+from unittest.mock import PropertyMock
 
 from aioresponses import aioresponses
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.rental_control.const import CONF_CLEANING_WINDOW
+from custom_components.rental_control.const import DEFAULT_CLEANING_WINDOW
 from custom_components.rental_control.const import DOMAIN
 
 from tests.fixtures import calendar_data
@@ -175,3 +180,71 @@ def mock_calendar_url(mock_aiohttp_session: aioresponses) -> aioresponses:
         body=calendar_data.AIRBNB_ICS_CALENDAR,
     )
     return mock_aiohttp_session
+
+
+@pytest.fixture
+def mock_checkin_coordinator(
+    hass: HomeAssistant,
+) -> MagicMock:
+    """Return a mock coordinator for checkin sensor tests.
+
+    The coordinator has configurable event data, lockname, start_slot,
+    max_events, checkin/checkout times, and unique_id. Event data
+    defaults to an empty list.
+
+    Args:
+        hass: Home Assistant instance.
+
+    Returns:
+        MagicMock: Mock coordinator with sensible defaults.
+    """
+    coordinator = MagicMock()
+    coordinator.hass = hass
+    coordinator.data = []
+    coordinator.last_update_success = True
+    coordinator.lockname = None
+    coordinator.start_slot = 10
+    coordinator.max_events = 3
+    coordinator.checkin = time(16, 0)
+    coordinator.checkout = time(11, 0)
+    coordinator.event_prefix = ""
+    type(coordinator).unique_id = PropertyMock(return_value="test-checkin-unique-id")
+    coordinator.name = "Test Rental"
+    coordinator.device_info = {
+        "identifiers": {(DOMAIN, "test-checkin-unique-id")},
+        "name": "Test Rental",
+        "sw_version": "0.0.0",
+    }
+    return coordinator
+
+
+@pytest.fixture
+def mock_checkin_config_entry() -> MockConfigEntry:
+    """Return a mock config entry with cleaning window in options.
+
+    Returns:
+        MockConfigEntry: Mock configuration entry for checkin testing.
+    """
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Rental",
+        version=7,
+        unique_id="test-checkin-unique-id",
+        data={
+            "name": "Test Rental",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "America/New_York",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            "start_slot": 10,
+            "max_events": 3,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+        },
+        options={
+            "refresh_frequency": 5,
+            CONF_CLEANING_WINDOW: DEFAULT_CLEANING_WINDOW,
+        },
+        entry_id="test_checkin_entry_id",
+    )

--- a/tests/fixtures/checkin_data.py
+++ b/tests/fixtures/checkin_data.py
@@ -112,23 +112,30 @@ def same_day_turnover_pair(
     gap_hours: int = 4,
     first_summary: str = "Reserved - Alice",
     second_summary: str = "Reserved - Bob",
+    base_date: datetime | None = None,
 ) -> list[CalendarEvent]:
     """Return coordinator data with a same-day turnover pair.
 
-    Event 0 ends today; event 1 starts the same day.
+    Event 0 ends today; event 1 starts the same day. Times are
+    anchored to the start of the local day so results are
+    deterministic regardless of when tests run.
 
     Args:
-        first_ends_in_hours: Hours until the first event ends.
-        gap_hours: Hours between first event end and second event start.
+        first_ends_in_hours: Hours from start of local day until
+            the first event ends.
+        gap_hours: Hours between first event end and second event
+            start.
         first_summary: Summary for the first event.
         second_summary: Summary for the second event.
+        base_date: Optional datetime whose local day is used as
+            anchor. Defaults to the current local day.
 
     Returns:
         List of two CalendarEvents representing a same-day turnover.
     """
-    now = dt_util.now()
-    first_start = now - timedelta(hours=48)
-    first_end = now + timedelta(hours=first_ends_in_hours)
+    day_start = dt_util.start_of_local_day(base_date or dt_util.now())
+    first_end = day_start + timedelta(hours=first_ends_in_hours)
+    first_start = first_end - timedelta(hours=48)
     second_start = first_end + timedelta(hours=gap_hours)
     second_end = second_start + timedelta(hours=120)
     return [
@@ -152,23 +159,28 @@ def different_day_followon_pair(
     days_until_second: int = 3,
     first_summary: str = "Reserved - Carol",
     second_summary: str = "Reserved - Dave",
+    base_date: datetime | None = None,
 ) -> list[CalendarEvent]:
     """Return coordinator data with a different-day follow-on pair.
 
-    Event 0 ends today; event 1 starts on a different day.
+    Event 0 ends today; event 1 starts on a different day. Times
+    are anchored to the start of the local day for determinism.
 
     Args:
-        first_ends_in_hours: Hours until the first event ends.
+        first_ends_in_hours: Hours from start of local day until
+            the first event ends.
         days_until_second: Days until the second event starts.
         first_summary: Summary for the first event.
         second_summary: Summary for the second event.
+        base_date: Optional datetime whose local day is used as
+            anchor. Defaults to the current local day.
 
     Returns:
         List of two CalendarEvents on different days.
     """
-    now = dt_util.now()
-    first_start = now - timedelta(hours=48)
-    first_end = now + timedelta(hours=first_ends_in_hours)
+    day_start = dt_util.start_of_local_day(base_date or dt_util.now())
+    first_end = day_start + timedelta(hours=first_ends_in_hours)
+    first_start = first_end - timedelta(hours=48)
     second_start = first_end + timedelta(days=days_until_second)
     second_end = second_start + timedelta(hours=120)
     return [

--- a/tests/fixtures/checkin_data.py
+++ b/tests/fixtures/checkin_data.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test fixture data for check-in tracking sensor tests.
+
+Provides helper functions that return sample coordinator event data as
+``list[CalendarEvent]`` matching ``RentalControlCoordinator.data`` for
+various test scenarios.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+
+from homeassistant.components.calendar import CalendarEvent
+from homeassistant.util import dt as dt_util
+
+
+def single_future_event(
+    hours_until_start: int = 24,
+    duration_hours: int = 120,
+    summary: str = "Reserved - John Smith",
+    description: str = "Guest: John Smith\nPhone: +1234567890",
+) -> list[CalendarEvent]:
+    """Return coordinator data with a single future event.
+
+    Args:
+        hours_until_start: Hours from now until event starts.
+        duration_hours: Duration of the event in hours.
+        summary: Event summary text.
+        description: Event description text.
+
+    Returns:
+        List containing one CalendarEvent starting in the future.
+    """
+    now = dt_util.now()
+    start = now + timedelta(hours=hours_until_start)
+    end = start + timedelta(hours=duration_hours)
+    return [
+        CalendarEvent(
+            summary=summary,
+            start=start,
+            end=end,
+            description=description,
+        )
+    ]
+
+
+def active_event(
+    started_hours_ago: int = 2,
+    ends_in_hours: int = 48,
+    summary: str = "Reserved - Jane Doe",
+    description: str = "Guest: Jane Doe\nPhone: +0987654321",
+) -> list[CalendarEvent]:
+    """Return coordinator data with an active event (started, not ended).
+
+    Args:
+        started_hours_ago: Hours since the event started.
+        ends_in_hours: Hours until the event ends.
+        summary: Event summary text.
+        description: Event description text.
+
+    Returns:
+        List containing one active CalendarEvent.
+    """
+    now = dt_util.now()
+    start = now - timedelta(hours=started_hours_ago)
+    end = now + timedelta(hours=ends_in_hours)
+    return [
+        CalendarEvent(
+            summary=summary,
+            start=start,
+            end=end,
+            description=description,
+        )
+    ]
+
+
+def past_event(
+    ended_hours_ago: int = 6,
+    duration_hours: int = 120,
+    summary: str = "Reserved - Past Guest",
+    description: str = "Guest: Past Guest",
+) -> list[CalendarEvent]:
+    """Return coordinator data with a past event (already ended).
+
+    Args:
+        ended_hours_ago: Hours since the event ended.
+        duration_hours: Duration of the event in hours.
+        summary: Event summary text.
+        description: Event description text.
+
+    Returns:
+        List containing one past CalendarEvent.
+    """
+    now = dt_util.now()
+    end = now - timedelta(hours=ended_hours_ago)
+    start = end - timedelta(hours=duration_hours)
+    return [
+        CalendarEvent(
+            summary=summary,
+            start=start,
+            end=end,
+            description=description,
+        )
+    ]
+
+
+def same_day_turnover_pair(
+    first_ends_in_hours: int = 2,
+    gap_hours: int = 4,
+    first_summary: str = "Reserved - Alice",
+    second_summary: str = "Reserved - Bob",
+) -> list[CalendarEvent]:
+    """Return coordinator data with a same-day turnover pair.
+
+    Event 0 ends today; event 1 starts the same day.
+
+    Args:
+        first_ends_in_hours: Hours until the first event ends.
+        gap_hours: Hours between first event end and second event start.
+        first_summary: Summary for the first event.
+        second_summary: Summary for the second event.
+
+    Returns:
+        List of two CalendarEvents representing a same-day turnover.
+    """
+    now = dt_util.now()
+    first_start = now - timedelta(hours=48)
+    first_end = now + timedelta(hours=first_ends_in_hours)
+    second_start = first_end + timedelta(hours=gap_hours)
+    second_end = second_start + timedelta(hours=120)
+    return [
+        CalendarEvent(
+            summary=first_summary,
+            start=first_start,
+            end=first_end,
+            description="Guest: Alice",
+        ),
+        CalendarEvent(
+            summary=second_summary,
+            start=second_start,
+            end=second_end,
+            description="Guest: Bob",
+        ),
+    ]
+
+
+def different_day_followon_pair(
+    first_ends_in_hours: int = 2,
+    days_until_second: int = 3,
+    first_summary: str = "Reserved - Carol",
+    second_summary: str = "Reserved - Dave",
+) -> list[CalendarEvent]:
+    """Return coordinator data with a different-day follow-on pair.
+
+    Event 0 ends today; event 1 starts on a different day.
+
+    Args:
+        first_ends_in_hours: Hours until the first event ends.
+        days_until_second: Days until the second event starts.
+        first_summary: Summary for the first event.
+        second_summary: Summary for the second event.
+
+    Returns:
+        List of two CalendarEvents on different days.
+    """
+    now = dt_util.now()
+    first_start = now - timedelta(hours=48)
+    first_end = now + timedelta(hours=first_ends_in_hours)
+    second_start = first_end + timedelta(days=days_until_second)
+    second_end = second_start + timedelta(hours=120)
+    return [
+        CalendarEvent(
+            summary=first_summary,
+            start=first_start,
+            end=first_end,
+            description="Guest: Carol",
+        ),
+        CalendarEvent(
+            summary=second_summary,
+            start=second_start,
+            end=second_end,
+            description="Guest: Dave",
+        ),
+    ]
+
+
+def no_events() -> list[CalendarEvent]:
+    """Return empty coordinator data (no events).
+
+    Returns:
+        Empty list representing no calendar events.
+    """
+    return []
+
+
+def event_at_times(
+    start: datetime,
+    end: datetime,
+    summary: str = "Reserved - Test Guest",
+    description: str = "Guest: Test Guest",
+) -> list[CalendarEvent]:
+    """Return coordinator data with an event at specific times.
+
+    Args:
+        start: Exact start datetime for the event.
+        end: Exact end datetime for the event.
+        summary: Event summary text.
+        description: Event description text.
+
+    Returns:
+        List containing one CalendarEvent at the specified times.
+    """
+    return [
+        CalendarEvent(
+            summary=summary,
+            start=start,
+            end=end,
+            description=description,
+        )
+    ]


### PR DESCRIPTION
## Phase 1 of 9: Check-in/Check-out Tracking Setup

This PR adds the foundational constants and test fixtures for the check-in/check-out tracking feature.

### Changes

**`custom_components/rental_control/const.py`**
- Check-in state constants: `no_reservation`, `awaiting_checkin`, `checked_in`, `checked_out`
- Event name constants for check-in state changes
- Config keys: `CONF_CLEANING_WINDOW` and associated defaults
- `SWITCH` platform constant (not yet added to `PLATFORMS` — that comes in a later phase)

**`tests/conftest.py`**
- `mock_checkin_coordinator` fixture for testing check-in coordinator behavior
- `mock_checkin_config_entry` fixture for integration tests

**`tests/fixtures/checkin_data.py`** *(new)*
- Test fixture helper functions for checkin sensor testing

### Context

This is **Phase 1 of 9** for the check-in/check-out tracking feature defined in `specs/004-checkin-tracking/tasks.md`. It covers tasks T001, T002, and T003.

Subsequent phases will add the coordinator, sensors, switches, services, and UI configuration flow.