### PR TITLE
Feat(calsensor): Wire atomic slot reservation

### DIFF
--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -325,6 +325,15 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             self._event_attributes["slot_name"] = slot_name
 
             slot_code = self._generate_door_code()
+
+            # Read-only lookup for display: show existing override code
+            # immediately rather than the generated fallback.  This is
+            # safe because it is not used for slot-assignment decisions.
+            overrides = self.coordinator.event_overrides
+            if overrides and slot_name is not None:
+                existing = overrides.get_slot_with_name(slot_name)
+                if existing and existing["slot_code"]:
+                    slot_code = str(existing["slot_code"])
             self._event_attributes["slot_code"] = slot_code
 
             # attributes parsed from description
@@ -352,10 +361,21 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
 
             self._parsed_attributes = parsed_attributes
 
-            # Schedule atomic slot assignment
-            overrides = self.coordinator.event_overrides
+            # Schedule atomic slot assignment with a snapshot of
+            # event data so the async task is immune to subsequent
+            # coordinator updates mutating self._event_attributes.
             if overrides and slot_name is not None:
-                self.hass.async_create_task(self._async_handle_slot_assignment())
+                uid: str | None = event.uid if hasattr(event, "uid") else None
+                self.hass.async_create_task(
+                    self._async_handle_slot_assignment(
+                        slot_name=slot_name,
+                        slot_code=slot_code,
+                        start_time=event.start,
+                        end_time=event.end,
+                        uid=uid,
+                        prefix=self.coordinator.event_prefix or "",
+                    )
+                )
 
         else:
             # No reservations
@@ -385,8 +405,21 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
 
         self.async_write_ha_state()
 
