### PR TITLE
Feat(checkin): add child lock check-in

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -398,6 +398,6 @@ def async_register_keymaster_listener(
     )
     hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(unsub)
     _LOGGER.debug(
-        "Registered keymaster event bus listener for lockname=%s",
-        coordinator.lockname,
+        "Registered keymaster event bus listener for monitored locknames=%s",
+        sorted(coordinator.monitored_locknames),
     )

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -315,7 +315,7 @@ def async_register_keymaster_listener(
     matching unlock events to the check-in tracking sensor.
 
     The listener validates:
-    - ``lockname`` matches ``coordinator.lockname``
+    - ``lockname`` is in ``coordinator.monitored_locknames`` (parent + children)
     - ``state`` is ``"unlocked"``
     - ``code_slot_num != 0`` (FR-017)
     - ``code_slot_num`` is in ``[start_slot, start_slot + max_events)``
@@ -325,7 +325,6 @@ def async_register_keymaster_listener(
         config_entry: The integration config entry.
     """
     coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
-    lockname = coordinator.lockname
     start_slot = coordinator.start_slot
     max_events = coordinator.max_events
 
@@ -338,8 +337,10 @@ def async_register_keymaster_listener(
         """
         event_data = event.data
 
-        # Validate lockname matches
-        if event_data.get("lockname") != lockname:
+        # Validate lockname matches parent or any child lock
+        event_lockname = event_data.get("lockname", "")
+        monitored = coordinator.monitored_locknames
+        if event_lockname not in monitored:
             return
 
         # Validate state is unlocked
@@ -383,15 +384,20 @@ def async_register_keymaster_listener(
             return
 
         _LOGGER.debug(
-            "Forwarding keymaster unlock (slot=%d) to checkin sensor",
+            "Forwarding keymaster unlock (slot=%d, lock=%s) to checkin sensor",
             code_slot_num,
+            event_lockname,
         )
         checkin_sensor.async_handle_keymaster_unlock(
             code_slot_num=code_slot_num,
+            lock_name=event_lockname,
         )
 
     unsub = hass.bus.async_listen(
         "keymaster_lock_state_changed", _handle_keymaster_event
     )
     hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(unsub)
-    _LOGGER.debug("Registered keymaster event bus listener for lockname=%s", lockname)
+    _LOGGER.debug(
+        "Registered keymaster event bus listener for lockname=%s",
+        coordinator.lockname,
+    )

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -1431,7 +1431,7 @@ class CheckinTrackingSensor(
             "Keymaster unlock detected for slot %d (lock=%s), "
             "transitioning to checked_in for %s",
             code_slot_num,
-            lock_name or "(parent)",
+            lock_name or self.coordinator.lockname,
             self._tracked_event_summary,
         )
         self._transition_to_checked_in(source="keymaster", lock_name=lock_name)

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -79,6 +79,7 @@ class CheckinExtraStoredData(ExtraStoredData):
         transition_target_time: datetime | None,
         checked_out_event_key: str | None,
         next_event_start_day: datetime | None = None,
+        checkin_lock_name: str | None = None,
     ) -> None:
         """Initialise from typed field values."""
         self.state = state
@@ -92,6 +93,7 @@ class CheckinExtraStoredData(ExtraStoredData):
         self.transition_target_time = transition_target_time
         self.checked_out_event_key = checked_out_event_key
         self.next_event_start_day = next_event_start_day
+        self.checkin_lock_name = checkin_lock_name
 
     def as_dict(self) -> dict[str, Any]:
         """Return a JSON-serialisable dict representation."""
@@ -123,6 +125,7 @@ class CheckinExtraStoredData(ExtraStoredData):
                 if self.next_event_start_day
                 else None
             ),
+            "checkin_lock_name": self.checkin_lock_name,
         }
 
     @classmethod
@@ -158,6 +161,7 @@ class CheckinExtraStoredData(ExtraStoredData):
             transition_target_time=_parse_dt(data.get("transition_target_time")),
             checked_out_event_key=data.get("checked_out_event_key"),
             next_event_start_day=_parse_dt(data.get("next_event_start_day")),
+            checkin_lock_name=data.get("checkin_lock_name"),
         )
 
 
