### PR TITLE
Fix(checkin): add force param to checkout

### DIFF
--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.typing import DiscoveryInfoType
+import voluptuous as vol
 
 from .const import CHECKIN_SENSOR
 from .const import CONF_MAX_EVENTS
@@ -80,8 +81,8 @@ async def async_setup_entry(
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(
         "checkout",
-        {},  # Empty schema — no parameters
-        "async_checkout",  # Method name on CheckinTrackingSensor
+        {vol.Optional("force", default=False): bool},
+        "async_checkout",
     )
 
     return True

--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -10,6 +10,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
@@ -81,7 +82,7 @@ async def async_setup_entry(
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(
         "checkout",
-        {vol.Optional("force", default=False): bool},
+        {vol.Optional("force", default=False): cv.boolean},
         "async_checkout",
     )
 

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -1047,22 +1047,19 @@ class CheckinTrackingSensor(
             )
 
         # Guard 3: Must be on or after the last day of the reservation
-        if end is not None and not force:
+        if end is not None:
             local_now = dt_util.as_local(now)
             local_end = dt_util.as_local(end)
             if local_now.date() < local_end.date():
-                raise ServiceValidationError(
-                    f"Checkout is only available on the last day "
-                    f"of the reservation or later "
-                    f"(current: {local_now.date().isoformat()}, "
-                    f"checkout day: "
-                    f"{local_end.date().isoformat()})"
-                )
-
-        if force and end is not None:
-            local_now = dt_util.as_local(now)
-            local_end = dt_util.as_local(end)
-            if local_now.date() < local_end.date():
+                if not force:
+                    raise ServiceValidationError(
+                        f"Checkout is only available on the last "
+                        f"day of the reservation or later "
+                        f"(current: "
+                        f"{local_now.date().isoformat()}, "
+                        f"checkout day: "
+                        f"{local_end.date().isoformat()})"
+                    )
                 _LOGGER.warning(
                     "Force checkout: overriding last-day guard "
                     "for %s (current: %s, checkout day: %s)",

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -139,7 +139,7 @@ class CheckinExtraStoredData(ExtraStoredData):
                 return None
             try:
                 result: datetime | None = dt_util.parse_datetime(value)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError):  # fmt: skip
                 _LOGGER.warning("Failed to parse stored datetime: %s", value)
                 return None
             if result is None:
@@ -521,6 +521,21 @@ class CheckinTrackingSensor(
                         source="automatic",
                         linger_baseline=fallback_end,
                     )
+                elif (
+                    fallback_end is None
+                    and self._tracked_event_start is None
+                    and self._tracked_event_summary is None
+                ):
+                    # All tracking data lost — cannot recover.
+                    # Transition to no_reservation so the next
+                    # coordinator update can pick up fresh events.
+                    _LOGGER.warning(
+                        "All tracking data lost while checked_in "
+                        "for %s; resetting to no_reservation",
+                        self.coordinator.name,
+                    )
+                    self._cancel_timer()
+                    self._transition_to_no_reservation()
                 else:
                     if not self._event_missing_warned:
                         _LOGGER.warning(
@@ -990,46 +1005,71 @@ class CheckinTrackingSensor(
                 "follow-up time, staying in no_reservation",
             )
 
-    async def async_checkout(self) -> None:
+    async def async_checkout(self, force: bool = False) -> None:
         """Handle manual checkout service call.
 
         Validates guard conditions:
         1. Sensor must be in ``checked_in`` state
-        2. Reservation boundaries must be known
+        2. Reservation boundaries must be known (skipped when
+           *force* is ``True``)
         3. Current date must be on or after the last day of the
-           reservation (the calendar date of the event end time)
+           reservation (skipped when *force* is ``True``)
 
         On success, calls ``_transition_to_checked_out(source="manual")``.
+
+        Args:
+            force: Bypass guards 2 and 3.  Use when the sensor is
+                stuck and the admin needs to override.
 
         Raises:
             ServiceValidationError: If guard conditions are not met.
         """
-        # Guard 1: State must be checked_in
+        # Guard 1: State must be checked_in (never bypassed)
         if self._state != CHECKIN_STATE_CHECKED_IN:
             raise ServiceValidationError(
                 f"Checkout is only available when the guest is "
                 f"checked in (current state: {self._state})"
             )
 
-        # Guard 2: Reservation boundaries must be known
         now = dt_util.now()
         end = self._tracked_event_end
 
+        # Guard 2: Reservation boundaries must be known
         if self._tracked_event_start is None or end is None:
-            raise ServiceValidationError(
-                "Checkout requires known reservation boundaries"
+            if not force:
+                raise ServiceValidationError(
+                    "Checkout requires known reservation boundaries"
+                )
+            _LOGGER.warning(
+                "Force checkout: reservation boundaries unknown "
+                "for %s, proceeding anyway",
+                self.coordinator.name,
             )
 
         # Guard 3: Must be on or after the last day of the reservation
-        local_now = dt_util.as_local(now)
-        local_end = dt_util.as_local(end)
-        if local_now.date() < local_end.date():
-            raise ServiceValidationError(
-                f"Checkout is only available on the last day of "
-                f"the reservation or later "
-                f"(current: {local_now.date().isoformat()}, "
-                f"checkout day: {local_end.date().isoformat()})"
-            )
+        if end is not None and not force:
+            local_now = dt_util.as_local(now)
+            local_end = dt_util.as_local(end)
+            if local_now.date() < local_end.date():
+                raise ServiceValidationError(
+                    f"Checkout is only available on the last day "
+                    f"of the reservation or later "
+                    f"(current: {local_now.date().isoformat()}, "
+                    f"checkout day: "
+                    f"{local_end.date().isoformat()})"
+                )
+
+        if force and end is not None:
+            local_now = dt_util.as_local(now)
+            local_end = dt_util.as_local(end)
+            if local_now.date() < local_end.date():
+                _LOGGER.warning(
+                    "Force checkout: overriding last-day guard "
+                    "for %s (current: %s, checkout day: %s)",
+                    self.coordinator.name,
+                    local_now.date().isoformat(),
+                    local_end.date().isoformat(),
+                )
 
         # Early expiry: shorten lock code if switch is on (FR-022)
         entry_data = self._hass.data.get(DOMAIN, {}).get(
@@ -1042,7 +1082,8 @@ class CheckinTrackingSensor(
                 new_end = compute_early_expiry_time(now, self._tracked_event_end)
                 if new_end < self._tracked_event_end:
                     _LOGGER.info(
-                        "Early checkout expiry: shortening end time from %s to %s for %s",
+                        "Early checkout expiry: shortening end "
+                        "time from %s to %s for %s",
                         self._tracked_event_end,
                         new_end,
                         self._tracked_event_summary,
@@ -1051,8 +1092,9 @@ class CheckinTrackingSensor(
                     await self._async_update_lock_code_expiry(new_end)
 
         # Use event end as linger baseline when past end so that
-        # follow-on event detection uses the correct reference point.
-        effective_baseline = min(now, end)
+        # follow-on event detection uses the correct reference
+        # point.  When boundaries are unknown fall back to now.
+        effective_baseline = min(now, end) if end is not None else now
         self._transition_to_checked_out(
             source="manual", linger_baseline=effective_baseline
         )

--- a/custom_components/rental_control/services.yaml
+++ b/custom_components/rental_control/services.yaml
@@ -6,3 +6,9 @@ checkout:
     entity:
       integration: rental_control
       domain: sensor
+  fields:
+    force:
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/rental_control/strings.json
+++ b/custom_components/rental_control/strings.json
@@ -103,7 +103,13 @@
   "services": {
     "checkout": {
       "name": "Checkout",
-      "description": "Manually check out the current guest."
+      "description": "Manually check out the current guest.",
+      "fields": {
+        "force": {
+          "name": "Force",
+          "description": "Bypass date and boundary guards. Use when the sensor is stuck and you need to override."
+        }
+      }
     }
   }
 }

--- a/custom_components/rental_control/translations/en.json
+++ b/custom_components/rental_control/translations/en.json
@@ -103,7 +103,13 @@
   "services": {
     "checkout": {
       "name": "Checkout",
-      "description": "Manually check out the current guest."
+      "description": "Manually check out the current guest.",
+      "fields": {
+        "force": {
+          "name": "Force",
+          "description": "Bypass date and boundary guards. Use when the sensor is stuck and you need to override."
+        }
+      }
     }
   }
 }

--- a/custom_components/rental_control/translations/fr.json
+++ b/custom_components/rental_control/translations/fr.json
@@ -103,7 +103,13 @@
   "services": {
     "checkout": {
       "name": "D\u00e9part",
-      "description": "Enregistrer manuellement le d\u00e9part du client actuel."
+      "description": "Enregistrer manuellement le d\u00e9part du client actuel.",
+      "fields": {
+        "force": {
+          "name": "Forcer",
+          "description": "Ignorer les gardes de date et de limites. Utiliser lorsque le capteur est bloqu\u00e9 et que vous devez forcer le d\u00e9part."
+        }
+      }
     }
   }
 }

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -3096,10 +3096,122 @@ class TestManualCheckout:
 
         assert sensor._state == CHECKIN_STATE_CHECKED_OUT
 
+    async def test_force_checkout_bypasses_last_day_guard(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test force=True bypasses the last-day guard (Guard 3).
 
-# ===========================================================================
-# T032: Early checkout expiry integration tests
-# ===========================================================================
+        When the upstream calendar modifies the event end to a
+        future date after the guest has physically left, the
+        admin must be able to force checkout.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - John Smith"
+        sensor._tracked_event_start = now - timedelta(days=2)
+        sensor._tracked_event_end = now + timedelta(days=3)
+        sensor._tracked_event_slot_name = "John Smith"
+        mock_checkin_coordinator.data = []
+
+        # Without force, this would raise (before last day)
+        with pytest.raises(ServiceValidationError, match="last day"):
+            await sensor.async_checkout()
+
+        # With force, it succeeds
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        await sensor.async_checkout(force=True)
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._checkout_source == "manual"
+
+    async def test_force_checkout_bypasses_unknown_boundaries(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test force=True bypasses unknown boundaries guard (Guard 2).
+
+        When tracking data is lost (e.g. upgrade from older version),
+        forced checkout must still succeed.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - Jane Doe"
+        sensor._tracked_event_start = None
+        sensor._tracked_event_end = None
+        mock_checkin_coordinator.data = []
+
+        # Without force, raises for unknown boundaries
+        with pytest.raises(ServiceValidationError, match="reservation boundaries"):
+            await sensor.async_checkout()
+
+        # With force, succeeds despite missing boundaries
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        await sensor.async_checkout(force=True)
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._checkout_source == "manual"
+
+    async def test_force_checkout_guard1_never_bypassed(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test that force=True does NOT bypass Guard 1 (state check).
+
+        Even with force, checkout only works from checked_in state.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        for state in [
+            CHECKIN_STATE_NO_RESERVATION,
+            CHECKIN_STATE_AWAITING,
+            CHECKIN_STATE_CHECKED_OUT,
+        ]:
+            sensor._state = state
+            with pytest.raises(ServiceValidationError, match="current state"):
+                await sensor.async_checkout(force=True)
+
+    async def test_force_checkout_uses_now_as_baseline_when_end_unknown(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test linger baseline falls back to now when end is unknown.
+
+        When force checkout is used with unknown boundaries, the
+        linger baseline should use now() since event end is None.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now().replace(hour=12, minute=0, second=0, microsecond=0)
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - Jane Doe"
+        sensor._tracked_event_start = None
+        sensor._tracked_event_end = None
+        mock_checkin_coordinator.data = []
+
+        with patch("homeassistant.util.dt.now", return_value=now):
+            await sensor.async_checkout(force=True)
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._checkout_time is not None
+        assert abs((sensor._checkout_time - now).total_seconds()) < 2
 
 
 def _setup_early_expiry_switch(
@@ -3747,6 +3859,33 @@ class TestEventTrackingStability:
 
         sensor._handle_coordinator_update()
         assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+
+    async def test_checked_in_resets_when_all_tracking_data_lost(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test checked_in resets to no_reservation when all data lost.
+
+        When the tracked event is gone from coordinator data and all
+        tracking metadata is None, the sensor cannot recover
+        automatically and should reset to no_reservation.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = None
+        sensor._tracked_event_start = None
+        sensor._tracked_event_end = None
+        sensor._checkin_source = "automatic"
+
+        mock_checkin_coordinator.data = []
+
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_NO_RESERVATION
 
     async def test_awaiting_survives_event_position_shift(
         self,

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -126,9 +126,13 @@ class TestAsyncSetupEntry:
             assert isinstance(sensor, RentalControlCalSensor)
             assert sensor._event_number == i
         assert isinstance(added_entities[3], CheckinTrackingSensor)
-        # Verify checkout service was registered
+        # Verify checkout service was registered with force parameter
+        import voluptuous as vol
+
         mock_platform.async_register_entity_service.assert_called_once_with(
-            "checkout", {}, "async_checkout"
+            "checkout",
+            {vol.Optional("force", default=False): bool},
+            "async_checkout",
         )
 
     async def test_returns_false_when_calendar_is_none(self, hass) -> None:

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -127,11 +127,12 @@ class TestAsyncSetupEntry:
             assert sensor._event_number == i
         assert isinstance(added_entities[3], CheckinTrackingSensor)
         # Verify checkout service was registered with force parameter
+        from homeassistant.helpers import config_validation as cv
         import voluptuous as vol
 
         mock_platform.async_register_entity_service.assert_called_once_with(
             "checkout",
-            {vol.Optional("force", default=False): bool},
+            {vol.Optional("force", default=False): cv.boolean},
             "async_checkout",
         )
 


### PR DESCRIPTION
## Problem

When the upstream calendar modifies a reservation's end time after the guest
has physically departed, the `checked_in` sensor becomes permanently stuck.
The last-day guard (Guard 3) on the manual checkout action blocks the override
because the updated end date is in the future.

## Changes

- **`async_checkout(force=False)`** — new optional `force` boolean parameter
  that bypasses Guards 2 (unknown boundaries) and 3 (last-day check) while
  Guard 1 (state must be `checked_in`) is never bypassed
- **Coordinator safety net** — resets to `no_reservation` when all tracking
  metadata is lost (summary, start, end all `None`) while in `checked_in`
- **Service schema** — `services.yaml`, `strings.json`, and `sensor.py`
  registration updated with the `force` field
- **5 new tests** — force bypasses Guard 2, Guard 3, Guard 1 never bypassed,
  linger baseline fallback, tracking-data-lost recovery
- **`# fmt: skip`** on except clause to prevent ruff format from producing
  Python 3.13-incompatible syntax in pre-commit hooks

## Testing

541 tests pass. All pre-commit hooks pass.