-    async def _async_handle_slot_assignment(self) -> None:
+    async def _async_handle_slot_assignment(
+        self,
+        *,
+        slot_name: str,
+        slot_code: str,
+        start_time: datetime,
+        end_time: datetime,
+        uid: str | None,
+        prefix: str,
+    ) -> None:
         """Atomically reserve or locate an existing slot for the current event.
+
+        All event data is captured at call-time so the coroutine is
+        immune to subsequent coordinator updates that could mutate
+        ``self._event_attributes`` before execution.
 
         Uses ``async_reserve_or_get_slot`` to eliminate the
         check-then-act race that previously existed between
@@ -395,22 +428,6 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         overrides = self.coordinator.event_overrides
         if overrides is None:
             return
-
-        slot_name: str | None = self._event_attributes.get("slot_name")
-        if slot_name is None:
-            return
-
-        slot_code: str = self._event_attributes.get("slot_code", "")
-        start_time: datetime = self._event_attributes["start"]
-        end_time: datetime = self._event_attributes["end"]
-
-        # Retrieve UID from the calendar event if still available
-        uid: str | None = None
-        event_list = self.coordinator.data
-        if event_list and self._event_number < len(event_list):
-            uid = event_list[self._event_number].uid
-
-        prefix = self.coordinator.event_prefix or ""
 
         result = await overrides.async_reserve_or_get_slot(
             slot_name=slot_name,

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -17,7 +17,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt
 
 from ..const import ICON
 from ..const import SECONDS_PER_HOUR
@@ -281,10 +280,6 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             self.async_write_ha_state()
             return
 
-        set_code = False
-        update_times = False
-        overrides = self.coordinator.event_overrides
-
         self._code_generator = self.coordinator.code_generator
         self._code_length = self.coordinator.code_length
         event_list = self.coordinator.data
@@ -329,28 +324,7 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             )
             self._event_attributes["slot_name"] = slot_name
 
-            override = None
-            if overrides and slot_name is not None:
-                override = overrides.get_slot_with_name(slot_name)
-            if override is None:
-                set_code = True
-
-            if (
-                not set_code
-                and override
-                and (
-                    dt.as_utc(override["start_time"]).date()
-                    != dt.as_utc(event.start).date()
-                    or dt.as_utc(override["end_time"]).date()
-                    != dt.as_utc(event.end).date()
-                )
-            ):
-                update_times = True
-
-            if override and override["slot_code"]:
-                slot_code = str(override["slot_code"])
-            else:
-                slot_code = self._generate_door_code()
+            slot_code = self._generate_door_code()
             self._event_attributes["slot_code"] = slot_code
 
             # attributes parsed from description
@@ -378,38 +352,10 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
 
             self._parsed_attributes = parsed_attributes
 
-            # Schedule async Keymaster side effects
-            if overrides and set_code and overrides.next_slot is not None:
-                self.hass.async_create_task(
-                    async_fire_set_code(
-                        self.coordinator,
-                        self,
-                        overrides.next_slot,
-                    )
-                )
-
-            if update_times:
-                if (
-                    self.coordinator.code_generator == "date_based"
-                    and self.coordinator.should_update_code
-                    and eta_days
-                    and eta_days > 0
-                ):
-                    assert overrides is not None
-                    assert slot_name is not None
-                    slot_key = overrides.get_slot_key_by_name(slot_name)
-                    _LOGGER.debug(
-                        "Clearing slot %s for sensor %s due to date shift",
-                        slot_key,
-                        self.name,
-                    )
-                    self.hass.async_create_task(
-                        async_fire_clear_code(self.coordinator, slot_key)
-                    )
-                else:
-                    self.hass.async_create_task(
-                        async_fire_update_times(self.coordinator, self)
-                    )
+            # Schedule atomic slot assignment
+            overrides = self.coordinator.event_overrides
+            if overrides and slot_name is not None:
+                self.hass.async_create_task(self._async_handle_slot_assignment())
 
         else:
             # No reservations
@@ -438,3 +384,70 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             self._state = summary
 
         self.async_write_ha_state()
+
+    async def _async_handle_slot_assignment(self) -> None:
+        """Atomically reserve or locate an existing slot for the current event.
+
+        Uses ``async_reserve_or_get_slot`` to eliminate the
+        check-then-act race that previously existed between
+        ``get_slot_with_name`` and ``next_slot`` reads.
+        """
+        overrides = self.coordinator.event_overrides
+        if overrides is None:
+            return
+
+        slot_name: str | None = self._event_attributes.get("slot_name")
+        if slot_name is None:
+            return
+
+        slot_code: str = self._event_attributes.get("slot_code", "")
+        start_time: datetime = self._event_attributes["start"]
+        end_time: datetime = self._event_attributes["end"]
+
+        # Retrieve UID from the calendar event if still available
+        uid: str | None = None
+        event_list = self.coordinator.data
+        if event_list and self._event_number < len(event_list):
+            uid = event_list[self._event_number].uid
+
+        prefix = self.coordinator.event_prefix or ""
+
+        result = await overrides.async_reserve_or_get_slot(
+            slot_name=slot_name,
+            slot_code=slot_code,
+            start_time=start_time,
+            end_time=end_time,
+            uid=uid,
+            prefix=prefix,
+        )
+
+        if result.slot is None:
+            return
+
+        if result.is_new:
+            await async_fire_set_code(self.coordinator, self, result.slot)
+            return
+
+        # Existing slot — update displayed code from the override
+        override = overrides.overrides.get(result.slot)
+        if override and override["slot_code"]:
+            self._event_attributes["slot_code"] = str(override["slot_code"])
+            self.async_write_ha_state()
+
+        if result.times_updated:
+            td = start_time - datetime.now(start_time.tzinfo)
+            eta_days = td.days if td.total_seconds() >= 0 else None
+            if (
+                self.coordinator.code_generator == "date_based"
+                and self.coordinator.should_update_code
+                and eta_days
+                and eta_days > 0
+            ):
+                _LOGGER.debug(
+                    "Clearing slot %s for sensor %s due to date shift",
+                    result.slot,
+                    self.name,
+                )
+                await async_fire_clear_code(self.coordinator, result.slot)
+            else:
+                await async_fire_update_times(self.coordinator, self)

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -376,6 +376,7 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
                         end_time=event.end,
                         uid=uid,
                         prefix=self.coordinator.event_prefix or "",
+                        eta_days=eta_days,
                     )
                 )
 
@@ -416,6 +417,7 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         end_time: datetime,
         uid: str | None,
         prefix: str,
+        eta_days: int | None,
     ) -> None:
         """Atomically reserve or locate an existing slot for the current event.
 
@@ -472,8 +474,6 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             self.async_write_ha_state()
 
         if result.times_updated:
