### PR TITLE
Fix: adopt has_entity_name for sensors

### DIFF
--- a/custom_components/rental_control/calendar.py
+++ b/custom_components/rental_control/calendar.py
@@ -53,8 +53,9 @@ class RentalControlCalendar(
     def __init__(self, coordinator: RentalControlCoordinator) -> None:
         """Create the iCal Calendar Event Device."""
         super().__init__(coordinator)
+        self._attr_has_entity_name = True
+        self._attr_name = NAME
         self._entity_category: EntityCategory = EntityCategory.DIAGNOSTIC
-        self._name: str = f"{NAME} {coordinator.name}"
         self._unique_id: str = gen_uuid(f"{coordinator.unique_id} calendar")
 
     @property
@@ -76,11 +77,6 @@ class RentalControlCalendar(
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         return self.coordinator.event
-
-    @property
-    def name(self) -> str:
-        """Return the name of the entity."""
-        return self._name
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform
@@ -21,7 +20,6 @@ from .const import CHECKIN_SENSOR
 from .const import CONF_MAX_EVENTS
 from .const import COORDINATOR
 from .const import DOMAIN
-from .const import NAME
 from .sensors.calsensor import RentalControlCalSensor
 from .sensors.checkinsensor import CheckinTrackingSensor
 
@@ -45,7 +43,6 @@ async def async_setup_entry(
 ) -> bool:
     """Set up the iCal Sensor."""
     config = config_entry.data
-    name = config.get(CONF_NAME)
     max_events = config.get(CONF_MAX_EVENTS)
 
     coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
@@ -60,7 +57,7 @@ async def async_setup_entry(
             RentalControlCalSensor(
                 hass,
                 coordinator,
-                f"{NAME} {name}",
+                "",
                 eventnumber,
             )
         )

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..const import ICON
+from ..const import NAME
 from ..const import SECONDS_PER_HOUR
 from ..const import SECONDS_PER_MINUTE
 from ..util import async_fire_clear_code
@@ -52,7 +53,8 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         """
         Initialize the sensor.
 
-        sensor_name is typically the name of the calendar.
+        sensor_name is accepted for backward compatibility but unused;
+        the entity name is derived from NAME and event_number.
         eventnumber indicates which upcoming event this is, starting at zero
         """
         super().__init__(coordinator)
@@ -60,6 +62,8 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             summary = f"{coordinator.event_prefix} No reservation"
         else:
             summary = "No reservation"
+        self._attr_has_entity_name = True
+        self._attr_name = f"{NAME} Event {event_number}"
         self._code_generator = coordinator.code_generator
         self._code_length = coordinator.code_length
         self._entity_category = EntityCategory.DIAGNOSTIC
@@ -78,7 +82,6 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         self._parsed_attributes: dict[str, str] = {}
         self._event_number = event_number
         self._hass = hass
-        self._name = f"{sensor_name} Event {self._event_number}"
         self._state = summary
         self._unique_id = gen_uuid(
             f"{self.coordinator.unique_id} sensor {self._event_number}"
@@ -273,11 +276,6 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
     def icon(self) -> str:
         """Return the icon for the frontend."""
         return ICON
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return self._name
 
     @property
     def state(self) -> str:

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -55,9 +55,11 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
 
         sensor_name is accepted for backward compatibility but unused;
         the entity name is derived from NAME and event_number.
-        eventnumber indicates which upcoming event this is, starting at zero
+        event_number indicates which upcoming event this is; numbering is
+        zero-based, so 0 refers to the first upcoming event.
         """
         super().__init__(coordinator)
+        del sensor_name
         if coordinator.event_prefix:
             summary = f"{coordinator.event_prefix} No reservation"
         else:

--- a/tests/integration/test_full_setup.py
+++ b/tests/integration/test_full_setup.py
@@ -399,19 +399,15 @@ async def test_entity_names_match_expected_format(
     calendar_entities = [e for e in entities if e.domain == "calendar"]
     sensor_entities = [e for e in entities if e.domain == "sensor"]
 
-    rental_name = mock_config_entry.data["name"]
-
     # Calendar entity name
     assert len(calendar_entities) == 1
-    assert calendar_entities[0].original_name == f"{NAME} {rental_name}"
+    assert calendar_entities[0].original_name == NAME
 
-    # Sensor entity names: '{NAME} {rental_name} Event {N}' + 'Check-in'
+    # Sensor entity names: '{NAME} Event {N}' + 'Check-in'
     # The check-in sensor uses has_entity_name=True with translation_key,
     # so original_name is just the entity-specific translated name.
     max_events = mock_config_entry.data["max_events"]
-    expected_sensor_names = {
-        f"{NAME} {rental_name} Event {i}" for i in range(max_events)
-    }
+    expected_sensor_names = {f"{NAME} Event {i}" for i in range(max_events)}
     expected_sensor_names.add("Check-in")
     actual_sensor_names = {e.original_name for e in sensor_entities}
     assert actual_sensor_names == expected_sensor_names

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -51,7 +51,7 @@ def _mock_coordinator(
 class TestRentalControlCalendarInit:
     """Tests for RentalControlCalendar initialization."""
 
-    def test_name_includes_coordinator_name(self) -> None:
+    def test_name_is_constant(self) -> None:
         """Verify entity name is NAME (has_entity_name=True)."""
         coordinator = _mock_coordinator(name="Beach House")
         cal = RentalControlCalendar(coordinator)

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -52,10 +52,10 @@ class TestRentalControlCalendarInit:
     """Tests for RentalControlCalendar initialization."""
 
     def test_name_includes_coordinator_name(self) -> None:
-        """Verify entity name is '{NAME} {coordinator.name}'."""
+        """Verify entity name is NAME (has_entity_name=True)."""
         coordinator = _mock_coordinator(name="Beach House")
         cal = RentalControlCalendar(coordinator)
-        assert cal.name == f"{NAME} Beach House"
+        assert cal.name == NAME
 
     def test_available_defaults_to_false(self) -> None:
         """Verify available is False after initialization."""
@@ -158,7 +158,7 @@ class TestAsyncSetupEntry:
 
         entity = async_add_entities.call_args[0][0][0]
         assert entity.coordinator is coordinator
-        assert entity.name == f"{NAME} Lake Cabin"
+        assert entity.name == NAME
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -171,16 +171,16 @@ class TestSensorInit:
     """Tests for RentalControlCalSensor initialization."""
 
     def test_name_format(self, hass) -> None:
-        """Verify sensor name follows 'NAME name Event N' pattern."""
+        """Verify sensor name follows 'NAME Event N' pattern."""
         coordinator = _make_coordinator()
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test Rental", 0)
-        assert sensor.name == "Rental Control Test Rental Event 0"
+        assert sensor.name == "Rental Control Event 0"
 
     def test_name_with_event_number(self, hass) -> None:
         """Verify event number is included in sensor name."""
         coordinator = _make_coordinator()
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test Rental", 2)
-        assert sensor.name == "Rental Control Test Rental Event 2"
+        assert sensor.name == "Rental Control Event 2"
 
     def test_unique_id_generation(self, hass) -> None:
         """Verify unique_id uses gen_uuid with coordinator unique_id and event number."""


### PR DESCRIPTION
## Problem

New installs produce entity IDs like `calendar.other_rental_control_other`
and `sensor.other_rental_control_other_event_0` — the user's rental name
appears twice because modern HA prepends the device name to entities
associated with a device when `has_entity_name` is not set.

## Root cause

Calendar and CalSensor entities set `device_info` (associating them with
a device) but don't set `has_entity_name = True`. Modern HA (2025+)
prepends the device name to the entity name when deriving entity IDs,
causing duplication.

## Fix

Set `has_entity_name = True` on both `RentalControlCalendar` and
`RentalControlCalSensor`. Entity names now use `NAME` ("Rental Control")
and `f"{NAME} Event {N}"` respectively, without including the
user-provided rental name (the device name provides that context).

**New entity IDs** for an integration named "Other":
- `calendar.other_rental_control`
- `sensor.other_rental_control_event_0`
- `sensor.other_rental_control_event_1`

**Existing installs** are unaffected — HA caches entity IDs in the
entity registry. Only new installs get the corrected IDs.

## Tests

- All 596 tests pass
- Updated name assertions in unit and integration tests