### PR TITLE
Docs(agents): add worktree path convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,8 @@ other work, **always** place them in the sibling `worktrees/` directory:
 git worktree add /home/tykeal/repos/personal/homeassistant/worktrees/<branch-name> -b <branch-name> main
 ```
 
-The worktree path is relative to the repository root's parent:
+The `worktrees/` directory is a sibling of the repository under the
+repository root's parent directory:
 
 ```
 repos/personal/homeassistant/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,34 @@ All new source files MUST include SPDX headers:
 
 Check `REUSE.toml` for file-type-specific header requirements.
 
+## Git Worktrees
+
+When creating git worktrees for feature branches, bug fixes, or any
+other work, **always** place them in the sibling `worktrees/` directory:
+
+```bash
+git worktree add /home/tykeal/repos/personal/homeassistant/worktrees/<branch-name> -b <branch-name> main
+```
+
+The worktree path is relative to the repository root's parent:
+
+```
+repos/personal/homeassistant/
+├── rental-control/          ← this repository
+└── worktrees/               ← all worktrees go here
+    ├── feat/some-feature/
+    └── fix/some-bugfix/
+```
+
+**NEVER** create worktrees inside the repository directory itself.
+
+Clean up worktrees when the associated branch has been merged:
+
+```bash
+git worktree remove /home/tykeal/repos/personal/homeassistant/worktrees/<branch-name>
+git branch -D <branch-name>
+```
+
 ## Testing Requirements
 
 The Python project lives under `custom_components/`. Run commands


### PR DESCRIPTION
Documents the convention that git worktrees must be created in `/home/tykeal/repos/personal/homeassistant/worktrees/`, not inside the repository. Ensures sub-agents use the correct location.