### PR TITLE
Fix(checkin): Preserve state when event lost

### DIFF
--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -503,25 +503,40 @@ class CheckinTrackingSensor(
                     self.async_write_ha_state()
             else:
                 # Tracked event not found in coordinator data.
-                # Preserve checked_in — a real guest is in the
-                # property.  The auto-checkout timer or end-time
-                # safety net will handle the transition; dropping
-                # to no_reservation here would lose physical state
-                # due to a transient data mismatch.
-                if not self._event_missing_warned:
+                # If the stored end time has already passed, force
+                # checkout as a safety net (mirrors the tracked-event
+                # end-time check above).  Otherwise, preserve
+                # checked_in for transient data mismatches.
+                fallback_end = self._tracked_event_end
+                if fallback_end is not None and fallback_end <= dt_util.now():
                     _LOGGER.warning(
                         "Tracked event not found in coordinator data "
-                        "while checked_in for %s; preserving state",
+                        "while checked_in for %s and stored end "
+                        "time %s has passed; forcing checkout",
                         self.coordinator.name,
+                        fallback_end,
                     )
-                    self._event_missing_warned = True
+                    self._cancel_timer()
+                    self._transition_to_checked_out(
+                        source="automatic",
+                        linger_baseline=fallback_end,
+                    )
                 else:
-                    _LOGGER.debug(
-                        "Tracked event still missing for %s; "
-                        "preserving checked_in state",
-                        self.coordinator.name,
-                    )
-                self.async_write_ha_state()
+                    if not self._event_missing_warned:
+                        _LOGGER.warning(
+                            "Tracked event not found in coordinator "
+                            "data while checked_in for %s; "
+                            "preserving state",
+                            self.coordinator.name,
+                        )
+                        self._event_missing_warned = True
+                    else:
+                        _LOGGER.debug(
+                            "Tracked event still missing for %s; "
+                            "preserving checked_in state",
+                            self.coordinator.name,
+                        )
+                    self.async_write_ha_state()
 
         elif current_state == CHECKIN_STATE_CHECKED_OUT:
             checkout_time = (
@@ -577,6 +592,7 @@ class CheckinTrackingSensor(
         self._next_event_start_day = None
         self._linger_followon_key = None
         self._linger_baseline = None
+        self._event_missing_warned = False
 
         # Schedule auto check-in at event start time
         self._cancel_timer()
@@ -616,6 +632,7 @@ class CheckinTrackingSensor(
         self._state = CHECKIN_STATE_CHECKED_IN
         self._checkin_source = source
         self._transition_target_time = None
+        self._event_missing_warned = False
 
         # Fire check-in event (per contracts/events.md)
         self._hass.bus.async_fire(
@@ -693,6 +710,7 @@ class CheckinTrackingSensor(
         self._state = CHECKIN_STATE_CHECKED_OUT
         self._checkout_source = source
         self._checkout_time = dt_util.now()
+        self._event_missing_warned = False
 
         # Store event identity key for FR-007
         if self._tracked_event_summary and self._tracked_event_start:

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -498,8 +498,18 @@ class CheckinTrackingSensor(
                     self._tracked_event_slot_name = self._extract_slot_name(tracked)
                     self.async_write_ha_state()
             else:
-                # Tracked event genuinely gone
-                self._transition_to_no_reservation()
+                # Tracked event not found in coordinator data.
+                # Preserve checked_in — a real guest is in the
+                # property.  The auto-checkout timer or end-time
+                # safety net will handle the transition; dropping
+                # to no_reservation here would lose physical state
+                # due to a transient data mismatch.
+                _LOGGER.warning(
+                    "Tracked event not found in coordinator data "
+                    "while checked_in for %s; preserving state",
+                    self.coordinator.name,
+                )
+                self.async_write_ha_state()
 
         elif current_state == CHECKIN_STATE_CHECKED_OUT:
             checkout_time = (

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -229,6 +229,9 @@ class CheckinTrackingSensor(
         # Internal timer unsubscribe handle
         self._unsub_timer: CALLBACK_TYPE | None = None
 
+        # Guard against repeated warnings when tracked event is missing
+        self._event_missing_warned: bool = False
+
         # Unique ID
         self._unique_id = gen_uuid(f"{self.coordinator.unique_id} checkin_tracking")
 
@@ -463,6 +466,7 @@ class CheckinTrackingSensor(
         elif current_state == CHECKIN_STATE_CHECKED_IN:
             tracked = self._find_tracked_event()
             if tracked is not None:
+                self._event_missing_warned = False
                 now = dt_util.now()
                 if tracked.end <= now:
                     # Event has ended — force checkout as safety net
@@ -504,11 +508,19 @@ class CheckinTrackingSensor(
                 # safety net will handle the transition; dropping
                 # to no_reservation here would lose physical state
                 # due to a transient data mismatch.
-                _LOGGER.warning(
-                    "Tracked event not found in coordinator data "
-                    "while checked_in for %s; preserving state",
-                    self.coordinator.name,
-                )
+                if not self._event_missing_warned:
+                    _LOGGER.warning(
+                        "Tracked event not found in coordinator data "
+                        "while checked_in for %s; preserving state",
+                        self.coordinator.name,
+                    )
+                    self._event_missing_warned = True
+                else:
+                    _LOGGER.debug(
+                        "Tracked event still missing for %s; "
+                        "preserving checked_in state",
+                        self.coordinator.name,
+                    )
                 self.async_write_ha_state()
 
         elif current_state == CHECKIN_STATE_CHECKED_OUT:
@@ -820,6 +832,7 @@ class CheckinTrackingSensor(
         self._checked_out_event_key = None
         self._linger_followon_key = None
         self._linger_baseline = None
+        self._event_missing_warned = False
 
         self._cancel_timer()
         self.async_write_ha_state()

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -3700,13 +3700,13 @@ class TestEventTrackingStability:
         sensor._handle_coordinator_update()
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
 
-    async def test_checked_in_preserved_when_event_truly_gone(
+    async def test_checked_in_preserved_when_event_mismatched(
         self,
         hass: HomeAssistant,
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Test checked_in preserved even with different event in data."""
+        """Test checked_in preserved when different event in data."""
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -3725,6 +3725,29 @@ class TestEventTrackingStability:
         sensor._handle_coordinator_update()
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
 
+    async def test_checked_in_force_checkout_when_event_gone_past_end(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test checked_in forces checkout when event gone and end passed."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        now = dt_util.now()
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - Vanished"
+        sensor._tracked_event_start = now - timedelta(hours=6)
+        sensor._tracked_event_end = now - timedelta(hours=1)
+        sensor._checkin_source = "automatic"
+
+        mock_checkin_coordinator.data = []
+
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+
     async def test_awaiting_survives_event_position_shift(
         self,
         hass: HomeAssistant,

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -538,31 +538,35 @@ class TestEventCancelled:
 
         assert sensor._state == CHECKIN_STATE_NO_RESERVATION
 
-    async def test_checked_in_to_no_reservation_on_event_removed(
+    async def test_checked_in_preserved_when_event_disappears(
         self,
         hass: HomeAssistant,
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Test checked_in → no_reservation when tracked event disappears."""
+        """Test checked_in is preserved when tracked event disappears.
+
+        The checked_in state represents a physical guest in the
+        property.  A transient coordinator data mismatch must not
+        drop the state to no_reservation.
+        """
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
 
         now = dt_util.now()
-        # Put sensor in checked_in state
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - John Smith"
         sensor._tracked_event_start = now - timedelta(hours=2)
-        sensor._tracked_event_end = now + timedelta(hours=48)
+        sensor._tracked_event_end = now + timedelta(hours=4)
         sensor._tracked_event_slot_name = "John Smith"
 
-        # Event disappears
+        # Event disappears from coordinator data
         mock_checkin_coordinator.data = []
         mock_checkin_coordinator.last_update_success = True
         sensor._handle_coordinator_update()
 
-        assert sensor._state == CHECKIN_STATE_NO_RESERVATION
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
 
     async def test_awaiting_shifts_to_next_event_on_cancel(
         self,
@@ -3696,13 +3700,13 @@ class TestEventTrackingStability:
         sensor._handle_coordinator_update()
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
 
-    async def test_checked_in_transitions_when_event_truly_gone(
+    async def test_checked_in_preserved_when_event_truly_gone(
         self,
         hass: HomeAssistant,
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Test CHECKED_IN transitions to no_reservation when gone."""
+        """Test checked_in preserved even with different event in data."""
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
@@ -3711,7 +3715,7 @@ class TestEventTrackingStability:
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._tracked_event_summary = "Reserved - Vanished"
         sensor._tracked_event_start = now - timedelta(hours=2)
-        sensor._tracked_event_end = now + timedelta(hours=48)
+        sensor._tracked_event_end = now + timedelta(hours=4)
         sensor._checkin_source = "automatic"
 
         mock_checkin_coordinator.data = [
@@ -3719,7 +3723,7 @@ class TestEventTrackingStability:
         ]
 
         sensor._handle_coordinator_update()
-        assert sensor._state == CHECKIN_STATE_NO_RESERVATION
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
 
     async def test_awaiting_survives_event_position_shift(
         self,


### PR DESCRIPTION
## Problem

When the check-in sensor is in `checked_in` state and the tracked event disappears from coordinator data (transient fetch issue, identity key mismatch after restart, or calendar edit), the sensor incorrectly transitions to `no_reservation`. This loses the physical guest state, and with keymaster monitoring enabled, the sensor gets stuck in `awaiting_checkin` because the door code event won't repeat.

## Fix

Preserve the `checked_in` state when `_find_tracked_event()` returns `None`. The auto-checkout timer (scheduled at event end) or the end-time safety net (PR #453) will handle the transition to `checked_out` at the right time. Log a warning so the event is visible in logs.

## Tests
- Updated `test_checked_in_preserved_when_event_disappears` (was `test_checked_in_to_no_reservation_on_event_removed`)
- Updated `test_checked_in_preserved_when_event_truly_gone` (was `test_checked_in_transitions_when_event_truly_gone`)
- All 535 tests pass