-            td = start_time - datetime.now(start_time.tzinfo)
-            eta_days = td.days if td.total_seconds() >= 0 else None
             if (
                 self.coordinator.code_generator == "date_based"
                 and self.coordinator.should_update_code

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -364,7 +364,9 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             # Schedule atomic slot assignment with a snapshot of
             # event data so the async task is immune to subsequent
             # coordinator updates mutating self._event_attributes.
-            if overrides and slot_name is not None:
+            # Gate on overrides.ready to avoid spurious overflow
+            # warnings during bootstrap when _next_slot is still None.
+            if overrides and overrides.ready and slot_name is not None:
                 uid: str | None = event.uid if hasattr(event, "uid") else None
                 self.hass.async_create_task(
                     self._async_handle_slot_assignment(
@@ -439,6 +441,24 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         )
 
         if result.slot is None:
+            return
+
+        # Staleness guard: a subsequent coordinator update may have
+        # changed this sensor to a different event.  The reservation
+        # itself is still valid, but Keymaster side effects must not
+        # fire for a stale event.
+        current_attrs = self._event_attributes
+        if (
+            current_attrs.get("slot_name") != slot_name
+            or current_attrs.get("start") != start_time
+            or current_attrs.get("end") != end_time
+        ):
+            _LOGGER.debug(
+                "Slot assignment for '%s' is stale, skipping "
+                "Keymaster side effects for sensor %s",
+                slot_name,
+                self.name,
+            )
             return
 
         if result.is_new:

--- a/specs/005-fix-duplicate-slot/tasks.md
+++ b/specs/005-fix-duplicate-slot/tasks.md
@@ -75,14 +75,14 @@ tests/
 
 ### Tests for User Story 1
 
-- [ ] T011 [US1] Write unit tests for `async_reserve_or_get_slot()` new-reservation path: single reservation gets slot, two sequential reservations get different slots, verify `_next_slot` recalculated after each in `tests/unit/test_event_overrides.py`
-- [ ] T012 [US1] Write unit tests for `_find_overlapping_slot()`: same name + overlapping times returns existing slot; different name returns None; same name + non-overlapping times returns None (back-to-back stays) in `tests/unit/test_event_overrides.py`
-- [ ] T013 [US1] Write unit tests for slot overflow: all slots occupied → `async_reserve_or_get_slot()` returns `ReserveResult(None, False, False)` and logs warning in `tests/unit/test_event_overrides.py`
+- [x] T011 [US1] Write unit tests for `async_reserve_or_get_slot()` new-reservation path: single reservation gets slot, two sequential reservations get different slots, verify `_next_slot` recalculated after each in `tests/unit/test_event_overrides.py`
+- [x] T012 [US1] Write unit tests for `_find_overlapping_slot()`: same name + overlapping times returns existing slot; different name returns None; same name + non-overlapping times returns None (back-to-back stays) in `tests/unit/test_event_overrides.py`
+- [x] T013 [US1] Write unit tests for slot overflow: all slots occupied → `async_reserve_or_get_slot()` returns `ReserveResult(None, False, False)` and logs warning in `tests/unit/test_event_overrides.py`
 
 ### Implementation for User Story 1
 
-- [ ] T014 [P] [US1] Implement `async _async_handle_slot_assignment(self)` coroutine in `RentalControlCalSensor`: extract slot_name/code/times/uid from current event, call `await overrides.async_reserve_or_get_slot(...)`, if `result.is_new` call `await async_fire_set_code()`, if `result.times_updated` call `await async_fire_update_times()`, if `result.slot is None` return silently in `custom_components/rental_control/sensors/calsensor.py`
-- [ ] T015 [US1] Refactor `_handle_coordinator_update()` to remove direct `next_slot` reads and `get_slot_with_name()` slot-assignment decisions; instead extract event data and schedule `self.hass.async_create_task(self._async_handle_slot_assignment())` for slot operations in `custom_components/rental_control/sensors/calsensor.py`
+- [x] T014 [P] [US1] Implement `async _async_handle_slot_assignment(self)` coroutine in `RentalControlCalSensor`: extract slot_name/code/times/uid from current event, call `await overrides.async_reserve_or_get_slot(...)`, if `result.is_new` call `await async_fire_set_code()`, if `result.times_updated` call `await async_fire_update_times()`, if `result.slot is None` return silently in `custom_components/rental_control/sensors/calsensor.py`
+- [x] T015 [US1] Refactor `_handle_coordinator_update()` to remove direct `next_slot` reads and `get_slot_with_name()` slot-assignment decisions; instead extract event data and schedule `self.hass.async_create_task(self._async_handle_slot_assignment())` for slot operations in `custom_components/rental_control/sensors/calsensor.py`
 
 **Checkpoint**: Core race condition fix is functional. Concurrent sensors serialize through the lock; each guest gets a unique slot.
 

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
+import logging
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -17,6 +18,7 @@ import pytest
 
 from custom_components.rental_control.event_overrides import EventOverride
 from custom_components.rental_control.event_overrides import EventOverrides
+from custom_components.rental_control.event_overrides import ReserveResult
 
 # ---------------------------------------------------------------------------
 # Helpers / Fixtures
@@ -846,3 +848,207 @@ class TestEdgeCases:
             # "Current Guest" at index 0 stays
             assert eo.overrides[1] is not None
             assert eo.overrides[1]["slot_name"] == "Current Guest"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — async_reserve_or_get_slot & _find_overlapping_slot Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncReserveOrGetSlotNewReservation:
+    """T011: Tests for async_reserve_or_get_slot() new-reservation path."""
+
+    async def test_single_reservation_gets_slot(
+        self, populated_eo: EventOverrides
+    ) -> None:
+        """A single new reservation should receive a valid slot."""
+        result = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+        )
+        assert result.slot is not None
+        assert result.is_new is True
+        assert result.times_updated is False
+        override = populated_eo.overrides[result.slot]
+        assert override is not None
+        assert override["slot_name"] == "Alice"
+
+    async def test_two_sequential_reservations_get_different_slots(
+        self, populated_eo: EventOverrides
+    ) -> None:
+        """Two distinct reservations must receive different slots."""
+        r1 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+        )
+        r2 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Bob",
+            slot_code="5678",
+            start_time=_make_dt(2025, 8, 6),
+            end_time=_make_dt(2025, 8, 10),
+        )
+        assert r1.slot is not None
+        assert r2.slot is not None
+        assert r1.slot != r2.slot
+        assert r1.is_new is True
+        assert r2.is_new is True
+
+    async def test_next_slot_recalculated_after_each_reservation(
+        self, populated_eo: EventOverrides
+    ) -> None:
+        """_next_slot should advance after each successful reservation."""
+        initial_next = populated_eo.next_slot
+        assert initial_next is not None
+
+        r1 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+        )
+        after_first = populated_eo.next_slot
+        assert after_first != initial_next
+
+        r2 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Bob",
+            slot_code="5678",
+            start_time=_make_dt(2025, 8, 6),
+            end_time=_make_dt(2025, 8, 10),
+        )
+        after_second = populated_eo.next_slot
+        assert after_second != after_first
+        assert r1.slot != r2.slot
+
+
+class TestFindOverlappingSlot:
+    """T012: Tests for _find_overlapping_slot() identity matching."""
+
+    async def test_same_name_overlapping_times_returns_existing(
+        self, populated_eo: EventOverrides
+    ) -> None:
+        """Same guest name with overlapping dates returns the existing slot."""
+        r1 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 10),
+        )
+        assert r1.is_new is True
+
+        # Same name, overlapping range
+        r2 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 5),
+            end_time=_make_dt(2025, 8, 15),
+        )
+        assert r2.slot == r1.slot
+        assert r2.is_new is False
+
+    async def test_different_name_returns_none_reserves_new(
+        self, populated_eo: EventOverrides
+    ) -> None:
+        """Different guest name should not match existing slot."""
+        r1 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 10),
+        )
+        r2 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Bob",
+            slot_code="5678",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 10),
+        )
+        assert r2.slot != r1.slot
+        assert r2.is_new is True
+
+    async def test_same_name_non_overlapping_returns_none_reserves_new(
+        self, populated_eo: EventOverrides
+    ) -> None:
+        """Same name with non-overlapping (back-to-back) stays gets new slot."""
+        r1 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+        )
+        # Back-to-back: starts exactly when previous ends
+        r2 = await populated_eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="5678",
+            start_time=_make_dt(2025, 8, 5),
+            end_time=_make_dt(2025, 8, 10),
+        )
+        assert r2.slot != r1.slot
+        assert r2.is_new is True
+
+
+class TestSlotOverflow:
+    """T013: Tests for slot overflow when all slots are occupied."""
+
+    async def test_overflow_returns_none(self) -> None:
+        """All slots occupied returns ReserveResult(None, False, False)."""
+        eo = EventOverrides(start_slot=1, max_slots=2)
+        now = dt_util.now()
+        # Initialize all slots as empty (system ready)
+        eo.update(1, "", "", now, now)
+        eo.update(2, "", "", now, now)
+
+        # Fill both slots
+        r1 = await eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+        )
+        r2 = await eo.async_reserve_or_get_slot(
+            slot_name="Bob",
+            slot_code="5678",
+            start_time=_make_dt(2025, 8, 6),
+            end_time=_make_dt(2025, 8, 10),
+        )
+        assert r1.is_new is True
+        assert r2.is_new is True
+
+        # Third reservation should overflow
+        r3 = await eo.async_reserve_or_get_slot(
+            slot_name="Charlie",
+            slot_code="9012",
+            start_time=_make_dt(2025, 8, 11),
+            end_time=_make_dt(2025, 8, 15),
+        )
+        assert r3 == ReserveResult(None, False, False)
+
+    async def test_overflow_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Overflow should log a warning with guest name."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = dt_util.now()
+        eo.update(1, "", "", now, now)
+
+        # Fill the single slot
+        await eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+        )
+
+        # Attempt overflow
+        with caplog.at_level(logging.WARNING):
+            result = await eo.async_reserve_or_get_slot(
+                slot_name="Bob",
+                slot_code="5678",
+                start_time=_make_dt(2025, 8, 6),
+                end_time=_make_dt(2025, 8, 10),
+            )
+        assert result.slot is None
+        assert "Bob" in caplog.text
+        assert "occupied" in caplog.text

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -990,6 +990,7 @@ class TestHandleCoordinatorUpdateOverrides:
         """Verify async_fire_set_code is called when slot is newly reserved."""
         event = _make_event()
         overrides = MagicMock()
