### PR TITLE
Fix(checkin): block auto check-in with monitoring

### DIFF
--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -42,6 +42,7 @@ from ..const import DOMAIN
 from ..const import EARLY_CHECKOUT_EXPIRY_SWITCH
 from ..const import EVENT_RENTAL_CONTROL_CHECKIN
 from ..const import EVENT_RENTAL_CONTROL_CHECKOUT
+from ..const import KEYMASTER_MONITORING_SWITCH
 from ..util import add_call
 from ..util import check_gather_results
 from ..util import compute_early_expiry_time
@@ -391,6 +392,19 @@ class CheckinTrackingSensor(
             self.coordinator.event_prefix or "",
         )
 
+    def _is_keymaster_monitoring_enabled(self) -> bool:
+        """Return True when keymaster monitoring is switched on.
+
+        Looks up the :class:`KeymasterMonitoringSwitch` stored in
+        ``hass.data`` for this config entry.  Returns ``False`` when
+        the switch entity is missing or turned off.
+        """
+        entry_data = self._hass.data.get(DOMAIN, {}).get(
+            self._config_entry.entry_id, {}
+        )
+        monitoring_switch = entry_data.get(KEYMASTER_MONITORING_SWITCH)
+        return monitoring_switch is not None and monitoring_switch.is_on
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator.
@@ -515,10 +529,13 @@ class CheckinTrackingSensor(
                 event.start,
             )
         else:
-            # Event start already passed - auto check-in immediately
+            # Event start already passed — auto check-in only if
+            # keymaster monitoring is disabled; otherwise stay in
+            # awaiting_checkin until the guest uses their code.
             self._transition_target_time = None
-            self._transition_to_checked_in(source="automatic")
-            return
+            if not self._is_keymaster_monitoring_enabled():
+                self._transition_to_checked_in(source="automatic")
+                return
 
         self.async_write_ha_state()
 
