### PR TITLE
Chore: bump icalendar floor to 7.0.0

### DIFF
--- a/custom_components/rental_control/manifest.json
+++ b/custom_components/rental_control/manifest.json
@@ -9,6 +9,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tykeal/homeassistant-rental-control/issues",
-  "requirements": ["icalendar>=6.1.0", "x-wr-timezone>=2.0.0"],
+  "requirements": ["icalendar>=7.0.0", "x-wr-timezone>=2.0.0"],
   "version": "0.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "icalendar>=6.1.0",
+    "icalendar>=7.0.0",
     "x-wr-timezone>=2.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1042,7 +1042,7 @@ requires-dist = [
     { name = "aioresponses", marker = "extra == 'test'" },
     { name = "homeassistant", marker = "extra == 'dev'", specifier = ">=2026.4.0" },
     { name = "homeassistant", marker = "extra == 'test'", specifier = ">=2026.4.0" },
-    { name = "icalendar", specifier = ">=6.1.0" },
+    { name = "icalendar", specifier = ">=7.0.0" },
     { name = "pytest-homeassistant-custom-component", marker = "extra == 'test'" },
     { name = "x-wr-timezone", specifier = ">=2.0.0" },
 ]


### PR DESCRIPTION
## Changes

Bump the icalendar minimum version from `>=6.1.0` to `>=7.0.0` in both `pyproject.toml` and `manifest.json`. The HA 2026.4 upgrade (PR #456) resolved icalendar 7.0.3, and all 536 tests pass. This prevents untested 6.x installations.

Regenerated `uv.lock` to reflect the new constraint.