### PR TITLE
Feat(calsensor): Parse new description fields

### DIFF
--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -109,11 +109,20 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         """Extract the last 4 digits from a description."""
         if self._event_attributes["description"] is None:
             return None
-        p = re.compile(r"""\(?Last 4 Digits\)?:\s+(\d{4})""")
+
+        # Match "Last 4 Digits: NNNN" with optional parens
+        p = re.compile(r"""\(?Last 4 Digits\)?:\s+(\d{4})(?!\d)""")
         ret = p.findall(self._event_attributes["description"])
         if ret:
             return str(ret[0])
-        elif "Phone" in self._event_attributes["description"]:
+
+        # Match "Phone (last 4): NNNN" variant
+        p2 = re.compile(r"""Phone\s*\(last\s*4\):\s*(\d{4})(?!\d)""", re.I)
+        ret = p2.findall(self._event_attributes["description"])
+        if ret:
+            return str(ret[0])
+
+        if "Phone" in self._event_attributes["description"]:
             phone = self._extract_phone_number()
             if phone:
                 phone = phone.replace(" ", "")
@@ -168,6 +177,19 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             return str(ret[0])
         else:
             return None
+
+    def _extract_booking_id(self) -> str | None:
+        """Extract booking ID from a description."""
+        if self._event_attributes["description"] is None:
+            return None
+        p = re.compile(r"""Booking ID:\s*(.+)$""", re.M)
+        ret = p.findall(self._event_attributes["description"])
+        if ret:
+            for match in ret:
+                booking_id = str(match).strip()
+                if booking_id:
+                    return booking_id
+        return None
 
     def _generate_door_code(self) -> str:
         """Generate a door code based upon the selected type."""
@@ -358,6 +380,10 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             reservation_url = self._extract_url()
             if reservation_url is not None:
                 parsed_attributes["reservation_url"] = reservation_url
+
+            booking_id = self._extract_booking_id()
+            if booking_id is not None:
+                parsed_attributes["booking_id"] = booking_id
 
             self._parsed_attributes = parsed_attributes
 

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -455,6 +455,44 @@ class TestExtractLastFour:
         sensor._event_attributes["description"] = None
         assert sensor._extract_last_four() is None
 
+    def test_extracts_phone_last_four_format(self, hass) -> None:
+        """Verify extraction from 'Phone (last 4): NNNN' format."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = "Phone (last 4): 5098"
+        assert sensor._extract_last_four() == "5098"
+
+    def test_extracts_phone_last_four_case_insensitive(self, hass) -> None:
+        """Verify extraction from 'Phone (Last 4): NNNN' format."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = "Phone (Last 4): 9012"
+        assert sensor._extract_last_four() == "9012"
+
+    def test_phone_last_four_with_booking_id(self, hass) -> None:
+        """Verify extraction when description has both phone and booking ID."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = (
+            "Phone (last 4): 5098\n"
+            "Booking ID: 69b9b2479bed480014536503::69b96feb583a880013ba1713"
+        )
+        assert sensor._extract_last_four() == "5098"
+
+    def test_phone_last_four_rejects_five_digits(self, hass) -> None:
+        """Verify Phone (last 4) pattern rejects 5+ digit sequences."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = "Phone (last 4): 12345"
+        assert sensor._extract_last_four() is None
+
+    def test_last_4_digits_rejects_five_digits(self, hass) -> None:
+        """Verify legacy Last 4 Digits pattern rejects 5+ digit sequences."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = "Last 4 Digits: 12345"
+        assert sensor._extract_last_four() is None
+
 
 class TestExtractUrl:
     """Tests for _extract_url parsing."""
@@ -488,6 +526,52 @@ class TestExtractUrl:
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor._event_attributes["description"] = None
         assert sensor._extract_url() is None
+
+
+class TestExtractBookingId:
+    """Tests for _extract_booking_id parsing."""
+
+    def test_extracts_booking_id(self, hass) -> None:
+        """Verify extraction of Booking ID from description."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = (
+            "Booking ID: 69b9b2479bed480014536503::69b96feb583a880013ba1713"
+        )
+        assert (
+            sensor._extract_booking_id()
+            == "69b9b2479bed480014536503::69b96feb583a880013ba1713"
+        )
+
+    def test_extracts_booking_id_multiline(self, hass) -> None:
+        """Verify extraction when booking ID is among other fields."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = (
+            "Phone (last 4): 5098\nBooking ID: abc123::def456"
+        )
+        assert sensor._extract_booking_id() == "abc123::def456"
+
+    def test_returns_none_when_no_booking_id(self, hass) -> None:
+        """Verify None returned when no booking ID in description."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = "No booking here"
+        assert sensor._extract_booking_id() is None
+
+    def test_returns_none_when_description_none(self, hass) -> None:
+        """Verify None returned when description is None."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = None
+        assert sensor._extract_booking_id() is None
+
+    def test_returns_none_when_booking_id_empty(self, hass) -> None:
+        """Verify None returned when Booking ID value is empty."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = "Booking ID:   "
+        assert sensor._extract_booking_id() is None
 
 
 # ---------------------------------------------------------------------------
@@ -815,6 +899,22 @@ class TestHandleCoordinatorUpdateWithEvents:
         assert attrs["number_of_guests"] == "6"
         assert attrs["last_four"] == "6543"
         assert attrs["reservation_url"] == "https://airbnb.com/reservations/abc"
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_parses_phone_last_four_and_booking_id(self, hass) -> None:
+        """Verify extraction of Phone (last 4) and Booking ID fields."""
+        description = "Phone (last 4): 5098\nBooking ID: 69b9b247::69b96feb"
+        event = _make_event(description=description)
+        coordinator = _make_coordinator(data=[event])
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["last_four"] == "5098"
+        assert attrs["booking_id"] == "69b9b247::69b96feb"
 
     @freeze_time("2025-03-10T12:00:00+00:00")
     def test_generates_slot_code(self, hass) -> None:


### PR DESCRIPTION
## Summary

Add support for two new iCal description fields:

1. **Phone (last 4)** — New format `Phone (last 4): NNNN` as an alternative to the existing `Last 4 Digits: NNNN` for extracting the last four phone digits used in door code generation.

2. **Booking ID** — New `Booking ID: <value>` field extracted as a sensor attribute when present in event descriptions.

## Changes

### `calsensor.py`
- Update `_extract_last_four()` to match `Phone (last 4): NNNN` format (case-insensitive)
- Harden both "Last 4 Digits" and "Phone (last 4)" regexes with negative lookahead `(?!\d)` to reject 5+ digit sequences
- Add `_extract_booking_id()` method with empty/whitespace guard and multi-match iteration
- Wire `booking_id` into parsed attributes in `_handle_coordinator_update()`

### `test_sensors.py`
- Add 11 new tests covering:
  - `Phone (last 4): NNNN` extraction
  - Case insensitivity (`Phone (Last 4): NNNN`)
  - Multi-field descriptions (phone + booking ID)
  - 5+ digit rejection for both `Last 4 Digits` and `Phone (last 4)` formats
  - Booking ID extraction (simple, multiline, missing, None, empty)
  - Full integration test for parsed attributes with new format

**Test count: 552** (was 541)