@@ -218,6 +222,9 @@ class CheckinTrackingSensor(
         # FR-006c: Start day of the follow-on event for midnight-to-awaiting
         self._next_event_start_day: datetime | None = None
 
+        # Spec 006: Lock that triggered check-in (child lock monitoring)
+        self._checkin_lock_name: str | None = None
+
         # Follow-on event key for linger guard (not persisted)
         self._linger_followon_key: str | None = None
 
@@ -266,6 +273,7 @@ class CheckinTrackingSensor(
             "checkout_source": self._checkout_source,
             "checkout_time": self._checkout_time,
             "next_transition": self._transition_target_time,
+            "lock_name": self._checkin_lock_name,
         }
 
     @property
@@ -287,6 +295,7 @@ class CheckinTrackingSensor(
             transition_target_time=self._transition_target_time,
             checked_out_event_key=self._checked_out_event_key,
             next_event_start_day=self._next_event_start_day,
+            checkin_lock_name=self._checkin_lock_name,
         )
 
     @staticmethod
@@ -605,6 +614,7 @@ class CheckinTrackingSensor(
         self._checkout_time = None
         self._checked_out_event_key = None
         self._next_event_start_day = None
+        self._checkin_lock_name = None
         self._linger_followon_key = None
         self._linger_baseline = None
         self._event_missing_warned = False
@@ -630,7 +640,7 @@ class CheckinTrackingSensor(
 
         self.async_write_ha_state()
 
-    def _transition_to_checked_in(self, source: str) -> None:
+    def _transition_to_checked_in(self, source: str, lock_name: str = "") -> None:
         """Transition to checked_in state.
 
         Fires a check-in event on the HA event bus and schedules auto
@@ -638,36 +648,40 @@ class CheckinTrackingSensor(
 
         Args:
             source: How check-in occurred (``keymaster`` or ``automatic``).
+            lock_name: The lock that triggered check-in (empty if automatic).
         """
         _LOGGER.debug(
-            "Transitioning to checked_in (source=%s) for event: %s",
+            "Transitioning to checked_in (source=%s, lock=%s) for event: %s",
             source,
+            lock_name or "(none)",
             self._tracked_event_summary,
         )
         self._state = CHECKIN_STATE_CHECKED_IN
         self._checkin_source = source
+        self._checkin_lock_name = lock_name or None
         self._transition_target_time = None
         self._event_missing_warned = False
 
         # Fire check-in event (per contracts/events.md)
+        event_payload: dict[str, Any] = {
+            "entity_id": self.entity_id,
+            "summary": self._tracked_event_summary or "",
+            "start": (
+                self._tracked_event_start.isoformat()
+                if self._tracked_event_start
+                else ""
+            ),
+            "end": (
+                self._tracked_event_end.isoformat() if self._tracked_event_end else ""
+            ),
+            "guest_name": self._tracked_event_slot_name or "",
+            "source": source,
+        }
+        if lock_name:
+            event_payload["lock_name"] = lock_name
         self._hass.bus.async_fire(
             EVENT_RENTAL_CONTROL_CHECKIN,
-            {
-                "entity_id": self.entity_id,
-                "summary": self._tracked_event_summary or "",
-                "start": (
-                    self._tracked_event_start.isoformat()
-                    if self._tracked_event_start
-                    else ""
-                ),
-                "end": (
-                    self._tracked_event_end.isoformat()
-                    if self._tracked_event_end
-                    else ""
-                ),
-                "guest_name": self._tracked_event_slot_name or "",
-                "source": source,
-            },
+            event_payload,
         )
 
         # Schedule auto check-out at event end time
@@ -863,6 +877,7 @@ class CheckinTrackingSensor(
         self._checkout_time = None
         self._transition_target_time = None
         self._checked_out_event_key = None
+        self._checkin_lock_name = None
         self._linger_followon_key = None
         self._linger_baseline = None
         self._event_missing_warned = False
@@ -1127,6 +1142,7 @@ class CheckinTrackingSensor(
             self._transition_target_time = restored.transition_target_time
             self._checked_out_event_key = restored.checked_out_event_key
             self._next_event_start_day = restored.next_event_start_day
+            self._checkin_lock_name = restored.checkin_lock_name
 
             _LOGGER.debug(
                 "Restored state '%s' for %s", self._state, self.coordinator.name
@@ -1347,6 +1363,7 @@ class CheckinTrackingSensor(
     def async_handle_keymaster_unlock(
         self,
         code_slot_num: int,
+        lock_name: str = "",
     ) -> None:
         """Handle a keymaster unlock event.
 
@@ -1362,6 +1379,7 @@ class CheckinTrackingSensor(
 
         Args:
             code_slot_num: The keymaster code slot number that was used.
+            lock_name: The lockname from the keymaster event (parent or child).
         """
         # FR-017: Ignore manual/RF unlocks (code_slot_num == 0)
         if code_slot_num == 0:
@@ -1410,11 +1428,13 @@ class CheckinTrackingSensor(
 
         # All conditions met — transition to checked_in
         _LOGGER.info(
-            "Keymaster unlock detected for slot %d, transitioning to checked_in for %s",
+            "Keymaster unlock detected for slot %d (lock=%s), "
+            "transitioning to checked_in for %s",
             code_slot_num,
+            lock_name or "(parent)",
             self._tracked_event_summary,
         )
-        self._transition_to_checked_in(source="keymaster")
+        self._transition_to_checked_in(source="keymaster", lock_name=lock_name)
 
     async def _async_update_lock_code_expiry(self, new_end: datetime) -> None:
         """Update keymaster lock code expiry after early checkout.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,6 +202,7 @@ def mock_checkin_coordinator(
     coordinator.data = []
     coordinator.last_update_success = True
     coordinator.lockname = None
+    coordinator.monitored_locknames = frozenset()
     coordinator.start_slot = 10
     coordinator.max_events = 3
     coordinator.checkin = time(16, 0)

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -21,12 +21,15 @@ from __future__ import annotations
 from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Generator
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from homeassistant.components.calendar import CalendarEvent
+from homeassistant.core import Event
+from homeassistant.core import callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 import pytest
@@ -44,6 +47,9 @@ from custom_components.rental_control.const import EVENT_RENTAL_CONTROL_CHECKIN
 from custom_components.rental_control.const import EVENT_RENTAL_CONTROL_CHECKOUT
 from custom_components.rental_control.const import KEYMASTER_MONITORING_SWITCH
 from custom_components.rental_control.const import UNSUB_LISTENERS
+from custom_components.rental_control.sensors.checkinsensor import (
+    CheckinExtraStoredData,
+)
 from custom_components.rental_control.sensors.checkinsensor import CheckinTrackingSensor
 
 if TYPE_CHECKING:
@@ -2358,6 +2364,7 @@ class TestEventBusListenerFiltering:
         from custom_components.rental_control.const import UNSUB_LISTENERS
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
 
@@ -2385,6 +2392,7 @@ class TestEventBusListenerFiltering:
 
         sensor.async_handle_keymaster_unlock.assert_called_once_with(
             code_slot_num=11,
+            lock_name="front_door",
         )
 
     async def test_wrong_lockname_not_forwarded(
@@ -2402,6 +2410,7 @@ class TestEventBusListenerFiltering:
         from custom_components.rental_control.const import UNSUB_LISTENERS
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
 
@@ -2444,6 +2453,7 @@ class TestEventBusListenerFiltering:
         from custom_components.rental_control.const import UNSUB_LISTENERS
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
 
@@ -2486,6 +2496,7 @@ class TestEventBusListenerFiltering:
         from custom_components.rental_control.const import UNSUB_LISTENERS
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
 
@@ -2528,6 +2539,7 @@ class TestEventBusListenerFiltering:
         from custom_components.rental_control.const import UNSUB_LISTENERS
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
 
@@ -2570,6 +2582,7 @@ class TestEventBusListenerFiltering:
         from custom_components.rental_control.const import UNSUB_LISTENERS
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
 
@@ -2629,6 +2642,7 @@ class TestEventBusListenerFiltering:
         from custom_components.rental_control.const import UNSUB_LISTENERS
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
 
@@ -2668,6 +2682,7 @@ class TestEventBusListenerFiltering:
         from custom_components.rental_control.const import UNSUB_LISTENERS
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
 
@@ -2709,6 +2724,7 @@ class TestEventBusListenerFiltering:
         from custom_components.rental_control.const import UNSUB_LISTENERS
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
         mock_checkin_coordinator.start_slot = 10
         mock_checkin_coordinator.max_events = 3
 
@@ -2735,6 +2751,298 @@ class TestEventBusListenerFiltering:
 
         sensor.async_handle_keymaster_unlock.assert_not_called()
         assert sensor._unsub_timer is not None
+
+
+# ===========================================================================
+# Spec 006: Child lock monitoring tests
+# ===========================================================================
+
+
+class TestChildLockEventHandling:
+    """Tests for child lock unlock events triggering check-in (spec 006)."""
+
+    async def test_child_lock_unlock_forwarded_to_sensor(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test child lock unlock event is forwarded to checkin sensor."""
+        from custom_components.rental_control import async_register_keymaster_listener
+        from custom_components.rental_control.const import CHECKIN_SENSOR
+        from custom_components.rental_control.const import COORDINATOR
+        from custom_components.rental_control.const import DOMAIN
+        from custom_components.rental_control.const import KEYMASTER_MONITORING_SWITCH
+        from custom_components.rental_control.const import UNSUB_LISTENERS
+
+        mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset(
+            {"front_door", "side_door"}
+        )
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        sensor = MagicMock()
+        mock_checkin_config_entry.add_to_hass(hass)
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            COORDINATOR: mock_checkin_coordinator,
+            UNSUB_LISTENERS: [],
+            CHECKIN_SENSOR: sensor,
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=True),
+        }
+
+        async_register_keymaster_listener(hass, mock_checkin_config_entry)
+
+        hass.bus.async_fire(
+            "keymaster_lock_state_changed",
+            {
+                "lockname": "side_door",
+                "state": "unlocked",
+                "code_slot_num": 11,
+            },
+        )
+        await hass.async_block_till_done()
+
+        sensor.async_handle_keymaster_unlock.assert_called_once_with(
+            code_slot_num=11,
+            lock_name="side_door",
+        )
+
+    async def test_unknown_lock_not_forwarded(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test unrelated lock event is not forwarded."""
+        from custom_components.rental_control import async_register_keymaster_listener
+        from custom_components.rental_control.const import CHECKIN_SENSOR
+        from custom_components.rental_control.const import COORDINATOR
+        from custom_components.rental_control.const import DOMAIN
+        from custom_components.rental_control.const import KEYMASTER_MONITORING_SWITCH
+        from custom_components.rental_control.const import UNSUB_LISTENERS
+
+        mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset(
+            {"front_door", "side_door"}
+        )
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        sensor = MagicMock()
+        mock_checkin_config_entry.add_to_hass(hass)
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            COORDINATOR: mock_checkin_coordinator,
+            UNSUB_LISTENERS: [],
+            CHECKIN_SENSOR: sensor,
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=True),
+        }
+
+        async_register_keymaster_listener(hass, mock_checkin_config_entry)
+
+        hass.bus.async_fire(
+            "keymaster_lock_state_changed",
+            {
+                "lockname": "garage_door",
+                "state": "unlocked",
+                "code_slot_num": 11,
+            },
+        )
+        await hass.async_block_till_done()
+
+        sensor.async_handle_keymaster_unlock.assert_not_called()
+
+    async def test_lock_name_in_event_payload(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test lock_name appears in check-in event payload."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        now = dt_util.now()
+        event = CalendarEvent(
+            summary="Reserved - Test Guest",
+            start=now + timedelta(hours=1),
+            end=now + timedelta(hours=23),
+        )
+        mock_checkin_coordinator.data = [event]
+
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+
+        events_fired: list[dict[str, Any]] = []
+
+        @callback
+        def _capture_event(event: Event) -> None:
+            """Capture fired events for assertion."""
+            events_fired.append(event.data)
+
+        hass.bus.async_listen(EVENT_RENTAL_CONTROL_CHECKIN, _capture_event)
+
+        sensor.async_handle_keymaster_unlock(code_slot_num=10, lock_name="side_door")
+        await hass.async_block_till_done()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+        assert len(events_fired) == 1
+        assert events_fired[0]["lock_name"] == "side_door"
+        assert events_fired[0]["source"] == "keymaster"
+
+    async def test_lock_name_in_extra_state_attributes(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test lock_name appears in extra_state_attributes."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        now = dt_util.now()
+        event = CalendarEvent(
+            summary="Reserved - Test Guest",
+            start=now + timedelta(hours=1),
+            end=now + timedelta(hours=23),
+        )
+        mock_checkin_coordinator.data = [event]
+
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+
+        sensor.async_handle_keymaster_unlock(code_slot_num=10, lock_name="side_door")
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["lock_name"] == "side_door"
+
+    async def test_lock_name_cleared_on_state_reset(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test lock_name is cleared on state resets."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        now = dt_util.now()
+        event = CalendarEvent(
+            summary="Reserved - Test Guest",
+            start=now + timedelta(hours=1),
+            end=now + timedelta(hours=23),
+        )
+        mock_checkin_coordinator.data = [event]
+
+        sensor._handle_coordinator_update()
+        sensor.async_handle_keymaster_unlock(code_slot_num=10, lock_name="side_door")
+        assert sensor._checkin_lock_name == "side_door"
+
+        # Transition to no_reservation clears it
+        sensor._transition_to_no_reservation()
+        assert sensor._checkin_lock_name is None
+        assert sensor.extra_state_attributes["lock_name"] is None
+
+    async def test_lock_name_persisted_and_restored(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test lock_name survives persist/restore cycle."""
+        stored = CheckinExtraStoredData(
+            state=CHECKIN_STATE_CHECKED_IN,
+            tracked_event_summary="Reserved - Test",
+            tracked_event_start=dt_util.now() - timedelta(hours=1),
+            tracked_event_end=dt_util.now() + timedelta(hours=23),
+            tracked_event_slot_name="Test",
+            checkin_source="keymaster",
+            checkout_source=None,
+            checkout_time=None,
+            transition_target_time=None,
+            checked_out_event_key=None,
+            checkin_lock_name="side_door",
+        )
+        data = stored.as_dict()
+        assert data["checkin_lock_name"] == "side_door"
+
+        restored = CheckinExtraStoredData.from_dict(data)
+        assert restored.checkin_lock_name == "side_door"
+
+    async def test_automatic_checkin_has_no_lock_name(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test automatic check-in has no lock_name set."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        now = dt_util.now()
+        event = CalendarEvent(
+            summary="Reserved - Test Guest",
+            start=now - timedelta(hours=1),
+            end=now + timedelta(hours=23),
+        )
+        mock_checkin_coordinator.data = [event]
+
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+        assert sensor._checkin_lock_name is None
+        assert sensor.extra_state_attributes["lock_name"] is None
+
+    async def test_simultaneous_parent_child_single_checkin(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test simultaneous parent and child unlock → single check-in.
+
+        The state machine prevents double check-in: the first unlock
+        transitions to checked_in, the second is ignored.
+        """
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        now = dt_util.now()
+        event = CalendarEvent(
+            summary="Reserved - Test Guest",
+            start=now + timedelta(hours=1),
+            end=now + timedelta(hours=23),
+        )
+        mock_checkin_coordinator.data = [event]
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+
+        # First unlock (child lock) — transitions to checked_in
+        sensor.async_handle_keymaster_unlock(code_slot_num=10, lock_name="side_door")
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+        assert sensor._checkin_lock_name == "side_door"
+
+        # Second unlock (parent lock) — ignored, already checked in
+        sensor.async_handle_keymaster_unlock(code_slot_num=10, lock_name="front_door")
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+        assert sensor._checkin_lock_name == "side_door"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Track which lock triggered a keymaster check-in by adding `lock_name` to event payload, extra attributes, and persisted state. The event listener now matches against `coordinator.monitored_locknames` (frozenset of parent + children) instead of a single lockname.

## Changes

### `checkinsensor.py`
- Added `checkin_lock_name` field to `CheckinExtraStoredData` for persistence
- Added `_checkin_lock_name` instance field with `lock_name` in `extra_state_attributes`
- Added `lock_name` parameter to `async_handle_keymaster_unlock()` and `_transition_to_checked_in()`
- Lock name included in `EVENT_RENTAL_CONTROL_CHECKIN` payload (only when non-empty)
- Lock name cleared on state reset (`awaiting_checkin`, `no_reservation`)

### `__init__.py`
- Changed keymaster event listener to use `coordinator.monitored_locknames` set membership
- Passes `lock_name=event_lockname` through to the sensor

### Tests
- Updated 9 existing event bus listener tests for `monitored_locknames`
- Added 8 new tests in `TestChildLockEventHandling`:
  - Child lock unlock forwarded to sensor
  - Unknown lock rejected
  - Lock name in event payload
  - Lock name in extra_state_attributes
  - Lock name cleared on state reset
  - Lock name persisted and restored
  - Automatic check-in has no lock_name
  - Simultaneous parent+child → single check-in

## Test Results
570 tests pass (562 existing + 8 new)

## Part of
Spec 006: Child Lock Monitoring — Phase 3 (US1: Child lock unlock triggers check-in)