### PR TITLE
Feat(checkin): declare sensor as enum type

### DIFF
--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from homeassistant.components.calendar import CalendarEvent
 from homeassistant.components.datetime import DOMAIN as DATETIME
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE
 from homeassistant.core import HomeAssistant
@@ -192,6 +193,13 @@ class CheckinTrackingSensor(
         self._config_entry = config_entry
         self._attr_has_entity_name = True
         self._attr_translation_key = "checkin"
+        self._attr_device_class = SensorDeviceClass.ENUM
+        self._attr_options = [
+            CHECKIN_STATE_NO_RESERVATION,
+            CHECKIN_STATE_AWAITING,
+            CHECKIN_STATE_CHECKED_IN,
+            CHECKIN_STATE_CHECKED_OUT,
+        ]
         self._state: str = CHECKIN_STATE_NO_RESERVATION
 
         # Tracked event fields (from data-model.md)

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -21,6 +21,7 @@ from typing import Any
 from homeassistant.components.calendar import CalendarEvent
 from homeassistant.components.datetime import DOMAIN as DATETIME
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE
 from homeassistant.core import HomeAssistant
@@ -162,6 +163,7 @@ class CheckinExtraStoredData(ExtraStoredData):
 
 class CheckinTrackingSensor(
     CoordinatorEntity["RentalControlCoordinator"],
+    SensorEntity,
     RestoreEntity,
 ):
     """Sensor that tracks guest check-in/check-out state.

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -102,6 +102,46 @@ def _create_sensor(
 
 
 # ===========================================================================
+# Sensor entity properties
+# ===========================================================================
+
+
+class TestSensorEntityProperties:
+    """Tests for CheckinTrackingSensor entity configuration."""
+
+    async def test_device_class_is_enum(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test sensor declares ENUM device class."""
+        from homeassistant.components.sensor import SensorDeviceClass
+
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        assert sensor._attr_device_class == SensorDeviceClass.ENUM
+
+    async def test_options_lists_all_states(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test sensor options contain all four states."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        assert sensor._attr_options == [
+            CHECKIN_STATE_NO_RESERVATION,
+            CHECKIN_STATE_AWAITING,
+            CHECKIN_STATE_CHECKED_IN,
+            CHECKIN_STATE_CHECKED_OUT,
+        ]
+
+
+# ===========================================================================
 # T007: State machine transitions
 # ===========================================================================
 

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -121,7 +121,7 @@ class TestSensorEntityProperties:
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
-        assert sensor._attr_device_class == SensorDeviceClass.ENUM
+        assert sensor.device_class == SensorDeviceClass.ENUM
 
     async def test_options_lists_all_states(
         self,
@@ -133,7 +133,7 @@ class TestSensorEntityProperties:
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
-        assert sensor._attr_options == [
+        assert sensor.options == [
             CHECKIN_STATE_NO_RESERVATION,
             CHECKIN_STATE_AWAITING,
             CHECKIN_STATE_CHECKED_IN,


### PR DESCRIPTION
## Feature

Convert the check-in tracking sensor to a proper Home Assistant enum sensor by setting `SensorDeviceClass.ENUM` and declaring `_attr_options`.

This exposes the four valid states (`no_reservation`, `awaiting_checkin`, `checked_in`, `checked_out`) to the HA frontend, automations, and other integrations.

### Changes
- `checkinsensor.py`: Added `SensorDeviceClass.ENUM` device class and `_attr_options`
- `test_checkin_sensor.py`: 2 new tests verifying enum properties

531 total tests pass.