### PR TITLE
Fix: reconcile slots by time range not name

### DIFF
--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -27,8 +27,9 @@ from typing import TypedDict
 from homeassistant.util import dt
 
 from .const import DEFAULT_MAX_RETRY_CYCLES
+from .util import EventIdentity
 from .util import async_fire_clear_code
-from .util import get_event_names
+from .util import get_event_identities
 
 if TYPE_CHECKING:
     from homeassistant.components.calendar import CalendarEvent
@@ -331,6 +332,37 @@ class EventOverrides:
         self._retry_counts[slot] = 0
         self._escalated[slot] = False
 
+    def _slot_has_matching_event(
+        self,
+        slot: int,
+        events: list[EventIdentity],
+    ) -> bool:
+        """Check if an override slot matches any current calendar event.
+
+        Uses name + strict interval overlap + UID tiebreaker, the same
+        logic as ``_find_overlapping_slot`` but searching calendar
+        events instead of other override slots.
+        """
+        override = self._overrides[slot]
+        if override is None:
+            return False
+
+        slot_name = override["slot_name"]
+        slot_start = override["start_time"]
+        slot_end = override["end_time"]
+        stored_uid = self._slot_uids.get(slot)
+
+        for ev in events:
+            if ev.name != slot_name:
+                continue
+            if not (slot_start < ev.end and ev.start < slot_end):
+                continue
+            if stored_uid is not None and ev.uid is not None and stored_uid != ev.uid:
+                continue
+            return True
+
+        return False
+
     async def async_check_overrides(
         self,
         coordinator,
@@ -353,8 +385,8 @@ class EventOverrides:
         # Only consider events within the sensor boundary so that
         # slots tied to events beyond max_events get cleared.
         sensor_cal = cal[: coordinator.max_events]
-        event_names = get_event_names(coordinator, calendar=sensor_cal)
-        _LOGGER.debug("event_names = %s", event_names)
+        event_ids = get_event_identities(coordinator, calendar=sensor_cal)
+        _LOGGER.debug("event_identities = %s", event_ids)
 
         async with self._lock:
             assigned_slots = self.__get_slots_with_values()
@@ -368,7 +400,7 @@ class EventOverrides:
             for slot in assigned_slots:
                 clear_code = False
 
-                if self.get_slot_name(slot) not in event_names:
+                if not self._slot_has_matching_event(slot, event_ids):
                     _LOGGER.debug(
                         "%s not in current events, clearing",
                         self._overrides[slot],

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -18,8 +18,11 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Coroutine
 from collections.abc import Sequence
+from datetime import date
 from datetime import datetime
+from datetime import time
 from datetime import timedelta
+from datetime import tzinfo
 import hashlib
 import logging
 from pathlib import Path
@@ -368,6 +371,23 @@ async def async_fire_update_times(coordinator, event) -> None:
     check_gather_results(results, "Lock slot operation")
 
 
+def _ensure_datetime(value: date | datetime, rc) -> datetime:
+    """Coerce a bare ``date`` to a timezone-aware ``datetime``.
+
+    ``CalendarEvent`` may carry ``date`` values for all-day
+    events.  Converting to midnight in the coordinator timezone
+    prevents ``TypeError`` when comparing with ``datetime``
+    override timestamps.  Falls back to UTC when no valid
+    timezone is available.
+    """
+    if isinstance(value, datetime):
+        return value
+    tz = getattr(rc, "timezone", None)
+    if not isinstance(tz, tzinfo):
+        tz = dt.UTC
+    return datetime.combine(value, time.min, tz)
+
+
 class EventIdentity(NamedTuple):
     """Structured identity for a calendar event."""
 
@@ -383,6 +403,10 @@ def get_event_identities(rc, calendar: list | None = None) -> list[EventIdentity
     Returns name, time range, and UID for each event so that
     override cleanup can distinguish same-named events by their
     time windows and calendar UIDs.
+
+    Bare ``date`` values are normalised to timezone-aware
+    ``datetime`` at midnight so downstream overlap comparisons
+    never mix types.
     """
     events = calendar if calendar is not None else rc.data
     if not events:
@@ -396,7 +420,9 @@ def get_event_identities(rc, calendar: list | None = None) -> list[EventIdentity
         )
         if name:
             uid = event.uid if hasattr(event, "uid") else None
-            identities.append(EventIdentity(name, event.start, event.end, uid))
+            start = _ensure_datetime(event.start, rc)
+            end = _ensure_datetime(event.end, rc)
+            identities.append(EventIdentity(name, start, end, uid))
     return identities
 
 

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -368,28 +368,6 @@ async def async_fire_update_times(coordinator, event) -> None:
     check_gather_results(results, "Lock slot operation")
 
 
-def get_event_names(rc, calendar: list | None = None) -> list[str]:
-    """Get the current event names from coordinator data.
-
-    When called from within _async_update_data, pass the fresh
-    calendar list directly because coordinator.data has not been
-    updated yet.
-    """
-    events = calendar if calendar is not None else rc.data
-    if not events:
-        return []
-    event_names = []
-    for event in events:
-        slot_name = get_slot_name(
-            event.summary,
-            event.description or "",
-            rc.event_prefix or "",
-        )
-        if slot_name:
-            event_names.append(slot_name)
-    return event_names
-
-
 class EventIdentity(NamedTuple):
     """Structured identity for a calendar event."""
 
@@ -420,6 +398,15 @@ def get_event_identities(rc, calendar: list | None = None) -> list[EventIdentity
             uid = event.uid if hasattr(event, "uid") else None
             identities.append(EventIdentity(name, event.start, event.end, uid))
     return identities
+
+
+def get_event_names(rc, calendar: list | None = None) -> list[str]:
+    """Get the current event names from coordinator data.
+
+    Delegates to ``get_event_identities`` so that filtering logic
+    is maintained in a single place.
+    """
+    return [eid.name for eid in get_event_identities(rc, calendar=calendar)]
 
 
 def gen_uuid(created: str) -> str:

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -25,6 +25,7 @@ import logging
 from pathlib import Path
 import re
 from typing import Any
+from typing import NamedTuple
 import uuid
 
 from homeassistant.components.automation import DOMAIN as AUTO_DOMAIN
@@ -387,6 +388,38 @@ def get_event_names(rc, calendar: list | None = None) -> list[str]:
         if slot_name:
             event_names.append(slot_name)
     return event_names
+
+
+class EventIdentity(NamedTuple):
+    """Structured identity for a calendar event."""
+
+    name: str
+    start: datetime
+    end: datetime
+    uid: str | None
+
+
+def get_event_identities(rc, calendar: list | None = None) -> list[EventIdentity]:
+    """Get structured event identities for slot reconciliation.
+
+    Returns name, time range, and UID for each event so that
+    override cleanup can distinguish same-named events by their
+    time windows and calendar UIDs.
+    """
+    events = calendar if calendar is not None else rc.data
+    if not events:
+        return []
+    identities: list[EventIdentity] = []
+    for event in events:
+        name = get_slot_name(
+            event.summary,
+            event.description or "",
+            rc.event_prefix or "",
+        )
+        if name:
+            uid = event.uid if hasattr(event, "uid") else None
+            identities.append(EventIdentity(name, event.start, event.end, uid))
+    return identities
 
 
 def gen_uuid(created: str) -> str:

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -32,12 +32,24 @@ def _make_dt(
     return datetime(year, month, day, hour, minute, tzinfo=dt_util.UTC)
 
 
-def _make_event(end: datetime, summary: str = "") -> MagicMock:
-    """Create a mock calendar event with the given end and summary."""
+def _make_event(
+    end: datetime,
+    summary: str = "",
+    start: datetime | None = None,
+    uid: str | None = None,
+) -> MagicMock:
+    """Create a mock calendar event with the given end and summary.
+
+    When *start* is omitted it defaults to ``end - 5 days`` which is
+    fine for tests that never inspect start.  Supply an explicit
+    *start* whenever the test relies on time-range overlap matching.
+    """
     event = MagicMock()
+    event.start = start if start is not None else end - timedelta(days=5)
     event.end = end
     event.summary = summary
     event.description = ""
+    event.uid = uid
     return event
 
 
@@ -645,7 +657,9 @@ class TestAsyncCheckOverrides:
         eo.update(1, "c", "Valid Guest", start, end)
 
         coordinator = _make_coordinator(
-            calendar_events=[_make_event(_make_dt(2025, 8, 1), "Valid Guest")],
+            calendar_events=[
+                _make_event(end, "Valid Guest", start=start),
+            ],
             max_events=5,
         )
 
@@ -668,18 +682,23 @@ class TestAsyncCheckOverrides:
         eo = EventOverrides(start_slot=1, max_slots=3)
         past = _make_dt(2025, 5, 1)
         past_end = _make_dt(2025, 5, 3)
+        past2 = _make_dt(2025, 5, 5)
+        past2_end = _make_dt(2025, 5, 8)
         future = _make_dt(2025, 7, 5)
         future_end = _make_dt(2025, 7, 10)
 
         eo.update(1, "c", "Past Guest", past, past_end)
         eo.update(2, "c", "Valid Guest", future, future_end)
-        eo.update(3, "c", "Also Past", past, past_end)
+        eo.update(3, "c", "Also Past", past2, past2_end)
 
+        # Calendar ordered chronologically; Valid Guest at end
+        # makes last_end=Jul 10 so slot 2 isn't caught by
+        # start_after_last_end.
         coordinator = _make_coordinator(
             calendar_events=[
-                _make_event(_make_dt(2025, 8, 1), "Past Guest"),
-                _make_event(_make_dt(2025, 8, 1), "Valid Guest"),
-                _make_event(_make_dt(2025, 8, 1), "Also Past"),
+                _make_event(past_end, "Past Guest", start=past),
+                _make_event(past2_end, "Also Past", start=past2),
+                _make_event(future_end, "Valid Guest", start=future),
             ],
             max_events=5,
         )
@@ -700,6 +719,119 @@ class TestAsyncCheckOverrides:
             # Slots 1 and 3 should be cleared
             assert eo.overrides[1] is None
             assert eo.overrides[3] is None
+
+    async def test_clears_orphaned_slot_same_name_different_dates(
+        self,
+    ) -> None:
+        """Verify orphaned slot is cleared when same-name event cancelled.
+
+        Scenario: Guest creates two reservations (same name, different
+        dates).  One reservation is cancelled.  The remaining event
+        still has the same name but a different time range.  The
+        orphaned slot must be cleared even though the name still
+        exists in the calendar.
+        """
+        eo = EventOverrides(start_slot=1, max_slots=2)
+
+        # Two overrides for the same guest, non-overlapping dates
+        stay_a_start = _make_dt(2025, 7, 1)
+        stay_a_end = _make_dt(2025, 7, 5)
+        stay_b_start = _make_dt(2025, 7, 10)
+        stay_b_end = _make_dt(2025, 7, 15)
+
+        eo.update(1, "1234", "John Doe", stay_a_start, stay_a_end)
+        eo.update(2, "5678", "John Doe", stay_b_start, stay_b_end)
+
+        # Guest cancels stay B — only stay A remains in calendar
+        coordinator = _make_coordinator(
+            calendar_events=[
+                _make_event(stay_a_end, "John Doe", start=stay_a_start),
+            ],
+            max_events=5,
+        )
+
+        frozen = _make_dt(2025, 6, 25)
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new_callable=AsyncMock,
+            ) as mock_fire,
+            patch.object(dt_util, "start_of_local_day", return_value=frozen),
+        ):
+            await eo.async_check_overrides(coordinator)
+            # Only slot 2 (stay B) should be cleared
+            mock_fire.assert_called_once_with(coordinator, 2, expected_name="John Doe")
+            assert eo.overrides[1] is not None
+            assert eo.overrides[1]["slot_name"] == "John Doe"
+            assert eo.overrides[2] is None
+
+    async def test_keeps_both_slots_same_name_both_active(self) -> None:
+        """Verify both slots kept when same-name events both exist."""
+        eo = EventOverrides(start_slot=1, max_slots=2)
+
+        stay_a_start = _make_dt(2025, 7, 1)
+        stay_a_end = _make_dt(2025, 7, 5)
+        stay_b_start = _make_dt(2025, 7, 10)
+        stay_b_end = _make_dt(2025, 7, 15)
+
+        eo.update(1, "1234", "John Doe", stay_a_start, stay_a_end)
+        eo.update(2, "5678", "John Doe", stay_b_start, stay_b_end)
+
+        # Both stays still in calendar
+        coordinator = _make_coordinator(
+            calendar_events=[
+                _make_event(stay_a_end, "John Doe", start=stay_a_start),
+                _make_event(stay_b_end, "John Doe", start=stay_b_start),
+            ],
+            max_events=5,
+        )
+
+        frozen = _make_dt(2025, 6, 25)
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new_callable=AsyncMock,
+            ) as mock_fire,
+            patch.object(dt_util, "start_of_local_day", return_value=frozen),
+        ):
+            await eo.async_check_overrides(coordinator)
+            mock_fire.assert_not_called()
+            assert eo.overrides[1] is not None
+            assert eo.overrides[2] is not None
+
+    async def test_uid_distinguishes_same_name_overlapping(self) -> None:
+        """Verify UID prevents false matches between same-name events."""
+        eo = EventOverrides(start_slot=1, max_slots=2)
+
+        start = _make_dt(2025, 7, 1)
+        end = _make_dt(2025, 7, 10)
+
+        eo.update(1, "1234", "John Doe", start, end)
+        eo._slot_uids[1] = "uid-A"
+        eo.update(2, "5678", "John Doe", start, end)
+        eo._slot_uids[2] = "uid-B"
+
+        # Only uid-A event remains
+        coordinator = _make_coordinator(
+            calendar_events=[
+                _make_event(end, "John Doe", start=start, uid="uid-A"),
+            ],
+            max_events=5,
+        )
+
+        frozen = _make_dt(2025, 6, 25)
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new_callable=AsyncMock,
+            ) as mock_fire,
+            patch.object(dt_util, "start_of_local_day", return_value=frozen),
+        ):
+            await eo.async_check_overrides(coordinator)
+            # Slot 2 (uid-B) should be cleared
+            mock_fire.assert_called_once_with(coordinator, 2, expected_name="John Doe")
+            assert eo.overrides[1] is not None
+            assert eo.overrides[2] is None
 
 
 # ---------------------------------------------------------------------------
@@ -807,7 +939,9 @@ class TestEdgeCases:
         eo.update(1, "c", "Today Guest", start, end)
 
         coordinator = _make_coordinator(
-            calendar_events=[_make_event(_make_dt(2025, 8, 1), "Today Guest")],
+            calendar_events=[
+                _make_event(end, "Today Guest", start=start),
+            ],
             max_events=5,
         )
 
@@ -829,9 +963,11 @@ class TestEdgeCases:
         end = _make_dt(2025, 7, 20)
         eo.update(1, "c", "Edge Guest", start, end)
 
-        # Last event ends July 15 — same as start
+        # Event overlaps the override and last_end == override start
         coordinator = _make_coordinator(
-            calendar_events=[_make_event(_make_dt(2025, 7, 15), "Edge Guest")],
+            calendar_events=[
+                _make_event(end, "Edge Guest", start=start),
+            ],
             max_events=5,
         )
 
@@ -904,9 +1040,21 @@ class TestEdgeCases:
         # Calendar: 3 events, but max_events=2 so sensors only see
         # the first 2. "Old Guest" is at index 2 (beyond sensors).
         events = [
-            _make_event(_make_dt(2025, 7, 10), "Current Guest"),
-            _make_event(_make_dt(2025, 7, 20), "New Guest"),
-            _make_event(_make_dt(2025, 7, 25), "Old Guest"),
+            _make_event(
+                _make_dt(2025, 7, 10),
+                "Current Guest",
+                start=_make_dt(2025, 7, 5),
+            ),
+            _make_event(
+                _make_dt(2025, 7, 20),
+                "New Guest",
+                start=_make_dt(2025, 7, 11),
+            ),
+            _make_event(
+                _make_dt(2025, 7, 25),
+                "Old Guest",
+                start=_make_dt(2025, 7, 12),
+            ),
         ]
         coordinator = _make_coordinator(
             calendar_events=events,

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -955,15 +955,14 @@ class TestEdgeCases:
             await eo.async_check_overrides(coordinator)
             mock_fire.assert_not_called()
 
-    async def test_check_overrides_start_equals_last_end_not_cleared(self) -> None:
-        """Verify slot is NOT cleared when start_date == last_end (not >)."""
+    async def test_valid_override_with_matching_event_not_cleared(self) -> None:
+        """Verify slot is NOT cleared when event matches by time overlap."""
         eo = EventOverrides(start_slot=1, max_slots=1)
         today = _make_dt(2025, 7, 1)
         start = _make_dt(2025, 7, 15)
         end = _make_dt(2025, 7, 20)
         eo.update(1, "c", "Edge Guest", start, end)
 
-        # Event overlaps the override and last_end == override start
         coordinator = _make_coordinator(
             calendar_events=[
                 _make_event(end, "Edge Guest", start=start),

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -447,6 +447,27 @@ class TestGetEventIdentities:
         assert len(result) == 1
         assert result[0].uid is None
 
+    def test_bare_date_normalised_to_datetime(self) -> None:
+        """Verify bare date values become aware datetime at midnight."""
+        from datetime import datetime as dt_class
+
+        rc = MagicMock()
+        rc.event_prefix = None
+        event = CalendarEvent(
+            summary="AllDay",
+            start=date(2025, 6, 1),
+            end=date(2025, 6, 5),
+        )
+        rc.data = [event]
+
+        result = get_event_identities(rc)
+        assert len(result) == 1
+        assert isinstance(result[0].start, dt_class)
+        assert isinstance(result[0].end, dt_class)
+        assert result[0].start.hour == 0
+        assert result[0].start.minute == 0
+        assert result[0].start.tzinfo is not None
+
     def test_uses_calendar_parameter(self) -> None:
         """Verify calendar parameter overrides coordinator data."""
         rc = MagicMock()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -417,8 +417,8 @@ class TestGetEventIdentities:
         rc.data = []
         assert get_event_identities(rc) == []
 
-    def test_event_without_uid_attribute(self) -> None:
-        """Verify uid is None when event lacks uid attribute."""
+    def test_event_with_default_uid_returns_none(self) -> None:
+        """Verify uid is None when CalendarEvent has default uid."""
         rc = MagicMock()
         rc.event_prefix = None
         event = CalendarEvent(
@@ -426,6 +426,21 @@ class TestGetEventIdentities:
             start=date(2025, 3, 15),
             end=date(2025, 3, 20),
         )
+        rc.data = [event]
+
+        result = get_event_identities(rc)
+        assert len(result) == 1
+        assert result[0].uid is None
+
+    def test_event_object_without_uid_attribute(self) -> None:
+        """Verify uid is None when event object lacks uid attribute."""
+        rc = MagicMock()
+        rc.event_prefix = None
+        event = MagicMock(spec=["summary", "description", "start", "end"])
+        event.summary = "Bob"
+        event.description = ""
+        event.start = date(2025, 3, 15)
+        event.end = date(2025, 3, 20)
         rc.data = [event]
 
         result = get_event_identities(rc)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -23,6 +23,7 @@ from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DEFAULT_PATH
 from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.const import NAME
+from custom_components.rental_control.util import EventIdentity
 from custom_components.rental_control.util import add_call
 from custom_components.rental_control.util import async_fire_clear_code
 from custom_components.rental_control.util import async_fire_set_code
@@ -32,6 +33,7 @@ from custom_components.rental_control.util import compute_early_expiry_time
 from custom_components.rental_control.util import delete_folder
 from custom_components.rental_control.util import delete_rc_and_base_folder
 from custom_components.rental_control.util import gen_uuid
+from custom_components.rental_control.util import get_event_identities
 from custom_components.rental_control.util import get_event_names
 from custom_components.rental_control.util import get_slot_name
 from custom_components.rental_control.util import handle_state_change
@@ -368,6 +370,84 @@ class TestGetEventNames:
         rc.event_prefix = None
         rc.data = []
         assert get_event_names(rc) == []
+
+
+# ---------------------------------------------------------------------------
+# get_event_identities tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetEventIdentities:
+    """Tests for the get_event_identities function."""
+
+    def test_returns_identities_with_times_and_uid(self) -> None:
+        """Verify structured identities include name, times, uid."""
+        rc = MagicMock()
+        rc.event_prefix = None
+        event = MagicMock()
+        event.summary = "Alice"
+        event.description = ""
+        event.start = dt_util.now()
+        event.end = dt_util.now() + timedelta(days=5)
+        event.uid = "uid-123"
+        rc.data = [event]
+
+        result = get_event_identities(rc)
+        assert len(result) == 1
+        assert result[0] == EventIdentity("Alice", event.start, event.end, "uid-123")
+
+    def test_filters_blocked_events(self) -> None:
+        """Verify blocked events are excluded."""
+        rc = MagicMock()
+        rc.event_prefix = None
+        blocked = MagicMock()
+        blocked.summary = "Blocked"
+        blocked.description = ""
+        blocked.start = dt_util.now()
+        blocked.end = dt_util.now() + timedelta(days=1)
+        blocked.uid = None
+        rc.data = [blocked]
+
+        assert get_event_identities(rc) == []
+
+    def test_empty_calendar(self) -> None:
+        """Verify empty list when no events."""
+        rc = MagicMock()
+        rc.event_prefix = None
+        rc.data = []
+        assert get_event_identities(rc) == []
+
+    def test_event_without_uid_attribute(self) -> None:
+        """Verify uid is None when event lacks uid attribute."""
+        rc = MagicMock()
+        rc.event_prefix = None
+        event = CalendarEvent(
+            summary="Bob",
+            start=date(2025, 3, 15),
+            end=date(2025, 3, 20),
+        )
+        rc.data = [event]
+
+        result = get_event_identities(rc)
+        assert len(result) == 1
+        assert result[0].uid is None
+
+    def test_uses_calendar_parameter(self) -> None:
+        """Verify calendar parameter overrides coordinator data."""
+        rc = MagicMock()
+        rc.event_prefix = None
+        rc.data = []
+
+        event = MagicMock()
+        event.summary = "Override"
+        event.description = ""
+        event.start = dt_util.now()
+        event.end = dt_util.now() + timedelta(days=3)
+        event.uid = "uid-456"
+
+        result = get_event_identities(rc, calendar=[event])
+        assert len(result) == 1
+        assert result[0].name == "Override"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a guest creates two reservations with the same name (e.g., same guest,
different date ranges) and one is subsequently cancelled, Rental Control
properly removes the cancelled event from sensors but the keymaster lock code
slot is never cleaned up.

### Root Cause

`async_check_overrides()` used `get_event_names()` which returns a flat list
of names. When checking `slot_name not in event_names`, both slots matched
because the remaining event still had the same guest name — the cancelled
event's slot was never cleared.

## Fix

Replace name-only matching with structured matching that considers:
- **Name** — must match
- **Time range overlap** — strict interval overlap (`start_a < end_b AND start_b < end_a`)
- **UID tiebreaker** — when both stored and event UIDs are non-None and differ, skip

This mirrors the same matching logic already used by `_find_overlapping_slot()`
for slot assignment, ensuring consistency between assignment and cleanup.

### Changes

- **`util.py`**: Add `EventIdentity` NamedTuple and `get_event_identities()` function
- **`event_overrides.py`**: Add `_slot_has_matching_event()` method; update
  `async_check_overrides()` to use structured matching; remove unused
  `get_event_names` import
- **Tests**: Update `_make_event` helper with `start`/`uid` params; fix
  existing tests with proper event time ranges; add 3 new tests (orphaned
  slot cleanup, both-slots-active, UID disambiguation) + 5 new
  `get_event_identities` tests

### Test Results

594 tests pass (8 new tests added).