### PR TITLE
Fix(checkin): force checkout when end passed

### DIFF
--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -221,6 +221,11 @@ class CheckinTrackingSensor(
         # Follow-on event key for linger guard (not persisted)
         self._linger_followon_key: str | None = None
 
+        # Effective baseline for follow-on event lookups (not persisted).
+        # Set by _transition_to_checked_out to preserve the correct
+        # reference point across subsequent coordinator updates.
+        self._linger_baseline: datetime | None = None
+
         # Internal timer unsubscribe handle
         self._unsub_timer: CALLBACK_TYPE | None = None
 
@@ -458,8 +463,25 @@ class CheckinTrackingSensor(
         elif current_state == CHECKIN_STATE_CHECKED_IN:
             tracked = self._find_tracked_event()
             if tracked is not None:
-                # FR-030: Check if event end time changed
-                if tracked.end != self._tracked_event_end:
+                now = dt_util.now()
+                if tracked.end <= now:
+                    # Event has ended — force checkout as safety net
+                    # in case the auto-checkout timer failed to fire.
+                    _LOGGER.debug(
+                        "Event end time %s has passed, forcing "
+                        "automatic checkout for %s",
+                        tracked.end,
+                        self.coordinator.name,
+                    )
+                    self._tracked_event_end = tracked.end
+                    self._tracked_event_slot_name = self._extract_slot_name(tracked)
+                    self._cancel_timer()
+                    self._transition_to_checked_out(
+                        source="automatic",
+                        linger_baseline=tracked.end,
+                    )
+                elif tracked.end != self._tracked_event_end:
+                    # FR-030: Check if event end time changed
                     _LOGGER.debug(
                         "Event end time changed from %s to %s, "
                         "rescheduling auto check-out",
@@ -469,15 +491,20 @@ class CheckinTrackingSensor(
                     self._tracked_event_end = tracked.end
                     self._cancel_timer()
                     self._schedule_auto_checkout(tracked.end)
-                # Update slot name in case it changed
-                self._tracked_event_slot_name = self._extract_slot_name(tracked)
-                self.async_write_ha_state()
+                    self._tracked_event_slot_name = self._extract_slot_name(tracked)
+                    self.async_write_ha_state()
+                else:
+                    # Update slot name in case it changed
+                    self._tracked_event_slot_name = self._extract_slot_name(tracked)
+                    self.async_write_ha_state()
             else:
                 # Tracked event genuinely gone
                 self._transition_to_no_reservation()
 
         elif current_state == CHECKIN_STATE_CHECKED_OUT:
-            checkout_time = self._checkout_time or dt_util.now()
+            checkout_time = (
+                self._linger_baseline or self._checkout_time or dt_util.now()
+            )
             followon = self._find_followon_event(checkout_time)
             if followon is not None:
                 followon_key = self._event_key(followon.summary, followon.start)
@@ -527,6 +554,7 @@ class CheckinTrackingSensor(
         self._checked_out_event_key = None
         self._next_event_start_day = None
         self._linger_followon_key = None
+        self._linger_baseline = None
 
         # Schedule auto check-in at event start time
         self._cancel_timer()
@@ -612,9 +640,16 @@ class CheckinTrackingSensor(
         else:
             # End time already passed - checkout immediately
             self._transition_target_time = None
-            self._transition_to_checked_out(source="automatic")
+            self._transition_to_checked_out(
+                source="automatic",
+                linger_baseline=end_time,
+            )
 
-    def _transition_to_checked_out(self, source: str) -> None:
+    def _transition_to_checked_out(
+        self,
+        source: str,
+        linger_baseline: datetime | None = None,
+    ) -> None:
         """Transition to checked_out state.
 
         Records checkout details, fires checkout event, stores event
@@ -622,6 +657,11 @@ class CheckinTrackingSensor(
 
         Args:
             source: How check-out occurred (``manual`` or ``automatic``).
+            linger_baseline: Reference time for follow-on event lookup
+                and linger scheduling.  Defaults to ``dt_util.now()``.
+                Pass the event end time when the reservation has already
+                ended so that follow-on events starting between ``end``
+                and ``now`` are not skipped.
         """
         _LOGGER.debug(
             "Transitioning to checked_out (source=%s) for event: %s",
@@ -661,11 +701,13 @@ class CheckinTrackingSensor(
 
         # Compute post-checkout linger timing
         self._cancel_timer()
-        self._compute_linger_timing()
+        effective_baseline = linger_baseline or self._checkout_time
+        self._linger_baseline = effective_baseline
+        self._compute_linger_timing(baseline=effective_baseline)
 
         self.async_write_ha_state()
 
-    def _compute_linger_timing(self) -> None:
+    def _compute_linger_timing(self, baseline: datetime | None = None) -> None:
         """Compute and schedule post-checkout linger timing.
 
         Determines which FR-006 scenario applies based on the next
@@ -674,8 +716,15 @@ class CheckinTrackingSensor(
         Date comparisons use the HA-configured local timezone so that
         "same calendar day" is evaluated from the user's perspective,
         not raw UTC dates.
+
+        Args:
+            baseline: Reference time for follow-on event lookup and
+                gap calculations.  Falls back to ``_linger_baseline``,
+                then ``_checkout_time``, then ``dt_util.now()``.
         """
-        checkout_time = self._checkout_time or dt_util.now()
+        checkout_time = (
+            baseline or self._linger_baseline or self._checkout_time or dt_util.now()
+        )
         next_event = self._find_followon_event(checkout_time)
 
         if next_event is not None:
@@ -760,6 +809,7 @@ class CheckinTrackingSensor(
         self._transition_target_time = None
         self._checked_out_event_key = None
         self._linger_followon_key = None
+        self._linger_baseline = None
 
         self._cancel_timer()
         self.async_write_ha_state()
@@ -814,7 +864,7 @@ class CheckinTrackingSensor(
         _LOGGER.debug("Linger-to-awaiting timer fired for %s", self.coordinator.name)
         self._unsub_timer = None
         if self._state == CHECKIN_STATE_CHECKED_OUT:
-            checkout_time = self._checkout_time or _now
+            checkout_time = self._linger_baseline or self._checkout_time or _now
             event = self._find_followon_event(checkout_time)
             if event is not None:
                 self._transition_to_awaiting(event)
@@ -902,10 +952,11 @@ class CheckinTrackingSensor(
     async def async_checkout(self) -> None:
         """Handle manual checkout service call.
 
-        Validates guard conditions per FR-019 and specs/004-checkin-tracking/contracts/checkout-service.md:
+        Validates guard conditions:
         1. Sensor must be in ``checked_in`` state
-        2. Current datetime must be within ``[start, end)`` of the active
-           reservation window
+        2. Reservation boundaries must be known
+        3. Current date must be on or after the last day of the
+           reservation (the calendar date of the event end time)
 
         On success, calls ``_transition_to_checked_out(source="manual")``.
 
@@ -915,26 +966,28 @@ class CheckinTrackingSensor(
         # Guard 1: State must be checked_in
         if self._state != CHECKIN_STATE_CHECKED_IN:
             raise ServiceValidationError(
-                f"Checkout is only available when the guest is checked in "
-                f"(current state: {self._state})"
+                f"Checkout is only available when the guest is "
+                f"checked in (current state: {self._state})"
             )
 
-        # Guard 2: Current datetime within active reservation window [start, end)
+        # Guard 2: Reservation boundaries must be known
         now = dt_util.now()
-        start = self._tracked_event_start
         end = self._tracked_event_end
 
-        if start is not None and end is not None:
-            if now < start or now >= end:
-                raise ServiceValidationError(
-                    f"Checkout is only available during the active reservation "
-                    f"window (current: {now.isoformat()}, "
-                    f"allowed: {start.isoformat()} to {end.isoformat()})"
-                )
-        elif start is None or end is None:
+        if self._tracked_event_start is None or end is None:
             raise ServiceValidationError(
-                "Checkout is only available during the active reservation "
-                "window (reservation boundaries are not set)"
+                "Checkout requires known reservation boundaries"
+            )
+
+        # Guard 3: Must be on or after the last day of the reservation
+        local_now = dt_util.as_local(now)
+        local_end = dt_util.as_local(end)
+        if local_now.date() < local_end.date():
+            raise ServiceValidationError(
+                f"Checkout is only available on the last day of "
+                f"the reservation or later "
+                f"(current: {local_now.date().isoformat()}, "
+                f"checkout day: {local_end.date().isoformat()})"
             )
 
         # Early expiry: shorten lock code if switch is on (FR-022)
@@ -956,7 +1009,12 @@ class CheckinTrackingSensor(
                     self._tracked_event_end = new_end
                     await self._async_update_lock_code_expiry(new_end)
 
-        self._transition_to_checked_out(source="manual")
+        # Use event end as linger baseline when past end so that
+        # follow-on event detection uses the correct reference point.
+        effective_baseline = min(now, end)
+        self._transition_to_checked_out(
+            source="manual", linger_baseline=effective_baseline
+        )
 
     async def async_added_to_hass(self) -> None:
         """Restore persisted state and validate against current time/data.

--- a/specs/004-checkin-tracking/contracts/checkout-service.md
+++ b/specs/004-checkin-tracking/contracts/checkout-service.md
@@ -30,8 +30,11 @@ The service handler validates the following before executing:
 1. **State check**: Sensor must be in `checked_in` state
    - Error: `"Checkout is only available when the guest is checked in (current state: {state})"`
 
-2. **Reservation window check**: Current datetime must be within the active reservation window — on or after the event start datetime and strictly before the event end datetime (FR-019)
-   - Error: `"Checkout is only available during the active reservation window (current: {current_datetime}, allowed: {start_datetime} to {end_datetime})"`
+2. **Reservation boundaries check**: Both `start` and `end` must be known
+   - Error: `"Checkout requires known reservation boundaries"`
+
+3. **Calendar-day check**: Current local date must be on or after the last calendar day of the reservation (the date of the event end time in the HA-configured local timezone)
+   - Error: `"Checkout is only available on the last day of the reservation or later (current: {current_date}, checkout day: {end_date})"`
 
 ## Success Response
 

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from typing import Generator
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -710,6 +711,57 @@ class TestAutoCheckoutRescheduling:
         mock_unsub.assert_not_called()
         # Should still be checked_in
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
+
+    async def test_coordinator_update_forces_checkout_when_ended(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test coordinator update transitions to checked_out when event ended.
+
+        If the auto-checkout timer fails to fire, the coordinator
+        update handler must detect that the event end has passed and
+        force checkout as a safety net.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        start = now - timedelta(hours=6)
+        end = now - timedelta(hours=1)
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - Overdue Guest"
+        sensor._tracked_event_start = start
+        sensor._tracked_event_end = end
+        sensor._tracked_event_slot_name = "Overdue Guest"
+        sensor._checkin_source = "automatic"
+
+        # Event still in coordinator data (same day, not filtered)
+        ended_event = _make_event(
+            summary="Reserved - Overdue Guest",
+            start=start,
+            end=end,
+        )
+        mock_checkin_coordinator.data = [ended_event]
+        mock_checkin_coordinator.last_update_success = True
+
+        fired_events: list = []
+        hass.bus.async_listen(
+            EVENT_RENTAL_CONTROL_CHECKOUT,
+            lambda e: fired_events.append(e),
+        )
+
+        sensor._handle_coordinator_update()
+        await hass.async_block_till_done()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._checkout_source == "automatic"
+        assert sensor._checkout_time is not None
+        assert len(fired_events) == 1
+        assert fired_events[0].data["source"] == "automatic"
 
 
 # ===========================================================================
@@ -2689,13 +2741,13 @@ class TestEventBusListenerFiltering:
 class TestManualCheckout:
     """Tests for manual checkout action / async_checkout (T027)."""
 
-    async def test_checkout_success_when_checked_in_within_window(
+    async def test_checkout_success_when_checked_in_on_last_day(
         self,
         hass: HomeAssistant,
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Test successful checkout when checked_in and within reservation window.
+        """Test successful checkout on the last day of the reservation.
 
         Verifies:
         - State transitions to checked_out
@@ -2706,11 +2758,10 @@ class TestManualCheckout:
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
 
-        now = dt_util.now()
+        now = dt_util.now().replace(hour=12, minute=0, second=0, microsecond=0)
         start = now - timedelta(hours=2)
-        end = now + timedelta(hours=48)
+        end = now + timedelta(hours=2)
 
-        # Set sensor to checked_in state with active reservation window
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
         sensor._tracked_event_start = start
@@ -2718,24 +2769,22 @@ class TestManualCheckout:
         sensor._tracked_event_slot_name = "John Smith"
         sensor._checkin_source = "automatic"
 
-        # No follow-on events
         mock_checkin_coordinator.data = []
 
-        # Collect fired events
         fired_events: list = []
         hass.bus.async_listen(
             EVENT_RENTAL_CONTROL_CHECKOUT,
             lambda e: fired_events.append(e),
         )
 
-        await sensor.async_checkout()
-        await hass.async_block_till_done()
+        with patch("homeassistant.util.dt.now", return_value=now):
+            await sensor.async_checkout()
+            await hass.async_block_till_done()
 
         assert sensor._state == CHECKIN_STATE_CHECKED_OUT
         assert sensor._checkout_source == "manual"
         assert sensor._checkout_time is not None
 
-        # Verify checkout event fired with source: manual
         assert len(fired_events) == 1
         event_data = fired_events[0].data
         assert event_data["entity_id"] == "sensor.test_rental_checkin"
@@ -2744,6 +2793,71 @@ class TestManualCheckout:
         assert event_data["start"] == start.isoformat()
         assert event_data["end"] == end.isoformat()
         assert event_data["guest_name"] == "John Smith"
+
+    async def test_checkout_succeeds_after_end_time_on_last_day(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test manual checkout allowed after end time on the last day.
+
+        If auto-checkout failed, the user must be able to manually
+        check out the guest on the same calendar day.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now().replace(hour=12, minute=0, second=0, microsecond=0)
+        start = now - timedelta(hours=6)
+        end = now - timedelta(hours=1)
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - Jane Doe"
+        sensor._tracked_event_start = start
+        sensor._tracked_event_end = end
+        sensor._tracked_event_slot_name = "Jane Doe"
+
+        mock_checkin_coordinator.data = []
+
+        with patch("homeassistant.util.dt.now", return_value=now):
+            await sensor.async_checkout()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._checkout_source == "manual"
+
+    async def test_checkout_succeeds_day_after_reservation_ends(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test manual checkout allowed on a day after the reservation ended.
+
+        Covers the edge case where both the auto-checkout timer and
+        the HA restart restoration failed to transition the sensor.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        start = now - timedelta(days=3)
+        end = now - timedelta(days=1)
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - Stale Guest"
+        sensor._tracked_event_start = start
+        sensor._tracked_event_end = end
+        sensor._tracked_event_slot_name = "Stale Guest"
+
+        mock_checkin_coordinator.data = []
+
+        await sensor.async_checkout()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._checkout_source == "manual"
 
     async def test_checkout_raises_when_not_checked_in(
         self,
@@ -2769,63 +2883,67 @@ class TestManualCheckout:
             with pytest.raises(ServiceValidationError, match="current state"):
                 await sensor.async_checkout()
 
-    async def test_checkout_raises_when_before_reservation_start(
+    async def test_checkout_raises_before_last_day(
         self,
         hass: HomeAssistant,
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Test ServiceValidationError when current time is before event start (FR-019).
+        """Test ServiceValidationError when current date is before last day.
 
-        Guard condition: current datetime must be >= start_datetime.
+        Checkout is allowed on the calendar date of the event end
+        time. Any earlier day must be rejected.
         """
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
 
         now = dt_util.now()
-        # Event starts in the future — shouldn't normally be checked_in,
-        # but we force the state to test the guard condition
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
-        sensor._tracked_event_start = now + timedelta(hours=2)
-        sensor._tracked_event_end = now + timedelta(hours=48)
+        sensor._tracked_event_start = now - timedelta(hours=2)
+        sensor._tracked_event_end = now + timedelta(days=3)
 
-        with pytest.raises(ServiceValidationError, match="active reservation window"):
+        with pytest.raises(ServiceValidationError, match="last day"):
             await sensor.async_checkout()
 
-    async def test_checkout_raises_when_at_or_after_reservation_end(
+    async def test_checkout_succeeds_at_and_after_end_on_last_day(
         self,
         hass: HomeAssistant,
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Test ServiceValidationError when current time is at or after event end (FR-019).
+        """Test manual checkout works at and after event end on the last day.
 
-        Guard condition: current datetime must be strictly before end_datetime.
-        Tests both at-end and after-end scenarios.
+        Previously this would raise; now checkout is allowed anytime
+        on the last day.
         """
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
 
         now = dt_util.now()
+        mock_checkin_coordinator.data = []
 
         # Case 1: exactly at end time
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
         sensor._tracked_event_start = now - timedelta(hours=48)
-        sensor._tracked_event_end = now  # End is exactly now
+        sensor._tracked_event_end = now
+        sensor._tracked_event_slot_name = "John Smith"
 
-        with pytest.raises(ServiceValidationError, match="active reservation window"):
-            await sensor.async_checkout()
+        await sensor.async_checkout()
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
 
-        # Case 2: after end time
+        # Case 2: after end time (same day)
         sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - Jane Doe"
+        sensor._tracked_event_start = now - timedelta(hours=48)
         sensor._tracked_event_end = now - timedelta(hours=1)
+        sensor._tracked_event_slot_name = "Jane Doe"
 
-        with pytest.raises(ServiceValidationError, match="active reservation window"):
-            await sensor.async_checkout()
+        await sensor.async_checkout()
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
 
     async def test_checkout_error_message_includes_state(
         self,
@@ -2845,34 +2963,31 @@ class TestManualCheckout:
 
         assert CHECKIN_STATE_AWAITING in str(exc_info.value)
 
-    async def test_checkout_error_message_includes_datetime_info(
+    async def test_checkout_error_message_includes_date_info(
         self,
         hass: HomeAssistant,
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Test that reservation window error includes datetime info per contract."""
+        """Test that before-last-day error includes date info."""
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
 
         now = dt_util.now()
-        start = now + timedelta(hours=2)
-        end = now + timedelta(hours=48)
+        end = now + timedelta(days=3)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
-        sensor._tracked_event_start = start
+        sensor._tracked_event_start = now - timedelta(hours=2)
         sensor._tracked_event_end = end
 
         with pytest.raises(ServiceValidationError) as exc_info:
             await sensor.async_checkout()
 
         error_msg = str(exc_info.value)
-        # Per contract: message should reference the allowed window
-        assert "active reservation window" in error_msg
-        assert start.isoformat() in error_msg
-        assert end.isoformat() in error_msg
+        local_end = dt_util.as_local(end)
+        assert local_end.date().isoformat() in error_msg
 
     async def test_checkout_no_state_change_on_guard_failure(
         self,
@@ -2919,10 +3034,9 @@ class TestManualCheckout:
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
 
-        now = dt_util.now()
+        now = dt_util.now().replace(hour=12, minute=0, second=0, microsecond=0)
         start = now - timedelta(hours=2)
-        # Event still has 48 hours to go
-        end = now + timedelta(hours=48)
+        end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -2933,7 +3047,8 @@ class TestManualCheckout:
         # No follow-on events → FR-006b cleaning window
         mock_checkin_coordinator.data = []
 
-        await sensor.async_checkout()
+        with patch("homeassistant.util.dt.now", return_value=now):
+            await sensor.async_checkout()
 
         assert sensor._state == CHECKIN_STATE_CHECKED_OUT
         assert sensor._checkout_time is not None
@@ -2948,9 +3063,6 @@ class TestManualCheckout:
 
         # Verify checkout_time is approximately now (not event end)
         assert abs((sensor._checkout_time - now).total_seconds()) < 2
-        # Event end is 48 hours away — if linger used event end,
-        # transition_target_time would be ~54 hours from now
-        assert sensor._transition_target_time < now + timedelta(hours=12)
 
     async def test_checkout_at_start_boundary_succeeds(
         self,
@@ -2958,18 +3070,14 @@ class TestManualCheckout:
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Test checkout succeeds when current time equals event start (inclusive).
-
-        Guard: current datetime must be >= start (inclusive boundary).
-        """
+        """Test checkout succeeds when on the last day of the reservation."""
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
 
-        now = dt_util.now()
-        # Start is exactly now or slightly in the past to ensure boundary
+        now = dt_util.now().replace(hour=12, minute=0, second=0, microsecond=0)
         start = now - timedelta(seconds=1)
-        end = now + timedelta(hours=48)
+        end = now + timedelta(hours=2)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -2979,8 +3087,8 @@ class TestManualCheckout:
 
         mock_checkin_coordinator.data = []
 
-        # Should NOT raise — start boundary is inclusive
-        await sensor.async_checkout()
+        with patch("homeassistant.util.dt.now", return_value=now):
+            await sensor.async_checkout()
 
         assert sensor._state == CHECKIN_STATE_CHECKED_OUT
 
@@ -3024,6 +3132,13 @@ class TestEarlyCheckoutExpiry:
     checkout (async_checkout), NOT on keymaster unlock while checked_in.
     """
 
+    @pytest.fixture(autouse=True)
+    def _freeze_midday(self) -> Generator[None, None, None]:
+        """Pin dt_util.now to midday so end-time offsets stay same-day."""
+        fixed = dt_util.now().replace(hour=12, minute=0, second=0, microsecond=0)
+        with patch("homeassistant.util.dt.now", return_value=fixed):
+            yield
+
     async def test_unlock_while_checked_in_is_ignored(
         self,
         hass: HomeAssistant,
@@ -3041,7 +3156,7 @@ class TestEarlyCheckoutExpiry:
 
         now = dt_util.now()
         start = now - timedelta(hours=2)
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -3074,7 +3189,7 @@ class TestEarlyCheckoutExpiry:
 
         now = dt_util.now()
         start = now - timedelta(hours=2)
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -3110,7 +3225,7 @@ class TestEarlyCheckoutExpiry:
 
         now = dt_util.now()
         start = now - timedelta(hours=2)
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -3147,7 +3262,7 @@ class TestEarlyCheckoutExpiry:
 
         now = dt_util.now()
         start = now - timedelta(hours=2)
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -3183,7 +3298,7 @@ class TestEarlyCheckoutExpiry:
 
         now = dt_util.now()
         start = now - timedelta(hours=2)
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -3219,7 +3334,7 @@ class TestEarlyCheckoutExpiry:
         )
 
         now = dt_util.now()
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -3289,7 +3404,7 @@ class TestEarlyCheckoutExpiry:
 
         now = dt_util.now()
         start = now - timedelta(hours=2)
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -3332,7 +3447,7 @@ class TestEarlyCheckoutExpiry:
         )
 
         now = dt_util.now()
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -3366,7 +3481,7 @@ class TestEarlyCheckoutExpiry:
         )
 
         now = dt_util.now()
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
@@ -3404,7 +3519,7 @@ class TestEarlyCheckoutExpiry:
         )
 
         now = dt_util.now()
-        original_end = now + timedelta(hours=48)
+        original_end = now + timedelta(hours=4)
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"


### PR DESCRIPTION
## Problem

When the sensor is `checked_in` and the event's end time passes, the sensor relies solely on a timer to transition to `checked_out`. If the timer fails to fire for any reason (race condition, platform issue), the sensor gets permanently stuck in `checked_in`.

Additionally, the manual checkout action was gated to `[start, end)`, making it impossible to manually recover after the reservation window closed.

## Fixes

### Safety net in coordinator update
Added an end-time check in `_handle_coordinator_update()` for the `checked_in` state. On every coordinator refresh, if the tracked event's end time has passed, the sensor forces automatic checkout immediately.

### Manual checkout guard relaxation
Changed the manual checkout guard from requiring `now` within `[start, end)` to allowing checkout anytime on or after the last calendar day of the reservation (using local timezone date comparison). Before the last day, checkout is still blocked.

## Tests
- Added `test_coordinator_update_forces_checkout_when_ended` — safety net test
- Added `test_checkout_succeeds_after_end_time_on_last_day` — post-end checkout
- Added `test_checkout_succeeds_day_after_reservation_ends` — next-day recovery
- Updated `test_checkout_raises_before_last_day` — new guard behavior
- Updated `test_checkout_succeeds_at_and_after_end_on_last_day` — replaces old window test
- Updated all early checkout expiry tests for same-day end times
- All 535 tests pass