### PR TITLE
Chore(ci): ignore cryptography CVEs in grype

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -17,6 +17,7 @@ ignore:
   - vulnerability: GHSA-m959-cc7f-wv43
     package:
       name: cryptography
+      version: "46.0.5"
       type: python
 
   # cryptography transitive dependency via
@@ -25,4 +26,5 @@ ignore:
   - vulnerability: GHSA-p423-j2cm-9vmq
     package:
       name: cryptography
+      version: "46.0.5"
       type: python

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,3 +10,19 @@ ignore:
     package:
       name: PyJWT
       type: python
+
+  # cryptography transitive dependency via
+  # homeassistant — we cannot pin it directly.
+  # Fixed in 46.0.6.
+  - vulnerability: GHSA-m959-cc7f-wv43
+    package:
+      name: cryptography
+      type: python
+
+  # cryptography transitive dependency via
+  # homeassistant — we cannot pin it directly.
+  # Fixed in 46.0.7.
+  - vulnerability: GHSA-p423-j2cm-9vmq
+    package:
+      name: cryptography
+      type: python


### PR DESCRIPTION
## Summary

Adds two cryptography CVEs to the grype ignore list to unblock the SBOM job and release pipeline.

### Ignored vulnerabilities

| GHSA | Package | Installed | Fixed In | Severity |
|------|---------|-----------|----------|----------|
| GHSA-m959-cc7f-wv43 | cryptography | 46.0.5 | 46.0.6 | Low |
| GHSA-p423-j2cm-9vmq | cryptography | 46.0.5 | 46.0.7 | Medium |

Both are transitive dependencies pulled in by `homeassistant` and cannot be pinned directly by this integration.