+        overrides.ready = True
         overrides.get_slot_with_name.return_value = None
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, True, False)
@@ -1018,6 +1019,7 @@ class TestHandleCoordinatorUpdateOverrides:
             "end_time": event.end,
         }
         overrides = MagicMock()
+        overrides.ready = True
         overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, False)
@@ -1055,6 +1057,40 @@ class TestHandleCoordinatorUpdateOverrides:
         assert attrs["slot_code"].isdigit()
 
     @freeze_time("2025-03-10T12:00:00+00:00")
+    async def test_generates_code_when_override_has_no_code(self, hass) -> None:
+        """Verify code is generated when override exists but has no slot_code."""
+        event = _make_event()
+        override = {
+            "slot_code": None,
+            "start_time": event.start,
+            "end_time": event.end,
+        }
+        overrides = MagicMock()
+        overrides.ready = True
+        overrides.get_slot_with_name.return_value = override
+        overrides.async_reserve_or_get_slot = AsyncMock(
+            return_value=ReserveResult(10, False, False)
+        )
+        overrides.overrides = {10: override}
+        coordinator = _make_coordinator(
+            data=[event], event_overrides=overrides, code_generator="date_based"
+        )
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        # Code is generated since override has no slot_code
+        attrs = sensor.extra_state_attributes
+        assert attrs["slot_code"] is not None
+        assert attrs["slot_code"].isdigit()
+
+        # Await the scheduled task to avoid unawaited coroutine warning
+        coro = sensor.hass.async_create_task.call_args[0][0]
+        await coro
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
     async def test_fires_update_times_when_dates_change(self, hass) -> None:
         """Verify async_fire_update_times is called when times_updated is True."""
         event = _make_event(
@@ -1067,6 +1103,7 @@ class TestHandleCoordinatorUpdateOverrides:
             "end_time": event.end,
         }
         overrides = MagicMock()
