### PR TITLE
Feat(checkin): add set_state debug action

### DIFF
--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -86,4 +86,11 @@ async def async_setup_entry(
         "async_checkout",
     )
 
+    # Register debug set_state entity service
+    platform.async_register_entity_service(
+        "set_state",
+        {vol.Required("state"): cv.string},
+        "async_set_state",
+    )
+
     return True

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -1144,7 +1144,10 @@ class CheckinTrackingSensor(
         guard conditions and transition logic.  It performs a raw
         state assignment, clears all tracked event and transition
         fields, cancels pending timers, and writes HA state.
-        No HA bus events are fired.
+        This does not fire the integration's custom
+        ``rental_control`` check-in/checkout bus events, but
+        ``async_write_ha_state()`` still emits Home Assistant's
+        standard ``state_changed`` event.
 
         Args:
             state: Target state — must be one of the four valid

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -1137,6 +1137,53 @@ class CheckinTrackingSensor(
             source="manual", linger_baseline=effective_baseline
         )
 
+    async def async_set_state(self, state: str) -> None:
+        """Force-set the sensor to an arbitrary valid state.
+
+        This is a **debug / testing** action that bypasses all
+        guard conditions and transition logic.  It performs a raw
+        state assignment, clears all tracked event and transition
+        fields, cancels pending timers, and writes HA state.
+        No HA bus events are fired.
+
+        Args:
+            state: Target state — must be one of the four valid
+                check-in states.
+
+        Raises:
+            ServiceValidationError: If *state* is not valid.
+        """
+        valid = self._attr_options
+        if valid is None or state not in valid:
+            raise ServiceValidationError(
+                f"Invalid state '{state}'. Valid states: {', '.join(valid or [])}"
+            )
+
+        _LOGGER.warning(
+            "DEBUG override: forcing %s from '%s' to '%s'",
+            self.entity_id,
+            self._state,
+            state,
+        )
+
+        self._state = state
+        self._tracked_event_summary = None
+        self._tracked_event_start = None
+        self._tracked_event_end = None
+        self._tracked_event_slot_name = None
+        self._checkin_source = None
+        self._checkout_source = None
+        self._checkout_time = None
+        self._transition_target_time = None
+        self._checked_out_event_key = None
+        self._next_event_start_day = None
+        self._checkin_lock_name = None
+        self._linger_followon_key = None
+        self._linger_baseline = None
+        self._event_missing_warned = False
+        self._cancel_timer()
+        self.async_write_ha_state()
+
     async def async_added_to_hass(self) -> None:
         """Restore persisted state and validate against current time/data.
 

--- a/custom_components/rental_control/services.yaml
+++ b/custom_components/rental_control/services.yaml
@@ -12,3 +12,19 @@ checkout:
       default: false
       selector:
         boolean:
+
+set_state:
+  target:
+    entity:
+      integration: rental_control
+      domain: sensor
+  fields:
+    state:
+      required: true
+      selector:
+        select:
+          options:
+            - no_reservation
+            - awaiting_checkin
+            - checked_in
+            - checked_out

--- a/custom_components/rental_control/strings.json
+++ b/custom_components/rental_control/strings.json
@@ -34,7 +34,7 @@
           "verify_ssl": "Verify SSL certificates"
         },
         "data_description": {
-          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)"
+          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5\u201348)"
         }
       }
     }
@@ -74,7 +74,7 @@
           "verify_ssl": "Verify SSL certificates"
         },
         "data_description": {
-          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)"
+          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5\u201348)"
         }
       }
     }
@@ -108,6 +108,16 @@
         "force": {
           "name": "Force",
           "description": "Bypass date and boundary guards. Use when the sensor is stuck and you need to override."
+        }
+      }
+    },
+    "set_state": {
+      "name": "Set state",
+      "description": "Force the check-in sensor into any valid state. Debug tool \u2014 bypasses all guard conditions and fires no events.",
+      "fields": {
+        "state": {
+          "name": "State",
+          "description": "Target state for the check-in sensor."
         }
       }
     }

--- a/custom_components/rental_control/strings.json
+++ b/custom_components/rental_control/strings.json
@@ -34,7 +34,7 @@
           "verify_ssl": "Verify SSL certificates"
         },
         "data_description": {
-          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5\u201348)"
+          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)"
         }
       }
     }
@@ -74,7 +74,7 @@
           "verify_ssl": "Verify SSL certificates"
         },
         "data_description": {
-          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5\u201348)"
+          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)"
         }
       }
     }
@@ -113,7 +113,7 @@
     },
     "set_state": {
       "name": "Set state",
-      "description": "Force the check-in sensor into any valid state. Debug tool \u2014 bypasses all guard conditions and fires no events.",
+      "description": "Force the check-in sensor into any valid state. Debug tool — bypasses all guard conditions and does not fire the integration's custom check-in/checkout events.",
       "fields": {
         "state": {
           "name": "State",

--- a/custom_components/rental_control/translations/en.json
+++ b/custom_components/rental_control/translations/en.json
@@ -34,7 +34,7 @@
           "verify_ssl": "Verify SSL certificates"
         },
         "data_description": {
-          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)"
+          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5\u201348)"
         }
       }
     }
@@ -74,7 +74,7 @@
           "verify_ssl": "Verify SSL certificates"
         },
         "data_description": {
-          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)"
+          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5\u201348)"
         }
       }
     }
@@ -108,6 +108,16 @@
         "force": {
           "name": "Force",
           "description": "Bypass date and boundary guards. Use when the sensor is stuck and you need to override."
+        }
+      }
+    },
+    "set_state": {
+      "name": "Set state",
+      "description": "Force the check-in sensor into any valid state. Debug tool \u2014 bypasses all guard conditions and fires no events.",
+      "fields": {
+        "state": {
+          "name": "State",
+          "description": "Target state for the check-in sensor."
         }
       }
     }

--- a/custom_components/rental_control/translations/en.json
+++ b/custom_components/rental_control/translations/en.json
@@ -34,7 +34,7 @@
           "verify_ssl": "Verify SSL certificates"
         },
         "data_description": {
-          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5\u201348)"
+          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)"
         }
       }
     }
@@ -74,7 +74,7 @@
           "verify_ssl": "Verify SSL certificates"
         },
         "data_description": {
-          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5\u201348)"
+          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)"
         }
       }
     }
@@ -113,7 +113,7 @@
     },
     "set_state": {
       "name": "Set state",
-      "description": "Force the check-in sensor into any valid state. Debug tool \u2014 bypasses all guard conditions and fires no events.",
+      "description": "Force the check-in sensor into any valid state. Debug tool — bypasses all guard conditions and does not fire the integration's custom check-in/checkout events.",
       "fields": {
         "state": {
           "name": "State",

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -4985,3 +4985,135 @@ class TestEventTrackingStability:
         # Key cleared, timer recomputed for cleaning window
         assert sensor._linger_followon_key is None
         assert sensor._transition_target_time != first_target
+
+
+class TestSetState:
+    """Tests for the debug set_state action."""
+
+    async def test_set_state_to_each_valid_state(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test forcing the sensor into each valid state."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        assert sensor._state == CHECKIN_STATE_NO_RESERVATION
+
+        for target in [
+            CHECKIN_STATE_AWAITING,
+            CHECKIN_STATE_CHECKED_IN,
+            CHECKIN_STATE_CHECKED_OUT,
+            CHECKIN_STATE_NO_RESERVATION,
+        ]:
+            await sensor.async_set_state(state=target)
+            assert sensor._state == target
+
+    async def test_set_state_rejects_invalid_state(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test that an invalid state raises ServiceValidationError."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        with pytest.raises(ServiceValidationError, match="Invalid state"):
+            await sensor.async_set_state(state="bogus")
+
+    async def test_set_state_clears_transition_fields(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test that set_state clears all tracked and transition fields."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        # Manually set fields to non-None values
+        sensor._tracked_event_summary = "Test Event"
+        sensor._tracked_event_start = dt_util.now()
+        sensor._tracked_event_end = dt_util.now()
+        sensor._tracked_event_slot_name = "John"
+        sensor._checkin_source = "automatic"
+        sensor._checkout_source = "manual"
+        sensor._checkout_time = dt_util.now()
+        sensor._transition_target_time = dt_util.now()
+        sensor._checked_out_event_key = "key"
+        sensor._next_event_start_day = dt_util.now()
+        sensor._checkin_lock_name = "front_door"
+        sensor._linger_followon_key = "followon"
+        sensor._linger_baseline = dt_util.now()
+
+        await sensor.async_set_state(state=CHECKIN_STATE_AWAITING)
+
+        assert sensor._state == CHECKIN_STATE_AWAITING
+        assert sensor._tracked_event_summary is None
+        assert sensor._tracked_event_start is None
+        assert sensor._tracked_event_end is None
+        assert sensor._tracked_event_slot_name is None
+        assert sensor._checkin_source is None
+        assert sensor._checkout_source is None
+        assert sensor._checkout_time is None
+        assert sensor._transition_target_time is None
+        assert sensor._checked_out_event_key is None
+        assert sensor._next_event_start_day is None
+        assert sensor._checkin_lock_name is None
+        assert sensor._linger_followon_key is None
+        assert sensor._linger_baseline is None
+
+    async def test_set_state_cancels_pending_timer(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test that set_state cancels any pending timer."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        cancel_called = False
+
+        def _mock_cancel() -> None:
+            """Track that cancel was called."""
+            nonlocal cancel_called
+            cancel_called = True
+
+        sensor._unsub_timer = _mock_cancel
+
+        await sensor.async_set_state(state=CHECKIN_STATE_CHECKED_IN)
+        assert cancel_called
+        assert sensor._unsub_timer is None
+
+    async def test_set_state_does_not_fire_events(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test that set_state does not fire bus events."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        fired: list = []
+        hass.bus.async_listen(
+            EVENT_RENTAL_CONTROL_CHECKIN,
+            lambda e: fired.append(e),
+        )
+        hass.bus.async_listen(
+            EVENT_RENTAL_CONTROL_CHECKOUT,
+            lambda e: fired.append(e),
+        )
+
+        await sensor.async_set_state(state=CHECKIN_STATE_CHECKED_IN)
+        await hass.async_block_till_done()
+
+        assert len(fired) == 0

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -10,6 +10,7 @@ from datetime import timezone
 import random
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import call
 from unittest.mock import patch
 
 from freezegun import freeze_time
@@ -126,14 +127,21 @@ class TestAsyncSetupEntry:
             assert isinstance(sensor, RentalControlCalSensor)
             assert sensor._event_number == i
         assert isinstance(added_entities[3], CheckinTrackingSensor)
-        # Verify checkout service was registered with force parameter
+        # Verify checkout and set_state services were registered
         from homeassistant.helpers import config_validation as cv
         import voluptuous as vol
 
-        mock_platform.async_register_entity_service.assert_called_once_with(
+        calls = mock_platform.async_register_entity_service.call_args_list
+        assert len(calls) == 2
+        assert calls[0] == call(
             "checkout",
             {vol.Optional("force", default=False): cv.boolean},
             "async_checkout",
+        )
+        assert calls[1] == call(
+            "set_state",
+            {vol.Required("state"): cv.string},
+            "async_set_state",
         )
 
     async def test_returns_false_when_calendar_is_none(self, hass) -> None:


### PR DESCRIPTION
## Summary

Adds a `set_state` entity service that forces the check-in sensor into any valid state (`no_reservation`, `awaiting_checkin`, `checked_in`, `checked_out`), bypassing all guard conditions and transition logic.

## Motivation

Testing the check-in state machine in production requires waiting for real calendar events to progress through states, which can take days between transitions. This debug tool enables rapid state manipulation for testing.

## Changes

- **`checkinsensor.py`**: Added `async_set_state()` method — validates target state, clears all tracked event/transition/linger fields, cancels timers, logs a warning, and writes HA state. No bus events are fired.
- **`sensor.py`**: Registered `set_state` entity service with `state` (required string) parameter.
- **`services.yaml`**: Added service definition with select dropdown for valid states.
- **`strings.json` / `translations/en.json`**: Added service name and description strings.
- **Tests**: 5 new tests covering valid states, invalid state rejection, field clearing, timer cancellation, and no-event-bus verification. Updated existing service registration test.

## Testing

586 tests pass (581 existing + 5 new). All linting, mypy, and interrogate checks pass.