### PR TITLE
CI(audit): ignore pygments CVE-2026-4539

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -140,9 +140,11 @@ jobs:
         with:
           python_version: "${{ matrix.python-version }}"
           # pillow transitive dep CVEs (via homeassistant)
+          # pygments ReDoS in AdlLexer (CVE-2026-4539)
           ignore_vulns: >-
             GHSA-4xh5-x5gv-qwph
             GHSA-cfh3-3jmp-rvhc
+            CVE-2026-4539
 
   sbom:
     name: 'Generate SBOM'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -189,9 +189,11 @@ jobs:
         with:
           python_version: "${{ matrix.python-version }}"
           # pillow transitive dep CVEs (via homeassistant)
+          # pygments ReDoS in AdlLexer (CVE-2026-4539)
           ignore_vulns: >-
             GHSA-4xh5-x5gv-qwph
             GHSA-cfh3-3jmp-rvhc
+            CVE-2026-4539
 
   sbom:
     name: 'Generate SBOM'

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -51,3 +51,12 @@ ignore:
     package:
       name: pyOpenSSL
       type: python
+
+  # pygments transitive dependency via homeassistant —
+  # ReDoS in AdlLexer (CVE-2026-4539), no fix version
+  # available yet. We cannot pin pygments directly
+  # because it comes from homeassistant.
+  - vulnerability: CVE-2026-4539
+    package:
+      name: pygments
+      type: python


### PR DESCRIPTION
## Ignore upstream pygments vulnerability

**CVE-2026-4539**: ReDoS in pygments AdlLexer (pygments/lexers/archetype.py). No fix version available yet. Transitive dependency via homeassistant — cannot pin directly.

Unblocks dependabot PR #440.

### Changes
- `.github/workflows/build-test.yaml`: Added to `ignore_vulns`
- `.github/workflows/release.yaml`: Added to `ignore_vulns`
- `.grype.yaml`: Added ignore entry