+        overrides.ready = True
         overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, True)
@@ -1103,6 +1140,7 @@ class TestHandleCoordinatorUpdateOverrides:
             "end_time": event.end,
         }
         overrides = MagicMock()
+        overrides.ready = True
         overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, True)
@@ -1153,6 +1191,7 @@ class TestHandleCoordinatorUpdateOverrides:
             "end_time": event.end,
         }
         overrides = MagicMock()
+        overrides.ready = True
         overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, False)
@@ -1190,6 +1229,7 @@ class TestHandleCoordinatorUpdateOverrides:
             "end_time": event.end,
         }
         overrides = MagicMock()
+        overrides.ready = True
         overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, True)

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -990,6 +990,7 @@ class TestHandleCoordinatorUpdateOverrides:
         """Verify async_fire_set_code is called when slot is newly reserved."""
         event = _make_event()
         overrides = MagicMock()
+        overrides.get_slot_with_name.return_value = None
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, True, False)
         )
@@ -1009,29 +1010,32 @@ class TestHandleCoordinatorUpdateOverrides:
 
     @freeze_time("2025-03-10T12:00:00+00:00")
     async def test_uses_override_slot_code(self, hass) -> None:
-        """Verify slot_code from override takes precedence after async reservation."""
+        """Verify slot_code from override is displayed immediately in sync path."""
         event = _make_event()
+        override = {
+            "slot_code": "5555",
+            "start_time": event.start,
+            "end_time": event.end,
+        }
         overrides = MagicMock()
+        overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, False)
         )
