### PR TITLE
Feat(checkin): Add sensor skeleton and platform

### DIFF
--- a/custom_components/rental_control/const.py
+++ b/custom_components/rental_control/const.py
@@ -38,7 +38,7 @@ UNSUB_LISTENERS = "unsub_listeners"
 CALENDAR = "calendar"
 SENSOR = "sensor"
 SWITCH = "switch"
-PLATFORMS = [CALENDAR, SENSOR]
+PLATFORMS = [CALENDAR, SENSOR, SWITCH]
 
 # Events
 EVENT_RENTAL_CONTROL_CHECKIN = "rental_control_checkin"

--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -19,6 +19,7 @@ from .const import COORDINATOR
 from .const import DOMAIN
 from .const import NAME
 from .sensors.calsensor import RentalControlCalSensor
+from .sensors.checkinsensor import CheckinTrackingSensor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +60,15 @@ async def async_setup_entry(
                 eventnumber,
             )
         )
+
+    # Add check-in tracking sensor (FR-028: created for every instance)
+    sensors.append(
+        CheckinTrackingSensor(
+            hass,
+            coordinator,
+            config_entry,
+        )
+    )
 
     async_add_entities(sensors)
 

--- a/custom_components/rental_control/sensors/__init__.py
+++ b/custom_components/rental_control/sensors/__init__.py
@@ -2,3 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Sensors submodule."""
+
+from .checkinsensor import CheckinTrackingSensor
+
+__all__ = ["CheckinTrackingSensor"]

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -3,16 +3,14 @@
 
 """Check-in/check-out tracking sensor for Rental Control.
 
