### PR TITLE
Feat(coordinator): Make update_event async

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -447,7 +447,7 @@ Please update Keymaster to at least v0.1.0-b0
         _LOGGER.debug("In update_event_overrides")
 
         if self.event_overrides:
-            self.event_overrides.update(
+            await self.event_overrides.async_update(
                 slot,
                 slot_code,
                 slot_name,

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -430,7 +430,7 @@ async def handle_state_change(
 
     if "_reset" in entity_id:
         _LOGGER.debug("Resetting overrides %s for %s.", slot_num, lockname)
-        coordinator.event_overrides.update(
+        await coordinator.event_overrides.async_update(
             slot_num, "", "", dt.start_of_local_day(), dt.start_of_local_day()
         )
         return

--- a/specs/005-fix-duplicate-slot/tasks.md
+++ b/specs/005-fix-duplicate-slot/tasks.md
@@ -96,12 +96,12 @@ tests/
 
 ### Tests for User Story 2
 
-- [ ] T016 [US2] Write unit tests for time-update path: guest in slot 10 with Mon–Fri, reserve again with Mon–Sat → `ReserveResult(10, False, True)` and stored times updated in `tests/unit/test_event_overrides.py`
-- [ ] T017 [US2] Write unit tests for identical-reservation no-op: guest in slot 10 with Mon–Fri, reserve again with Mon–Fri → `ReserveResult(10, False, False)` and no state changes in `tests/unit/test_event_overrides.py`
+- [x] T016 [US2] Write unit tests for time-update path: guest in slot 10 with Mon–Fri, reserve again with Mon–Sat → `ReserveResult(10, False, True)` and stored times updated in `tests/unit/test_event_overrides.py`
+- [x] T017 [US2] Write unit tests for identical-reservation no-op: guest in slot 10 with Mon–Fri, reserve again with Mon–Fri → `ReserveResult(10, False, False)` and no state changes in `tests/unit/test_event_overrides.py`
 
 ### Implementation for User Story 2
 
-- [ ] T018 [P] [US2] Adapt `update_event_overrides()` to be async and call `await self.event_overrides.async_update()` instead of sync `self.event_overrides.update()`; update all callers of `update_event_overrides()` (e.g., `handle_state_change` listener in `util.py`) to await it in `custom_components/rental_control/coordinator.py`
+- [x] T018 [P] [US2] Adapt `update_event_overrides()` to be async and call `await self.event_overrides.async_update()` instead of sync `self.event_overrides.update()`; update all callers of `update_event_overrides()` (e.g., `handle_state_change` listener in `util.py`) to await it in `custom_components/rental_control/coordinator.py`
 
 **Checkpoint**: Time updates and re-deliveries handled idempotently. Coordinator state-change path uses async_update.
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -399,6 +399,7 @@ async def test_coordinator_update_event_overrides_with_overrides(
 
     mock_overrides = MagicMock()
     mock_overrides.ready = True
+    mock_overrides.async_update = AsyncMock()
     coordinator.event_overrides = mock_overrides
     coordinator.async_request_refresh = AsyncMock()
 
@@ -411,7 +412,7 @@ async def test_coordinator_update_event_overrides_with_overrides(
         end_time=now + timedelta(days=2),
     )
 
-    mock_overrides.update.assert_called_once()
+    mock_overrides.async_update.assert_awaited_once()
     assert coordinator.async_request_refresh.called
 
 

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -17,6 +17,7 @@ import pytest
 
 from custom_components.rental_control.event_overrides import EventOverride
 from custom_components.rental_control.event_overrides import EventOverrides
+from custom_components.rental_control.event_overrides import ReserveResult
 
 # ---------------------------------------------------------------------------
 # Helpers / Fixtures
@@ -846,3 +847,76 @@ class TestEdgeCases:
             # "Current Guest" at index 0 stays
             assert eo.overrides[1] is not None
             assert eo.overrides[1]["slot_name"] == "Current Guest"
+
+
+# ---------------------------------------------------------------------------
+# Idempotent reservation (US2: async_reserve_or_get_slot)
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentReservation:
+    """Tests for idempotent reservation updates via async_reserve_or_get_slot."""
+
+    @pytest.mark.asyncio
+    async def test_time_update_returns_times_updated_true(self) -> None:
+        """Re-reserving with changed times updates the slot.
+
+        Guest in slot 10 with Mon-Fri, reserve again with Mon-Sat.
+        Expected: ReserveResult(10, False, True) and stored times
+        reflect the new end time.
+        """
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        now = dt_util.now()
+        # Bootstrap all slots so next_slot is computed
+        for s in (10, 11, 12):
+            eo.update(s, "", "", now, now)
+
+        mon = _make_dt(2025, 7, 7)
+        fri = _make_dt(2025, 7, 11)
+        sat = _make_dt(2025, 7, 12)
+
+        # Initial reservation: Mon-Fri
+        first = await eo.async_reserve_or_get_slot("Alice", "1234", mon, fri)
+        assert first == ReserveResult(10, True, False)
+
+        # Re-deliver with extended end: Mon-Sat
+        second = await eo.async_reserve_or_get_slot("Alice", "1234", mon, sat)
+        assert second == ReserveResult(10, False, True)
+
+        # Stored times reflect the update
+        override = eo.overrides[10]
+        assert override is not None
+        assert override["start_time"] == mon
+        assert override["end_time"] == sat
+
+    @pytest.mark.asyncio
+    async def test_identical_reservation_is_noop(self) -> None:
+        """Re-reserving with identical times is a no-op.
+
+        Guest in slot 10 with Mon-Fri, reserve again with Mon-Fri.
+        Expected: ReserveResult(10, False, False) and no state changes.
+        """
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        now = dt_util.now()
+        # Bootstrap all slots so next_slot is computed
+        for s in (10, 11, 12):
+            eo.update(s, "", "", now, now)
+
+        mon = _make_dt(2025, 7, 7)
+        fri = _make_dt(2025, 7, 11)
+
+        # Initial reservation: Mon-Fri
+        first = await eo.async_reserve_or_get_slot("Alice", "1234", mon, fri)
+        assert first == ReserveResult(10, True, False)
+
+        # Snapshot state before re-delivery
+        override_10 = eo.overrides[10]
+        assert override_10 is not None
+        before = override_10.copy()
+
+        # Re-deliver with identical times
+        second = await eo.async_reserve_or_get_slot("Alice", "1234", mon, fri)
+        assert second == ReserveResult(10, False, False)
+
+        # No state changes
+        assert eo.overrides[10] == before

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -959,6 +959,7 @@ class TestHandleStateChangeSlotExtraction:
         mock_coordinator = MagicMock()
         mock_coordinator.lockname = lockname
         mock_coordinator.event_overrides = MagicMock()
+        mock_coordinator.event_overrides.async_update = AsyncMock()
 
         hass = MagicMock()
         hass.data = {DOMAIN: {"entry_id": {COORDINATOR: mock_coordinator}}}
@@ -972,8 +973,8 @@ class TestHandleStateChangeSlotExtraction:
         with patch("custom_components.rental_control.util.asyncio.sleep"):
             await handle_state_change(hass, config_entry, event)
 
-        mock_coordinator.event_overrides.update.assert_called_once()
-        call_args = mock_coordinator.event_overrides.update.call_args
+        mock_coordinator.event_overrides.async_update.assert_awaited_once()
+        call_args = mock_coordinator.event_overrides.async_update.call_args
         assert call_args[0][0] == expected_slot
 
 
@@ -1381,7 +1382,7 @@ class TestSlugifiedLocknameEntityIds:
 
         await handle_state_change(hass, config_entry, event)
 
-        mock_coordinator.event_overrides.update.assert_not_called()
+        mock_coordinator.event_overrides.async_update.assert_not_called()
 
     async def test_state_change_returns_early_when_no_event_overrides(
         self,


### PR DESCRIPTION
## Phase 4: US2 — Idempotent Reservation Updates

### Tasks
- T016: Unit tests for time-update path
- T017: Unit tests for identical-reservation no-op
- T018: Convert `update_event_overrides()` to async

### What this does
Completes the async migration by converting the coordinator's `update_event_overrides()` to call `async_update()` instead of the sync `update()`, ensuring all post-bootstrap slot mutations go through the lock.

Also converts the `handle_state_change` reset path in `util.py` from sync `update()` to async `async_update()`.

Builds on Phase 2 (#429). Part of spec 005-fix-duplicate-slot.