-        overrides.overrides = {
-            10: {
-                "slot_code": "5555",
-                "start_time": event.start,
-                "end_time": event.end,
-            }
-        }
+        overrides.overrides = {10: override}
         coordinator = _make_coordinator(data=[event], event_overrides=overrides)
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
         sensor.async_write_ha_state = MagicMock()
 
         sensor._handle_coordinator_update()
+
+        # Code is available immediately from the sync read-only lookup
+        assert sensor.extra_state_attributes["slot_code"] == "5555"
+
+        # Await the scheduled task to avoid unawaited coroutine warning
         coro = sensor.hass.async_create_task.call_args[0][0]
         await coro
-
-        assert sensor.extra_state_attributes["slot_code"] == "5555"
 
     @freeze_time("2025-03-10T12:00:00+00:00")
     def test_generates_code_when_no_override(self, hass) -> None:
@@ -1057,17 +1061,17 @@ class TestHandleCoordinatorUpdateOverrides:
             start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
             end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
         )
+        override = {
+            "slot_code": "1234",
+            "start_time": event.start,
+            "end_time": event.end,
+        }
         overrides = MagicMock()
+        overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, True)
         )
-        overrides.overrides = {
-            10: {
-                "slot_code": "1234",
-                "start_time": event.start,
-                "end_time": event.end,
-            }
-        }
+        overrides.overrides = {10: override}
         coordinator = _make_coordinator(
             data=[event],
             event_overrides=overrides,
@@ -1093,17 +1097,17 @@ class TestHandleCoordinatorUpdateOverrides:
             start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
             end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
         )
+        override = {
+            "slot_code": "1234",
+            "start_time": event.start,
+            "end_time": event.end,
+        }
         overrides = MagicMock()
+        overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, True)
         )
-        overrides.overrides = {
-            10: {
-                "slot_code": "1234",
-                "start_time": event.start,
-                "end_time": event.end,
-            }
-        }
+        overrides.overrides = {10: override}
         coordinator = _make_coordinator(
             data=[event],
             event_overrides=overrides,
@@ -1143,17 +1147,17 @@ class TestHandleCoordinatorUpdateOverrides:
     async def test_no_set_code_when_existing_reservation(self, hass) -> None:
         """Verify set_code is not called when reservation already has a slot."""
         event = _make_event()
+        override = {
+            "slot_code": "1234",
+            "start_time": event.start,
+            "end_time": event.end,
+        }
         overrides = MagicMock()
+        overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, False)
         )
-        overrides.overrides = {
-            10: {
-                "slot_code": "1234",
-                "start_time": event.start,
-                "end_time": event.end,
-            }
-        }
+        overrides.overrides = {10: override}
         coordinator = _make_coordinator(data=[event], event_overrides=overrides)
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
@@ -1180,17 +1184,17 @@ class TestHandleCoordinatorUpdateOverrides:
             start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
             end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
         )
+        override = {
+            "slot_code": "1234",
+            "start_time": event.start,
+            "end_time": event.end,
+        }
         overrides = MagicMock()
+        overrides.get_slot_with_name.return_value = override
         overrides.async_reserve_or_get_slot = AsyncMock(
             return_value=ReserveResult(10, False, True)
         )
-        overrides.overrides = {
-            10: {
-                "slot_code": "1234",
-                "start_time": event.start,
-                "end_time": event.end,
-            }
-        }
+        overrides.overrides = {10: override}
         coordinator = _make_coordinator(
             data=[event],
             event_overrides=overrides,

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -19,6 +19,7 @@ from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.const import ICON
 from custom_components.rental_control.const import NAME
+from custom_components.rental_control.event_overrides import ReserveResult
 from custom_components.rental_control.sensor import async_setup_entry
 from custom_components.rental_control.sensor import async_setup_platform
 from custom_components.rental_control.sensors.calsensor import RentalControlCalSensor
@@ -985,12 +986,13 @@ class TestHandleCoordinatorUpdateOverrides:
     """Tests for _handle_coordinator_update interactions with event_overrides."""
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    def test_fires_set_code_when_no_override(self, hass) -> None:
-        """Verify async_fire_set_code is scheduled when slot not in overrides."""
+    async def test_fires_set_code_when_new_reservation(self, hass) -> None:
+        """Verify async_fire_set_code is called when slot is newly reserved."""
         event = _make_event()
         overrides = MagicMock()
-        overrides.get_slot_with_name.return_value = None
-        overrides.next_slot = 10
+        overrides.async_reserve_or_get_slot = AsyncMock(
+            return_value=ReserveResult(10, True, False)
+        )
         coordinator = _make_coordinator(data=[event], event_overrides=overrides)
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
@@ -1001,42 +1003,42 @@ class TestHandleCoordinatorUpdateOverrides:
             new_callable=AsyncMock,
         ) as mock_set_code:
             sensor._handle_coordinator_update()
