### PR TITLE
Fix(overrides): set ready flag in async_update

### DIFF
--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -303,6 +303,8 @@ class EventOverrides:
                 self._slot_uids.pop(slot, None)
 
             self.__assign_next_slot()
+            if len(self._overrides) == self.max_slots:
+                self._ready = True
 
     def verify_slot_ownership(self, slot: int, expected_name: str) -> bool:
         """Check if slot is still assigned to expected_name.

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -119,6 +119,17 @@ class TestEventOverridesInit:
         eo.update(1, "", "", now, now)
         assert eo.ready is True
 
+    @pytest.mark.asyncio
+    async def test_async_update_sets_ready(self) -> None:
+        """Verify async_update sets ready once all slots are populated."""
+        eo = EventOverrides(start_slot=1, max_slots=2)
+        now = dt_util.now()
+        assert eo.ready is False
+        await eo.async_update(1, "code1", "Guest A", now, now)
+        assert eo.ready is False
+        await eo.async_update(2, "code2", "Guest B", now, now)
+        assert eo.ready is True
+
 
 # ---------------------------------------------------------------------------
 # EventOverride TypedDict


### PR DESCRIPTION
## Bug

**Critical regression** — lock code slots are never assigned to events.

The bootstrap calls `update_event_overrides()` → `async_update()`, but `async_update()` never sets `_ready = True`. The sync `update()` does. Since `calsensor._handle_coordinator_update()` gates on `overrides.ready`, no events get slot assignments.

## Fix

Added the same `_ready` check to `async_update()` that exists in sync `update()`:
```python
if len(self._overrides) == self._max_slots:
    self._ready = True
```

## Test

Added `test_async_update_sets_ready` — verifies `ready` transitions from False to True after all slots are populated via `async_update()`.

532 total tests pass.