@@ -741,13 +758,27 @@ class CheckinTrackingSensor(
     def _async_auto_checkin_callback(self, _now: datetime) -> None:
         """Timer callback for automatic check-in at event start time.
 
+        When keymaster monitoring is enabled the sensor must stay in
+        ``awaiting_checkin`` until the guest actually uses their door
+        code, so the automatic transition is skipped.
+
         Args:
             _now: The current time when the callback fires.
         """
         _LOGGER.debug("Auto check-in timer fired for %s", self.coordinator.name)
         self._unsub_timer = None
-        if self._state == CHECKIN_STATE_AWAITING:
-            self._transition_to_checked_in(source="automatic")
+        if self._state != CHECKIN_STATE_AWAITING:
+            return
+        if self._is_keymaster_monitoring_enabled():
+            _LOGGER.debug(
+                "Keymaster monitoring is on; staying in awaiting_checkin "
+                "until door code is used for %s",
+                self.coordinator.name,
+            )
+            self._transition_target_time = None
+            self.async_write_ha_state()
+            return
+        self._transition_to_checked_in(source="automatic")
 
     @callback
     def _async_auto_checkout_callback(self, _now: datetime) -> None:
@@ -1026,10 +1057,12 @@ class CheckinTrackingSensor(
             if (
                 self._tracked_event_start is not None
                 and self._tracked_event_start <= now
+                and not self._is_keymaster_monitoring_enabled()
             ):
                 # Event start passed while we were down → silent checkin
                 # (no HA bus event to avoid triggering automations on
-                # restart catch-up).
+                # restart catch-up).  Skipped when keymaster monitoring
+                # is enabled — the guest must use their door code.
                 _LOGGER.debug(
                     "Stale restore: awaiting_checkin but start passed, "
                     "transitioning to checked_in (silent)"

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -41,6 +41,7 @@ from custom_components.rental_control.const import EARLY_CHECKOUT_EXPIRY_SWITCH
 from custom_components.rental_control.const import EARLY_CHECKOUT_GRACE_MINUTES
 from custom_components.rental_control.const import EVENT_RENTAL_CONTROL_CHECKIN
 from custom_components.rental_control.const import EVENT_RENTAL_CONTROL_CHECKOUT
+from custom_components.rental_control.const import KEYMASTER_MONITORING_SWITCH
 from custom_components.rental_control.const import UNSUB_LISTENERS
 from custom_components.rental_control.sensors.checkinsensor import CheckinTrackingSensor
 
@@ -1255,6 +1256,60 @@ class TestStaleStateValidation:
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
         assert sensor._checkin_source == "automatic"
 
+    async def test_awaiting_stays_awaiting_on_restore_with_monitoring(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test restored awaiting stays awaiting when monitoring is on.
+
+        When keymaster monitoring is enabled and HA restarts with
+        awaiting_checkin state whose start has already passed, the
+        sensor must NOT silently transition to checked_in.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        # Monitoring switch is ON
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=True),
+        }
+
+        now = dt_util.now()
+        start = now - timedelta(hours=2)
+        end = now + timedelta(hours=48)
+
+        data_dict = _make_extra_data_dict(
+            state=CHECKIN_STATE_AWAITING,
+            summary="Reserved - John Smith",
+            start=start,
+            end=end,
+            slot_name="John Smith",
+            checkin_source=None,
+            transition_target_time=start,
+        )
+
+        event = _make_event(
+            summary="Reserved - John Smith",
+            start=start,
+            end=end,
+        )
+        mock_checkin_coordinator.data = [event]
+        mock_checkin_coordinator.last_update_success = True
+
+        with patch.object(
+            sensor,
+            "async_get_last_extra_data",
+            new=AsyncMock(return_value=_mock_extra_data(data_dict)),
+        ):
+            await sensor.async_added_to_hass()
+
+        assert sensor._state == CHECKIN_STATE_AWAITING
+        assert sensor._checkin_source is None
+
     async def test_checked_out_transitions_to_awaiting_when_new_event(
         self,
         hass: HomeAssistant,
@@ -1943,12 +1998,11 @@ class TestToggleMidEvent:
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Test time-based fallback fires at event start regardless of toggle.
+        """Test time-based auto check-in fires when monitoring is off.
 
-        The auto check-in timer is always scheduled at event start
-        regardless of monitoring switch state.  When monitoring is off,
-        the listener blocks keymaster events, and only the time-based
-        callback fires.
+        When keymaster monitoring is explicitly disabled the auto
+        check-in timer callback should transition to checked_in at
+        event start time.
         """
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
@@ -1956,6 +2010,12 @@ class TestToggleMidEvent:
         mock_checkin_coordinator.lockname = "test_lock"
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
+
+        # Explicitly register monitoring switch as OFF
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=False),
+        }
 
         # Set up sensor in awaiting state with future event
         future_start = dt_util.now() + timedelta(hours=2)
@@ -1973,6 +2033,125 @@ class TestToggleMidEvent:
         sensor._async_auto_checkin_callback(future_start)
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
         assert sensor._checkin_source == "automatic"
+
+    async def test_monitoring_on_blocks_auto_checkin_callback(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test auto check-in callback is suppressed when monitoring on.
+
+        When keymaster monitoring is enabled the timer callback must
+        NOT transition to checked_in — the sensor should remain in
+        awaiting_checkin until the guest actually uses their door code.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = "test_lock"
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        # Monitoring switch is ON
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=True),
+        }
+
+        # Set up sensor in awaiting state with future event
+        future_start = dt_util.now() + timedelta(hours=2)
+        event = _make_event(start=future_start)
+        mock_checkin_coordinator.data = [event]
+        mock_checkin_coordinator.last_update_success = True
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+
+        # Timer fires — but monitoring is on so no transition
+        sensor._async_auto_checkin_callback(future_start)
+        assert sensor._state == CHECKIN_STATE_AWAITING
+        assert sensor._checkin_source is None
+
+    async def test_monitoring_on_blocks_immediate_auto_checkin(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test past-start event stays awaiting when monitoring is on.
+
+        When a new event whose start time has already passed is picked
+        up by the coordinator update, _transition_to_awaiting should
+        NOT immediately transition to checked_in if keymaster
+        monitoring is enabled.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = "test_lock"
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        # Monitoring switch is ON
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=True),
+        }
+
+        # Event whose start has already passed
+        event = _make_event(
+            start=dt_util.now() - timedelta(hours=1),
+            end=dt_util.now() + timedelta(hours=48),
+        )
+        mock_checkin_coordinator.data = [event]
+        mock_checkin_coordinator.last_update_success = True
+
+        sensor._handle_coordinator_update()
+
+        # Should stay in awaiting, not auto-checkin
+        assert sensor._state == CHECKIN_STATE_AWAITING
+        assert sensor._checkin_source is None
+
+    async def test_monitoring_on_then_keymaster_unlock_checks_in(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test full flow: monitoring on, timer suppressed, unlock works.
+
+        With monitoring enabled and event start passed, the sensor
+        stays in awaiting_checkin.  A subsequent keymaster unlock
+        transitions to checked_in with source ``keymaster``.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = "test_lock"
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        # Monitoring switch is ON
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=True),
+        }
+
+        # Event whose start has already passed
+        event = _make_event(
+            start=dt_util.now() - timedelta(hours=1),
+            end=dt_util.now() + timedelta(hours=48),
+        )
+        mock_checkin_coordinator.data = [event]
+        mock_checkin_coordinator.last_update_success = True
+
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+
+        # Guest uses their door code
+        sensor.async_handle_keymaster_unlock(code_slot_num=11)
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+        assert sensor._checkin_source == "keymaster"
 
     async def test_toggle_while_checked_in_no_effect(
         self,


### PR DESCRIPTION
## Bug

When keymaster monitoring is enabled, the check-in sensor auto-transitions to `checked_in` at event start time with source `automatic`. It should remain in `awaiting_checkin` until the guest actually uses their door code.

## Root Cause

`_async_auto_checkin_callback()` and the immediate-checkin path in `_transition_to_awaiting()` unconditionally called `_transition_to_checked_in(source="automatic")` without checking whether keymaster monitoring is enabled.

## Fix

- Added `_is_keymaster_monitoring_enabled()` helper that checks the `KeymasterMonitoringSwitch` state from `hass.data`
- Modified `_async_auto_checkin_callback()` to skip auto-transition when monitoring is on
- Modified `_transition_to_awaiting()` past-start branch to skip immediate transition when monitoring is on
- Added 3 new tests, updated 1 existing test (528 total tests pass)