+            coro = sensor.hass.async_create_task.call_args[0][0]
+            await coro
             mock_set_code.assert_called_once_with(coordinator, sensor, 10)
-            sensor.hass.async_create_task.assert_called_once()
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    def test_uses_override_slot_code(self, hass) -> None:
-        """Verify slot_code from override takes precedence over generated code."""
+    async def test_uses_override_slot_code(self, hass) -> None:
+        """Verify slot_code from override takes precedence after async reservation."""
         event = _make_event()
-        override = {
-            "slot_code": "5555",
-            "start_time": event.start,
-            "end_time": event.end,
-        }
         overrides = MagicMock()
-        overrides.get_slot_with_name.return_value = override
+        overrides.async_reserve_or_get_slot = AsyncMock(
+            return_value=ReserveResult(10, False, False)
+        )
+        overrides.overrides = {
+            10: {
+                "slot_code": "5555",
+                "start_time": event.start,
+                "end_time": event.end,
+            }
+        }
         coordinator = _make_coordinator(data=[event], event_overrides=overrides)
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
         sensor.async_write_ha_state = MagicMock()
 
         sensor._handle_coordinator_update()
+        coro = sensor.hass.async_create_task.call_args[0][0]
+        await coro
 
         assert sensor.extra_state_attributes["slot_code"] == "5555"
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    def test_generates_code_when_override_has_no_code(self, hass) -> None:
-        """Verify code is generated when override exists but has no slot_code."""
+    def test_generates_code_when_no_override(self, hass) -> None:
+        """Verify code is always generated synchronously in coordinator update."""
         event = _make_event()
-        override = {
-            "slot_code": None,
-            "start_time": event.start,
-            "end_time": event.end,
-        }
-        overrides = MagicMock()
-        overrides.get_slot_with_name.return_value = override
         coordinator = _make_coordinator(
-            data=[event], event_overrides=overrides, code_generator="date_based"
+            data=[event], event_overrides=None, code_generator="date_based"
         )
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
@@ -1049,19 +1051,23 @@ class TestHandleCoordinatorUpdateOverrides:
         assert attrs["slot_code"].isdigit()
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    def test_fires_update_times_when_dates_change(self, hass) -> None:
-        """Verify async_fire_update_times is scheduled when override dates differ."""
+    async def test_fires_update_times_when_dates_change(self, hass) -> None:
+        """Verify async_fire_update_times is called when times_updated is True."""
         event = _make_event(
             start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
             end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
         )
-        override = {
-            "slot_code": "1234",
-            "start_time": datetime(2025, 3, 14, 16, 0, tzinfo=timezone.utc),
-            "end_time": datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
-        }
         overrides = MagicMock()
-        overrides.get_slot_with_name.return_value = override
+        overrides.async_reserve_or_get_slot = AsyncMock(
+            return_value=ReserveResult(10, False, True)
+        )
+        overrides.overrides = {
+            10: {
+                "slot_code": "1234",
+                "start_time": event.start,
+                "end_time": event.end,
+            }
+        }
         coordinator = _make_coordinator(
             data=[event],
             event_overrides=overrides,
@@ -1076,24 +1082,28 @@ class TestHandleCoordinatorUpdateOverrides:
             new_callable=AsyncMock,
         ) as mock_update_times:
             sensor._handle_coordinator_update()
+            coro = sensor.hass.async_create_task.call_args[0][0]
+            await coro
             mock_update_times.assert_called_once_with(coordinator, sensor)
-            sensor.hass.async_create_task.assert_called_once()
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    def test_fires_clear_code_on_date_shift_date_based(self, hass) -> None:
-        """Verify async_fire_clear_code is scheduled on date shift with date_based generator."""
+    async def test_fires_clear_code_on_date_shift_date_based(self, hass) -> None:
+        """Verify async_fire_clear_code is called on date shift with date_based generator."""
         event = _make_event(
             start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
             end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
         )
-        override = {
-            "slot_code": "1234",
-            "start_time": datetime(2025, 3, 14, 16, 0, tzinfo=timezone.utc),
-            "end_time": datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
-        }
         overrides = MagicMock()