-Implements a four-state state machine that tracks guest occupancy:
-``no_reservation`` → ``awaiting_checkin`` → ``checked_in`` → ``checked_out``.
-Transitions are driven by coordinator data updates and timer-scheduled
-callbacks.
+Phase 2 skeleton — provides entity wiring, unique_id, device_info,
+extra_state_attributes, and _event_key.  State-machine transitions
+will be added in later phases.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
-import logging
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -29,8 +27,6 @@ from ..util import gen_uuid
 if TYPE_CHECKING:
     from ..coordinator import RentalControlCoordinator
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class CheckinTrackingSensor(
     CoordinatorEntity["RentalControlCoordinator"],
@@ -38,13 +34,9 @@ class CheckinTrackingSensor(
 ):
     """Sensor that tracks guest check-in/check-out state.
 
-    Maintains a four-state state machine driven by coordinator data
-    updates and timer-scheduled callbacks:
-
-    - ``no_reservation``: No relevant calendar event
-    - ``awaiting_checkin``: Event identified, waiting for guest arrival
-    - ``checked_in``: Guest has arrived
-    - ``checked_out``: Guest has departed, post-checkout linger active
+    Phase 2 skeleton — exposes entity metadata and attributes.
+    State-machine transitions (no_reservation → awaiting_checkin →
+    checked_in → checked_out) will be added in later phases.
     """
 
     def __init__(
@@ -63,7 +55,7 @@ class CheckinTrackingSensor(
         super().__init__(coordinator)
         self._hass = hass
         self._config_entry = config_entry
-        self._attr_native_value: str = CHECKIN_STATE_NO_RESERVATION
+        self._state: str = CHECKIN_STATE_NO_RESERVATION
 
         # Tracked event fields (from data-model.md)
         self._tracked_event_summary: str | None = None
@@ -93,6 +85,11 @@ class CheckinTrackingSensor(
         return f"{self.coordinator.name} Check-in"
 
     @property
+    def state(self) -> str:
+        """Return the current check-in tracking state."""
+        return self._state
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device info linking to the existing integration device."""
         return self.coordinator.device_info
@@ -104,7 +101,7 @@ class CheckinTrackingSensor(
         Returns all tracked event attributes per data-model.md.
         """
         return {
-            "state": self._attr_native_value,
+            "state": self._state,
             "summary": self._tracked_event_summary,
             "start": (
                 self._tracked_event_start.isoformat()

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check-in/check-out tracking sensor for Rental Control.
+
+Implements a four-state state machine that tracks guest occupancy:
+``no_reservation`` → ``awaiting_checkin`` → ``checked_in`` → ``checked_out``.
+Transitions are driven by coordinator data updates and timer-scheduled
+callbacks.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+from typing import TYPE_CHECKING
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import CALLBACK_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from ..const import CHECKIN_STATE_NO_RESERVATION
+from ..util import gen_uuid
+
+if TYPE_CHECKING:
+    from ..coordinator import RentalControlCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CheckinTrackingSensor(
+    CoordinatorEntity["RentalControlCoordinator"],
+    RestoreEntity,
+):
+    """Sensor that tracks guest check-in/check-out state.
+
+    Maintains a four-state state machine driven by coordinator data
+    updates and timer-scheduled callbacks:
+
+    - ``no_reservation``: No relevant calendar event
+    - ``awaiting_checkin``: Event identified, waiting for guest arrival
+    - ``checked_in``: Guest has arrived
+    - ``checked_out``: Guest has departed, post-checkout linger active
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: RentalControlCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the check-in tracking sensor.
+
+        Args:
+            hass: Home Assistant instance.
+            coordinator: The rental control data coordinator.
+            config_entry: The integration config entry.
+        """
+        super().__init__(coordinator)
+        self._hass = hass
+        self._config_entry = config_entry
+        self._attr_native_value: str = CHECKIN_STATE_NO_RESERVATION
+
+        # Tracked event fields (from data-model.md)
+        self._tracked_event_summary: str | None = None
+        self._tracked_event_start: datetime | None = None
+        self._tracked_event_end: datetime | None = None
+        self._tracked_event_slot_name: str | None = None
+        self._checkin_source: str | None = None
+        self._checkout_source: str | None = None
+        self._checkout_time: datetime | None = None
+        self._transition_target_time: datetime | None = None
+        self._checked_out_event_key: str | None = None
+
+        # Internal timer unsubscribe handle
+        self._unsub_timer: CALLBACK_TYPE | None = None
+
+        # Unique ID
+        self._unique_id = gen_uuid(f"{self.coordinator.unique_id} checkin_tracking")
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this sensor."""
+        return self._unique_id
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return f"{self.coordinator.name} Check-in"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info linking to the existing integration device."""
+        return self.coordinator.device_info
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes for the sensor.
+
+        Returns all tracked event attributes per data-model.md.
+        """
+        return {
+            "state": self._attr_native_value,
+            "summary": self._tracked_event_summary,
+            "start": (
+                self._tracked_event_start.isoformat()
+                if self._tracked_event_start
+                else None
+            ),
+            "end": (
+                self._tracked_event_end.isoformat() if self._tracked_event_end else None
+            ),
+            "guest_name": self._tracked_event_slot_name,
+            "checkin_source": self._checkin_source,
+            "checkout_source": self._checkout_source,
+            "checkout_time": (
+                self._checkout_time.isoformat() if self._checkout_time else None
+            ),
+            "next_transition": (
+                self._transition_target_time.isoformat()
+                if self._transition_target_time
+                else None
+            ),
+        }
+
+    @staticmethod
+    def _event_key(summary: str, start: datetime) -> str:
+        """Generate a unique identity key for an event.
+
+        Only summary and start are used for identity. The end time is
+        deliberately excluded so that post-checkout event extensions
+        (same summary + start but later end) are detected as the SAME
+        event rather than a new one, satisfying FR-007.
+
+        Args:
+            summary: The event summary text.
+            start: The event start datetime.
+
+        Returns:
+            A composite identity key string.
+        """
+        return f"{summary}|{start.isoformat()}"
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up when entity is being removed."""
+        if self._unsub_timer is not None:
+            self._unsub_timer()
+            self._unsub_timer = None
+        await super().async_will_remove_from_hass()

--- a/custom_components/rental_control/switch.py
+++ b/custom_components/rental_control/switch.py
@@ -9,13 +9,9 @@ expiry. Switch entities are only created when keymaster is configured.
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(

--- a/custom_components/rental_control/switch.py
+++ b/custom_components/rental_control/switch.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Switch platform for Rental Control.
+
+Provides toggle entities for keymaster monitoring and early checkout
+expiry. Switch entities are only created when keymaster is configured.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Rental Control switch entities.
+
+    Switch entities (keymaster monitoring, early checkout expiry) will
+    be created conditionally when keymaster is configured. Currently
+    a placeholder for Phase 5 implementation.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: The integration config entry.
+        async_add_entities: Callback to add entities.
+    """
+    # Phase 5 will add KeymasterMonitoringSwitch and
+    # EarlyCheckoutExpirySwitch here

--- a/tests/integration/test_full_setup.py
+++ b/tests/integration/test_full_setup.py
@@ -150,15 +150,15 @@ async def test_entities_created(
     ent_reg = er.async_get(hass)
     entities = er.async_entries_for_config_entry(ent_reg, mock_config_entry.entry_id)
 
-    # 1 calendar + max_events (3) sensors
-    assert len(entities) == 4
+    # 1 calendar + max_events (3) sensors + 1 checkin tracking sensor
+    assert len(entities) == 5
 
     domains = {e.domain for e in entities}
     assert "calendar" in domains
     assert "sensor" in domains
 
     sensor_entities = [e for e in entities if e.domain == "sensor"]
-    assert len(sensor_entities) == 3
+    assert len(sensor_entities) == 4
 
 
 # ---------------------------------------------------------------------------
@@ -340,10 +340,12 @@ async def test_sensor_entity_unique_id_format(
     sensor_entities = [e for e in entities if e.domain == "sensor"]
 
     max_events = mock_config_entry.data["max_events"]
-    assert len(sensor_entities) == max_events
+    assert len(sensor_entities) == max_events + 1  # +1 for checkin tracking sensor
     expected_uids = {
         gen_uuid(f"{mock_config_entry.unique_id} sensor {i}") for i in range(max_events)
     }
+    # Add the checkin tracking sensor unique_id
+    expected_uids.add(gen_uuid(f"{mock_config_entry.unique_id} checkin_tracking"))
     actual_uids = {e.unique_id for e in sensor_entities}
     assert actual_uids == expected_uids
 
@@ -403,11 +405,12 @@ async def test_entity_names_match_expected_format(
     assert len(calendar_entities) == 1
     assert calendar_entities[0].original_name == f"{NAME} {rental_name}"
 
-    # Sensor entity names: '{NAME} {rental_name} Event {N}'
+    # Sensor entity names: '{NAME} {rental_name} Event {N}' + '{rental_name} Check-in'
     max_events = mock_config_entry.data["max_events"]
     expected_sensor_names = {
         f"{NAME} {rental_name} Event {i}" for i in range(max_events)
     }
+    expected_sensor_names.add(f"{rental_name} Check-in")
     actual_sensor_names = {e.original_name for e in sensor_entities}
     assert actual_sensor_names == expected_sensor_names
 

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -22,6 +22,7 @@ from custom_components.rental_control.const import NAME
 from custom_components.rental_control.sensor import async_setup_entry
 from custom_components.rental_control.sensor import async_setup_platform
 from custom_components.rental_control.sensors.calsensor import RentalControlCalSensor
+from custom_components.rental_control.sensors.checkinsensor import CheckinTrackingSensor
 from custom_components.rental_control.util import gen_uuid
 
 
@@ -116,6 +117,7 @@ class TestAsyncSetupEntry:
         for i, sensor in enumerate(added_entities[:3]):
             assert isinstance(sensor, RentalControlCalSensor)
             assert sensor._event_number == i
+        assert isinstance(added_entities[3], CheckinTrackingSensor)
 
     async def test_returns_false_when_calendar_is_none(self, hass) -> None:
         """Verify async_setup_entry returns False when calendar fetch fails."""

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -112,8 +112,8 @@ class TestAsyncSetupEntry:
         await async_setup_entry(hass, config_entry, async_add_entities)
 
         assert async_add_entities.called
-        assert len(added_entities) == 3
-        for i, sensor in enumerate(added_entities):
+        assert len(added_entities) == 4  # 3 cal sensors + 1 checkin sensor
+        for i, sensor in enumerate(added_entities[:3]):
             assert isinstance(sensor, RentalControlCalSensor)
             assert sensor._event_number == i
 


### PR DESCRIPTION
## Phase 2: Foundational Skeleton

### Summary
Adds the foundational `CheckinTrackingSensor` skeleton and wires up all
platform registration so future phases can focus on behavior.

### Changes
- **`const.py`** — Added `SWITCH` to `PLATFORMS` list
- **`sensors/checkinsensor.py`** — NEW: `CheckinTrackingSensor` skeleton
  class inheriting `CoordinatorEntity` and `RestoreEntity`, with
  `unique_id`, `device_info`, `extra_state_attributes`, and
  `_event_key` static method (no state machine logic yet)
- **`sensor.py`** — Register `CheckinTrackingSensor` in
  `async_setup_entry` for every integration instance
- **`sensors/__init__.py`** — Export `CheckinTrackingSensor`
- **`switch.py`** — NEW: Stub switch platform for `SWITCH` in
  `PLATFORMS`
- **`tests/integration/test_full_setup.py`** — Updated entity counts
  (4→5 entities, 3→4 sensors) and name assertions for new checkin sensor
- **`tests/unit/test_sensors.py`** — Updated entity count (3→4) in
  `async_setup_entry` test

### Part of
Check-in/check-out tracking feature — Phase 2 of multi-phase
implementation (tasks.md: T004, T005, T006).