### PR TITLE
Fix(checkin): slugify keymaster event lockname

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -31,6 +31,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.util import slugify
 
 from .const import CHECKIN_SENSOR
 from .const import CONF_CODE_LENGTH
@@ -337,8 +338,16 @@ def async_register_keymaster_listener(
         """
         event_data = event.data
 
-        # Validate lockname matches parent or any child lock
-        event_lockname = event_data.get("lockname", "")
+        # Validate lockname matches parent or any child lock.
+        # Keymaster sends the raw (friendly) lockname in event data,
+        # but monitored_locknames contains slugified names, so we
+        # must slugify before comparison.
+        raw_lockname = event_data.get("lockname", "")
+        event_lockname = (
+            slugify(raw_lockname)
+            if raw_lockname and isinstance(raw_lockname, str)
+            else ""
+        )
         monitored = coordinator.monitored_locknames
         if event_lockname not in monitored:
             return
@@ -386,11 +395,11 @@ def async_register_keymaster_listener(
         _LOGGER.debug(
             "Forwarding keymaster unlock (slot=%d, lock=%s) to checkin sensor",
             code_slot_num,
-            event_lockname,
+            raw_lockname,
         )
         checkin_sensor.async_handle_keymaster_unlock(
             code_slot_num=code_slot_num,
-            lock_name=event_lockname,
+            lock_name=raw_lockname,
         )
 
     unsub = hass.bus.async_listen(

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -2753,6 +2753,113 @@ class TestEventBusListenerFiltering:
         sensor.async_handle_keymaster_unlock.assert_not_called()
         assert sensor._unsub_timer is not None
 
+    async def test_raw_lockname_with_spaces_matched(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test raw lockname with spaces and capitals is matched.
+
+        Keymaster sends the friendly lockname (e.g. "Front Door")
+        while monitored_locknames contains slugified names
+        (e.g. "front_door").  The listener must slugify the event
+        lockname before comparison.
+        """
+        from custom_components.rental_control import async_register_keymaster_listener
+        from custom_components.rental_control.const import CHECKIN_SENSOR
+        from custom_components.rental_control.const import COORDINATOR
+        from custom_components.rental_control.const import DOMAIN
+        from custom_components.rental_control.const import KEYMASTER_MONITORING_SWITCH
+        from custom_components.rental_control.const import UNSUB_LISTENERS
+
+        mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset({"front_door"})
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        sensor = MagicMock()
+        mock_checkin_config_entry.add_to_hass(hass)
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            COORDINATOR: mock_checkin_coordinator,
+            UNSUB_LISTENERS: [],
+            CHECKIN_SENSOR: sensor,
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=True),
+        }
+
+        async_register_keymaster_listener(hass, mock_checkin_config_entry)
+
+        # Fire event with raw lockname containing spaces and capitals
+        hass.bus.async_fire(
+            "keymaster_lock_state_changed",
+            {
+                "lockname": "Front Door",
+                "state": "unlocked",
+                "code_slot_num": 11,
+            },
+        )
+        await hass.async_block_till_done()
+
+        sensor.async_handle_keymaster_unlock.assert_called_once_with(
+            code_slot_num=11,
+            lock_name="Front Door",
+        )
+
+    async def test_raw_child_lockname_with_spaces_matched(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test raw child lockname with spaces is matched.
+
+        Validates that child lock events with friendly locknames
+        are properly matched against the slugified
+        monitored_locknames set.
+        """
+        from custom_components.rental_control import async_register_keymaster_listener
+        from custom_components.rental_control.const import CHECKIN_SENSOR
+        from custom_components.rental_control.const import COORDINATOR
+        from custom_components.rental_control.const import DOMAIN
+        from custom_components.rental_control.const import KEYMASTER_MONITORING_SWITCH
+        from custom_components.rental_control.const import UNSUB_LISTENERS
+
+        mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.monitored_locknames = frozenset(
+            {"front_door", "side_door"}
+        )
+        mock_checkin_coordinator.start_slot = 10
+        mock_checkin_coordinator.max_events = 3
+
+        sensor = MagicMock()
+        mock_checkin_config_entry.add_to_hass(hass)
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            COORDINATOR: mock_checkin_coordinator,
+            UNSUB_LISTENERS: [],
+            CHECKIN_SENSOR: sensor,
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=True),
+        }
+
+        async_register_keymaster_listener(hass, mock_checkin_config_entry)
+
+        # Fire event with raw child lockname
+        hass.bus.async_fire(
+            "keymaster_lock_state_changed",
+            {
+                "lockname": "Side Door",
+                "state": "unlocked",
+                "code_slot_num": 11,
+            },
+        )
+        await hass.async_block_till_done()
+
+        sensor.async_handle_keymaster_unlock.assert_called_once_with(
+            code_slot_num=11,
+            lock_name="Side Door",
+        )
+
 
 # ===========================================================================
 # Spec 006: Child lock monitoring tests


### PR DESCRIPTION
## Problem

Keymaster sends the raw friendly lockname in event data (e.g. `"Akuvox Relay A"`) while `monitored_locknames` contains slugified names (e.g. `"akuvox_relay_a"`). The set-membership check silently rejected **every** keymaster event because the formats never matched, completely breaking check-in via keymaster unlock for both parent and child locks.

## Root Cause

The Phase 3 changes (PR #463) replaced the old single-string equality check with a set-membership check against `coordinator.monitored_locknames`, but the event lockname was used as-is (raw) while the set contains slugified names.

Note: the old code had the same fundamental mismatch (`event_data.get("lockname") != coordinator.lockname` where `coordinator.lockname` is slugified), but it was masked by the fact that the configured locknames happened to already match their slugified form.

## Fix

- Slugify the event lockname before the set-membership check
- Pass the raw (friendly) lockname downstream for display/persistence
- Add `isinstance(raw_lockname, str)` guard against non-string values
- Add 2 regression tests verifying raw locknames with spaces/capitals are matched

## Testing

- 579 tests pass (577 existing + 2 new)
- All pre-commit hooks pass