-        overrides.get_slot_with_name.return_value = override
-        overrides.get_slot_key_by_name.return_value = 10
+        overrides.async_reserve_or_get_slot = AsyncMock(
+            return_value=ReserveResult(10, False, True)
+        )
+        overrides.overrides = {
+            10: {
+                "slot_code": "1234",
+                "start_time": event.start,
+                "end_time": event.end,
+            }
+        }
         coordinator = _make_coordinator(
             data=[event],
             event_overrides=overrides,
@@ -1109,8 +1119,9 @@ class TestHandleCoordinatorUpdateOverrides:
             new_callable=AsyncMock,
         ) as mock_clear_code:
             sensor._handle_coordinator_update()
+            coro = sensor.hass.async_create_task.call_args[0][0]
+            await coro
             mock_clear_code.assert_called_once_with(coordinator, 10)
-            sensor.hass.async_create_task.assert_called_once()
 
     @freeze_time("2025-03-10T12:00:00+00:00")
     def test_no_override_interactions_when_overrides_none(self, hass) -> None:
@@ -1129,16 +1140,20 @@ class TestHandleCoordinatorUpdateOverrides:
             mock_set_code.assert_not_called()
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    def test_no_set_code_when_override_exists(self, hass) -> None:
-        """Verify set_code is not called when slot already has an override."""
+    async def test_no_set_code_when_existing_reservation(self, hass) -> None:
+        """Verify set_code is not called when reservation already has a slot."""
         event = _make_event()
-        override = {
-            "slot_code": "1234",
-            "start_time": event.start,
-            "end_time": event.end,
-        }
         overrides = MagicMock()
-        overrides.get_slot_with_name.return_value = override
+        overrides.async_reserve_or_get_slot = AsyncMock(
+            return_value=ReserveResult(10, False, False)
+        )
+        overrides.overrides = {
+            10: {
+                "slot_code": "1234",
+                "start_time": event.start,
+                "end_time": event.end,
+            }
+        }
         coordinator = _make_coordinator(data=[event], event_overrides=overrides)
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
@@ -1149,10 +1164,12 @@ class TestHandleCoordinatorUpdateOverrides:
             new_callable=AsyncMock,
         ) as mock_set_code:
             sensor._handle_coordinator_update()
+            coro = sensor.hass.async_create_task.call_args[0][0]
+            await coro
             mock_set_code.assert_not_called()
 
     @freeze_time("2025-03-15T12:00:00+00:00")
-    def test_updates_times_not_clear_when_eta_days_zero(self, hass) -> None:
+    async def test_updates_times_not_clear_when_eta_days_zero(self, hass) -> None:
         """Verify update_times (not clear_code) is called when eta_days is 0.
 
         When event starts today (eta_days=0), the clear_code branch requires
@@ -1163,13 +1180,17 @@ class TestHandleCoordinatorUpdateOverrides:
             start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
             end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
         )
-        override = {
-            "slot_code": "1234",
-            "start_time": datetime(2025, 3, 14, 16, 0, tzinfo=timezone.utc),
-            "end_time": datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
-        }
         overrides = MagicMock()
-        overrides.get_slot_with_name.return_value = override
+        overrides.async_reserve_or_get_slot = AsyncMock(
+            return_value=ReserveResult(10, False, True)
+        )
+        overrides.overrides = {
+            10: {
+                "slot_code": "1234",
+                "start_time": event.start,
+                "end_time": event.end,
+            }
+        }
         coordinator = _make_coordinator(
             data=[event],
             event_overrides=overrides,
@@ -1191,5 +1212,7 @@ class TestHandleCoordinatorUpdateOverrides:
             ) as mock_update_times,
         ):
             sensor._handle_coordinator_update()
+            coro = sensor.hass.async_create_task.call_args[0][0]
+            await coro
             mock_clear_code.assert_not_called()
             mock_update_times.assert_called_once_with(coordinator, sensor)


### PR DESCRIPTION
## Phase 3: US1 — Concurrent Reservations Get Unique Slots (MVP)

### Tasks
- T011: Unit tests for reserve new-reservation path
- T012: Unit tests for `_find_overlapping_slot()` identity matching
- T013: Unit tests for slot overflow
- T014: `_async_handle_slot_assignment()` coroutine
- T015: Refactor `_handle_coordinator_update()` to use atomic reservation

### What this fixes
Eliminates the TOCTOU race condition where multiple sensors could simultaneously read `next_slot` and `get_slot_with_name()`, leading to duplicate slot assignments.

### How
Sensors now call `await overrides.async_reserve_or_get_slot()` which atomically checks existence and reserves under a single lock acquisition.

Builds on Phase 2 (#429). Part of spec 005-fix-duplicate-slot.