### PR TITLE
Docs(spec): add plan and tasks for 007

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -21,6 +21,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-12
 - N/A (all state in-memory, config via HA config entries) (003-coordinator-migration)
 - Python ≥3.13.2 (per pyproject.toml `requires-python = ">=3.13.2"`) + homeassistant ≥ 2025.8.0, icalendar ≥ 6.1.0, x-wr-timezone ≥ 2.0.0 (004-checkin-tracking)
 - Home Assistant RestoreEntity state persistence (built-in HA mechanism) (004-checkin-tracking)
+- Python ≥ 3.14.2 + homeassistant (core), icalendar, voluptuous, x-wr-timezone, aiohttp (007-honor-pms-times)
+- Home Assistant config entries (persisted via HA's `.storage/` JSON files) (007-honor-pms-times)
 
 ## Project Structure
 
@@ -39,9 +41,9 @@ uv run ruff check custom_components/ tests/
 Python ≥3.13.2: Follow standard conventions, ruff formatting
 
 ## Recent Changes
+- 007-honor-pms-times: Added Python ≥ 3.14.2 + homeassistant (core), icalendar, voluptuous, x-wr-timezone, aiohttp
 - 004-checkin-tracking: Added Python ≥3.13.2 (per pyproject.toml `requires-python = ">=3.13.2"`) + homeassistant ≥ 2025.8.0, icalendar ≥ 6.1.0, x-wr-timezone ≥ 2.0.0
 - 003-coordinator-migration: Added Python ≥3.13.2 + Home Assistant ≥ 2025.8.0, icalendar ≥6.1.0, x-wr-timezone ≥2.0.0
-- 002-code-health: Added Python ≥3.13.2 + icalendar ≥6.1.0, x-wr-timezone ≥2.0.0
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/specs/007-honor-pms-times/contracts/time-resolution.md
+++ b/specs/007-honor-pms-times/contracts/time-resolution.md
@@ -1,0 +1,124 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Contract: Time Resolution in `_ical_parser`
+
+**Feature**: 007-honor-pms-times
+**Date**: 2025-07-22
+
+## Overview
+
+This contract defines the time resolution interface within `coordinator._ical_parser()`. Since
+Rental Control is a Home Assistant integration (not a REST/GraphQL API), the "contract" is the
+internal interface between the coordinator's event-building logic and the downstream sensor/override
+pipeline.
+
+## Interface: Time Resolution Function
+
+### Current Behavior (FR-005 — preserved when `honor_event_times=False`)
+
+```
+resolve_times(event, override, defaults) -> (checkin: time, checkout: time)
+
+Priority:
+  1. override exists        → override.start_time.time(), override.end_time.time()
+  2. event has explicit time → event.DTSTART.dt.time(), event.DTEND.dt.time()
+  3. all-day event          → defaults.checkin, defaults.checkout
+```
+
+### New Behavior (FR-003, FR-004 — when `honor_event_times=True`)
+
+```
+resolve_times(event, override, defaults) -> (checkin: time, checkout: time)
+
+Priority:
+  1. event has explicit time → event.DTSTART.dt.time(), event.DTEND.dt.time()
+  2. override exists        → override.start_time.time(), override.end_time.time()
+  3. all-day event          → defaults.checkin, defaults.checkout
+```
+
+### Explicit Time Detection
+
+```python
+# An event has explicit times when DTSTART.dt is a datetime (not date)
+has_explicit_times: bool = isinstance(event["DTSTART"].dt, datetime)
+```
+
+## Interface: Configuration Propagation
+
+### Config Flow → Coordinator
+
+```
+config_entry.data["honor_event_times"] : bool
+  │
+  ├── __init__() → self.honor_event_times = bool(config.get(CONF_HONOR_EVENT_TIMES))
+  │
+  └── update_config() → self.honor_event_times = bool(config.get(CONF_HONOR_EVENT_TIMES))
+```
+
+### Options Flow → Config Entry
+
+```
+User toggles "Honor event times" in UI
+  │
+  └── config_flow._start_config_flow() → user_input["honor_event_times"] = True/False
+        │
+        └── update_listener() → config_entry.data["honor_event_times"] = value
+              │
+              └── coordinator.update_config() → self.honor_event_times = value
+                    │
+                    └── coordinator.async_request_refresh() → _ical_parser uses new value
+```
+
+## Interface: Downstream Time Update (unchanged — no modifications)
+
+### Preconditions
+
+- CalendarEvent is built with resolved times from the time resolution function above
+- Sensor has an assigned Keymaster slot via `async_reserve_or_get_slot()`
+
+### Contract
+
+```
+async_reserve_or_get_slot(slot_name, slot_code, start_time, end_time, uid, prefix)
+  → ReserveResult(slot, is_new, times_updated)
+
+Postconditions:
+  - If times_updated=True:
+    - Override's stored start_time/end_time are updated to match incoming times
+    - Caller MUST fire async_fire_update_times() or async_fire_clear_code()
+  - If times_updated=False:
+    - Override's stored times already matched incoming — no action needed
+    - FR-007 satisfied: no unnecessary updates
+```
+
+## Migration Contract
+
+### v7 → v8
+
+```
+Precondition:  config_entry.version == 7
+               config_entry.data does NOT contain "honor_event_times"
+
+Action:        config_entry.data["honor_event_times"] = False
+
+Postcondition: config_entry.version == 8
+               config_entry.data["honor_event_times"] == False
+               Existing behavior preserved (FR-005)
+```
+
+## Test Verification Points
+
+| Contract Point | Test Assertion |
+|----------------|----------------|
+| honor_event_times=False, override exists | CalendarEvent times == override times |
+| honor_event_times=True, timed event, override exists | CalendarEvent times == calendar times (not override) |
+| honor_event_times=True, all-day event, override exists | CalendarEvent times == override times |
+| honor_event_times=True, all-day event, no override | CalendarEvent times == default times |
+| honor_event_times=True, timed event, no override | CalendarEvent times == calendar times |
+| Time difference detected by async_reserve_or_get_slot | times_updated=True, async_fire_update_times called |
+| No time difference | times_updated=False, no update fired |
+| Migration v7→v8 | honor_event_times key exists and equals False |
+| Options flow toggle | Setting persists after reload |

--- a/specs/007-honor-pms-times/data-model.md
+++ b/specs/007-honor-pms-times/data-model.md
@@ -1,0 +1,137 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Data Model: Honor PMS Calendar Event Times
+
+**Feature**: 007-honor-pms-times
+**Date**: 2025-07-22
+
+## Entities
+
+### Configuration Option: `honor_event_times`
+
+| Property | Value |
+|----------|-------|
+| **Config key** | `honor_event_times` |
+| **Type** | `bool` |
+| **Default** | `False` |
+| **Storage** | `config_entry.data` (via HA `.storage/` JSON) |
+| **Persisted** | Yes — survives reloads and restarts |
+| **Migration** | v7 → v8: set `False` for existing entries |
+
+**Relationships**:
+- Read by `RentalControlCoordinator.__init__()` → stored as `self.honor_event_times`
+- Read by `RentalControlCoordinator.update_config()` → updated on options flow save
+- Consumed by `RentalControlCoordinator._ical_parser()` → controls time resolution
+- Displayed in `_get_schema()` → options flow toggle (both config and options steps)
+
+### Existing Entity: `EventOverride` (unchanged)
+
+```python
+class EventOverride(TypedDict):
+    slot_name: str       # Guest/reservation name
+    slot_code: str       # Lock code for this slot
+    start_time: datetime  # Check-in time (UTC)
+    end_time: datetime    # Check-out time (UTC)
+```
+
+| Property | Impact of This Feature |
+|----------|-----------------------|
+| `start_time` | When `honor_event_times=True` and event has explicit times, override times are **superseded** during CalendarEvent construction. The override's stored times are then **updated** by `async_reserve_or_get_slot()` when it detects the difference. |
+| `end_time` | Same as `start_time`. |
+| `slot_name` | Unchanged — still used for slot lookup. |
+| `slot_code` | Unchanged — lock code management is orthogonal. |
+
+### Existing Entity: `RentalControlCoordinator` (modified)
+
+New attribute added:
+
+| Attribute | Type | Source | Default |
+|-----------|------|--------|---------|
+| `honor_event_times` | `bool` | `config_entry.data[CONF_HONOR_EVENT_TIMES]` | `False` |
+
+### Existing Entity: `RentalControlFlowHandler` (modified)
+
+| Property | Change |
+|----------|--------|
+| `VERSION` | `7` → `8` |
+| `DEFAULTS` | Add `CONF_HONOR_EVENT_TIMES: DEFAULT_HONOR_EVENT_TIMES` |
+
+## State Transitions
+
+### Time Resolution Priority (per event, during `_ical_parser`)
+
+```
+┌─────────────────────────────┐
+│ For each VEVENT in calendar │
+└─────────────┬───────────────┘
+              │
+              ▼
+     ┌────────────────┐
+     │ Has override?   │──No──┐
+     │ (slot assigned) │      │
+     └───────┬────────┘      │
+             │Yes             │
+             ▼                │
+  ┌──────────────────────┐    │
+  │ honor_event_times    │    │
+  │ enabled?             │    │
+  └───┬────────────┬─────┘    │
+      │Yes         │No        │
+      ▼            ▼          │
+┌──────────┐  ┌──────────┐   │
+│ Has      │  │ Use      │   │
+│ explicit │  │ override │   │
+│ times?   │  │ times    │   │
+└──┬────┬──┘  └──────────┘   │
+   │Yes │No                   │
+   ▼    ▼                     ▼
+┌──────┐ ┌──────────┐  ┌──────────────┐
+│ Use  │ │ Use      │  │ Has explicit │
+│ cal  │ │ override │  │ times?       │
+│ times│ │ times    │  └──┬───────┬───┘
+└──────┘ └──────────┘     │Yes    │No
+                          ▼       ▼
+                    ┌──────┐ ┌─────────┐
+                    │ Use  │ │ Use     │
+                    │ cal  │ │ default │
+                    │ times│ │ times   │
+                    └──────┘ └─────────┘
+```
+
+### Downstream Time Update Flow (unchanged)
+
+```
+CalendarEvent built with resolved times
+        │
+        ▼
+Sensor._reserve_or_update_slot()
+        │
+        ▼
+EventOverrides.async_reserve_or_get_slot()
+        │
+        ├─ times match stored override → ReserveResult(times_updated=False) → no action
+        │
+        └─ times differ from stored override → update override in-place
+                                              → ReserveResult(times_updated=True)
+                                              → async_fire_update_times()
+                                              → Keymaster datetime entities updated
+```
+
+## Validation Rules
+
+| Field | Rule | Enforcement |
+|-------|------|-------------|
+| `honor_event_times` | Must be `bool` | `cv.boolean` in voluptuous schema |
+| `honor_event_times` | Default `False` on new installs | Schema default in `_get_schema()` |
+| `honor_event_times` | Default `False` on migration | Migration v7→v8 in `__init__.py` |
+
+## Constants (new)
+
+```python
+# const.py additions
+CONF_HONOR_EVENT_TIMES = "honor_event_times"
+DEFAULT_HONOR_EVENT_TIMES = False
+```

--- a/specs/007-honor-pms-times/plan.md
+++ b/specs/007-honor-pms-times/plan.md
@@ -1,0 +1,88 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Implementation Plan: Honor PMS Calendar Event Times
+
+**Branch**: `007-honor-pms-times` | **Date**: 2025-07-22 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/007-honor-pms-times/spec.md`
+
+## Summary
+
+Add a boolean "Honor event times" configuration option that, when enabled, changes the time
+resolution priority in `coordinator._ical_parser()` so that calendar-provided check-in/check-out
+times (from the PMS) take precedence over stored Keymaster override times for events with explicit
+times. All-day events continue to fall back to override times or configured defaults. The existing
+`async_reserve_or_get_slot()` → `async_fire_update_times()` pipeline already detects time
+differences and propagates updates to Keymaster — no downstream changes are needed.
+
+## Technical Context
+
+**Language/Version**: Python ≥ 3.14.2
+**Primary Dependencies**: homeassistant (core), icalendar, voluptuous, x-wr-timezone, aiohttp
+**Storage**: Home Assistant config entries (persisted via HA's `.storage/` JSON files)
+**Testing**: pytest (with pytest-homeassistant-custom-component, aioresponses)
+**Target Platform**: Home Assistant (Linux/aarch64/x86_64, Raspberry Pi to server)
+**Project Type**: Single HA custom integration
+**Performance Goals**: No degradation to calendar refresh cycle (configurable 30s–1440min, default 2min)
+**Constraints**: Must not block HA event loop; async patterns required; must work on constrained hardware
+**Scale/Scope**: Single integration, ~3k LOC in `custom_components/rental_control/`, ~10 source files touched
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I: Code Quality & Testing | ✅ PASS | New code will have full test coverage, type hints, docstrings |
+| II: Atomic Commit Discipline | ✅ PASS | Feature decomposes into 5-7 atomic commits (const→config→coordinator→migration→tests→strings) |
+| III: Licensing & Attribution | ✅ PASS | All new/modified files will include SPDX headers |
+| IV: Pre-Commit Integrity | ✅ PASS | All commits must pass ruff, mypy, interrogate, reuse-tool, gitlint |
+| V: Agent Co-Authorship & DCO | ✅ PASS | Commits will include Co-authored-by and Signed-off-by trailers |
+| VI: User Experience Consistency | ✅ PASS | New toggle follows existing `should_update_code` boolean pattern in options flow |
+| VII: Performance Requirements | ✅ PASS | Change is a conditional branch in existing code path — zero perf impact |
+
+**Gate result**: ALL PASS — proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-honor-pms-times/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — research findings
+├── data-model.md        # Phase 1 output — entity and config model
+├── quickstart.md        # Phase 1 output — developer quickstart
+├── contracts/           # Phase 1 output — internal interface contracts
+│   └── time-resolution.md
+└── tasks.md             # Phase 2 output (NOT created by plan)
+```
+
+### Source Code (repository root)
+
+```text
+custom_components/rental_control/
+├── __init__.py          # MODIFY: Add v7→v8 migration for new config key
+├── config_flow.py       # MODIFY: Add honor_event_times toggle to schema, bump VERSION
+├── const.py             # MODIFY: Add CONF_HONOR_EVENT_TIMES + DEFAULT_HONOR_EVENT_TIMES
+├── coordinator.py       # MODIFY: Read new config, alter time resolution in _ical_parser
+├── strings.json         # MODIFY: Add UI labels for new option
+└── translations/
+    ├── en.json          # MODIFY: Add English translation
+    └── fr.json          # MODIFY: Add French translation
+
+tests/
+├── unit/
+│   ├── test_config_flow.py   # MODIFY: Test new toggle appears and persists
+│   └── test_coordinator.py   # MODIFY: Test time resolution with honor_event_times on/off
+└── integration/               # May need integration test for end-to-end time propagation
+```
+
+**Structure Decision**: Existing single HA custom integration layout. No new files created in
+source tree — all changes are additions to existing modules. One new documentation contract file.
+
+## Complexity Tracking
+
+> No constitution violations. No complexity justifications needed.

--- a/specs/007-honor-pms-times/quickstart.md
+++ b/specs/007-honor-pms-times/quickstart.md
@@ -1,0 +1,159 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart: Honor PMS Calendar Event Times
+
+**Feature**: 007-honor-pms-times
+**Date**: 2025-07-22
+
+## Prerequisites
+
+- Python ≥ 3.14.2
+- [uv](https://docs.astral.sh/uv/) package manager (see `UV_USAGE.md`)
+- Home Assistant development environment (pytest-homeassistant-custom-component)
+- Pre-commit hooks installed (`pre-commit install`)
+
+## Setup
+
+```bash
+# From repository root
+cd /home/tykeal/repos/personal/homeassistant/worktrees/007-honor-pms-times
+
+# Install dependencies
+uv sync
+
+# Verify pre-commit hooks are installed
+pre-commit run --all-files
+```
+
+## Implementation Order (Atomic Commits)
+
+Each step produces one atomic commit:
+
+### 1. Add constants (`const.py`)
+
+Add to `const.py`:
+```python
+CONF_HONOR_EVENT_TIMES = "honor_event_times"
+DEFAULT_HONOR_EVENT_TIMES = False
+```
+
+Place after the existing `CONF_SHOULD_UPDATE_CODE` / `DEFAULT_SHOULD_UPDATE_CODE` entries.
+
+### 2. Add config flow toggle (`config_flow.py`)
+
+- Import `CONF_HONOR_EVENT_TIMES` and `DEFAULT_HONOR_EVENT_TIMES`
+- Add to `DEFAULTS` dict in `RentalControlFlowHandler`
+- Add `vol.Optional` entry in `_get_schema()` after `CONF_SHOULD_UPDATE_CODE`
+- Bump `VERSION` from 7 to 8
+
+### 3. Add migration (`__init__.py`)
+
+Add v7 → v8 migration block after the existing v6 → v7 block:
+```python
+if version == 7:
+    _LOGGER.debug("Migrating from version %s", version)
+    data = config_entry.data.copy()
+    data[CONF_HONOR_EVENT_TIMES] = False
+    hass.config_entries.async_update_entry(
+        entry=config_entry,
+        unique_id=config_entry.unique_id,
+        data=data,
+        version=8,
+    )
+    version = 8
+```
+
+### 4. Modify coordinator time resolution (`coordinator.py`)
+
+- Import `CONF_HONOR_EVENT_TIMES` from `.const`
+- Add `self.honor_event_times` in `__init__()` and `update_config()`
+- Modify the time resolution block in `_ical_parser()` (lines 605–631)
+
+The new logic:
+```python
+# Determine if event has explicit times (datetime vs date)
+has_explicit_times = isinstance(event["DTSTART"].dt, datetime)
+
+if self.honor_event_times and has_explicit_times:
+    # FR-003: PMS times take priority for timed events
+    checkin = event["DTSTART"].dt.time()
+    checkout = event["DTEND"].dt.time()
+elif override:
+    # FR-005 (disabled) or FR-004 (all-day with override)
+    start_time_val = override["start_time"].astimezone(self.timezone)
+    end_time_val = override["end_time"].astimezone(self.timezone)
+    checkin = start_time_val.time()
+    checkout = end_time_val.time()
+else:
+    try:
+        checkin = event["DTSTART"].dt.time()
+        checkout = event["DTEND"].dt.time()
+    except AttributeError:
+        checkin = self.checkin
+        checkout = self.checkout
+```
+
+### 5. Add UI strings (`strings.json`, translations)
+
+Add to all three JSON files (strings.json, translations/en.json, translations/fr.json):
+```json
+"honor_event_times": "Honor calendar event times from PMS instead of stored override times"
+```
+
+In both `config.step.user.data` and `options.step.init.data` sections.
+
+### 6. Add tests
+
+- `tests/unit/test_config_flow.py`: Test toggle appears and persists
+- `tests/unit/test_coordinator.py`: Test time resolution with all combinations:
+  - honor=False + override → override times used
+  - honor=True + timed event + override → calendar times used
+  - honor=True + all-day event + override → override times used
+  - honor=True + all-day event + no override → default times used
+  - honor=True + timed event + no override → calendar times used
+- `tests/unit/test_init.py`: Test v7→v8 migration
+
+## Running Tests
+
+```bash
+# Run all tests
+uv run pytest tests/ -v
+
+# Run only unit tests
+uv run pytest tests/unit/ -v
+
+# Run specific test file
+uv run pytest tests/unit/test_coordinator.py -v -k "honor"
+
+# Run with coverage
+uv run pytest tests/ --cov=custom_components/rental_control --cov-report=term-missing
+```
+
+## Pre-Commit Verification
+
+```bash
+# Run all hooks
+pre-commit run --all-files
+
+# Key hooks to watch for:
+# - ruff (linting + formatting)
+# - mypy (type checking)
+# - interrogate (docstring coverage — 100% required)
+# - reuse (SPDX license headers)
+# - gitlint (commit message format)
+```
+
+## Key Files Reference
+
+| File | Role |
+|------|------|
+| `custom_components/rental_control/const.py` | Constants: config keys, defaults |
+| `custom_components/rental_control/config_flow.py` | Options flow UI schema |
+| `custom_components/rental_control/__init__.py` | Entry setup, migration, update listener |
+| `custom_components/rental_control/coordinator.py` | Calendar fetch, time resolution, data coordination |
+| `custom_components/rental_control/event_overrides.py` | Override storage, slot reservation, time comparison |
+| `custom_components/rental_control/sensors/calsensor.py` | Sensor entities, slot assignment, Keymaster side effects |
+| `custom_components/rental_control/util.py` | `async_fire_update_times()`, helper functions |

--- a/specs/007-honor-pms-times/research.md
+++ b/specs/007-honor-pms-times/research.md
@@ -1,0 +1,207 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Research: Honor PMS Calendar Event Times
+
+**Feature**: 007-honor-pms-times
+**Date**: 2025-07-22
+
+## Research Question 1: Current Time Resolution Priority in `_ical_parser`
+
+**Context**: The core change requires reordering the time resolution priority in
+`coordinator._ical_parser()` (lines 605–631). We need to understand the exact
+current logic before modifying it.
+
+### Finding
+
+The current time resolution in `_ical_parser` follows this priority:
+
+1. **Override exists** (`slot_name` found in `event_overrides`) → use
+   `override["start_time"]` / `override["end_time"]` (converted from UTC to
+   coordinator timezone)
+2. **Event has explicit times** (`event["DTSTART"].dt` is `datetime`, not `date`)
+   → use `event["DTSTART"].dt.time()` / `event["DTEND"].dt.time()`
+3. **All-day event** (`event["DTSTART"].dt` is `date`, which raises
+   `AttributeError` on `.time()`) → use `self.checkin` / `self.checkout`
+   (configured defaults)
+
+**Decision**: The new "Honor event times" option changes this priority so that
+when enabled, explicit calendar times (step 2) take precedence over stored
+overrides (step 1) for events with explicit times. All-day events remain
+unchanged.
+
+**Rationale**: This is the minimal change that achieves the spec's goal — PMS
+time changes flow through because the CalendarEvent is built with calendar times,
+and when the sensor later calls `async_reserve_or_get_slot()`, the time
+difference between the CalendarEvent and the stored override triggers
+`times_updated=True`, which fires `async_fire_update_times()` to push updates
+to Keymaster.
+
+**Alternatives considered**:
+- Modifying the sensor layer (`calsensor.py`) to detect time differences and
+  override from there — rejected because it would duplicate time resolution
+  logic and break separation of concerns.
+- Adding a separate "time sync" mechanism — rejected because the existing
+  `async_reserve_or_get_slot()` → `async_fire_update_times()` pipeline already
+  handles exactly this case when times differ.
+
+## Research Question 2: All-Day Event Detection Mechanism
+
+**Context**: FR-004 requires that all-day events still fall back to overrides or
+defaults even when "Honor event times" is enabled. We need to understand how
+all-day events are distinguished from timed events.
+
+### Finding
+
+All-day events in iCal have `DTSTART`/`DTEND` values that are `date` objects,
+not `datetime` objects. The icalendar library parses these accordingly:
+
+- **Timed event**: `event["DTSTART"].dt` returns `datetime` → `.time()` works
+- **All-day event**: `event["DTSTART"].dt` returns `date` → `.time()` raises
+  `AttributeError`
+
+The current code uses a `try/except AttributeError` pattern to detect this
+(coordinator.py lines 621–630).
+
+**Decision**: Use `isinstance(event["DTSTART"].dt, datetime)` as a reliable
+explicit check rather than relying on try/except for control flow. This is
+cleaner and makes the honor_event_times branching straightforward.
+
+**Rationale**: Using `isinstance` is more Pythonic for type branching and avoids
+masking genuine `AttributeError` bugs. The `datetime` class is a subclass of
+`date`, so `isinstance(val, datetime)` correctly identifies timed events, while
+`isinstance(val, date)` would match both.
+
+**Alternatives considered**:
+- Keep the try/except pattern — viable but harder to read with the new
+  three-way branching (honor+timed, override, fallback).
+- Check `hasattr(dt_val, 'hour')` — works but less explicit than isinstance.
+
+## Research Question 3: Config Option Persistence and Migration Pattern
+
+**Context**: FR-008 requires the setting to persist across reloads and restarts.
+We need to determine the correct pattern for adding a new config option.
+
+### Finding
+
+The integration stores configuration in `config_entry.data` (not
+`config_entry.options`). The options flow writes to `config_entry.options`, then
+`update_listener()` in `__init__.py` copies options to data and clears options.
+
+Adding a new config key requires:
+
+1. **`const.py`**: Add `CONF_HONOR_EVENT_TIMES` and `DEFAULT_HONOR_EVENT_TIMES`
+2. **`config_flow.py`**: Add to `_get_schema()`, bump `VERSION` from 7 to 8
+3. **`__init__.py`**: Add migration `7 → 8` that sets the default (`False`) for
+   existing entries
+4. **`coordinator.py`**: Read the config in `__init__()` and `update_config()`
+
+The existing `CONF_SHOULD_UPDATE_CODE` option (added in migration 6→7) provides
+an exact template for this pattern.
+
+**Decision**: Follow the `CONF_SHOULD_UPDATE_CODE` pattern exactly — same
+migration approach, same schema position (optional boolean after
+`should_update_code`), same default behavior.
+
+**Rationale**: Proven pattern already in the codebase. The migration sets default
+to `False` for existing entries (preserving current behavior), while new entries
+get `False` as the schema default.
+
+**Alternatives considered**:
+- Store in `config_entry.options` instead of `config_entry.data` — rejected
+  because the integration's existing pattern always promotes options to data.
+- Use HA's `async_setup_entry` to detect missing key and add default — rejected
+  because the migration pattern is cleaner and only runs once per entry.
+
+## Research Question 4: Downstream Time Update Mechanism
+
+**Context**: FR-006 says the existing time-update mechanism must propagate
+changes without new Keymaster code. We need to verify this.
+
+### Finding
+
+The time update pipeline:
+
+1. `_ical_parser()` builds `CalendarEvent` objects with start/end times
+2. Sensor `_reserve_or_update_slot()` (calsensor.py:439) calls
+   `async_reserve_or_get_slot()` with the event's UTC times
+3. `async_reserve_or_get_slot()` (event_overrides.py:202) finds the existing
+   slot, compares stored times with incoming times
+4. If times differ → updates the override in-place, returns
+   `ReserveResult(slot, is_new=False, times_updated=True)`
+5. Sensor detects `times_updated=True` (calsensor.py:502) and either:
+   - Fires `async_fire_clear_code()` (for date-based code + should_update_code)
+   - Fires `async_fire_update_times()` (otherwise)
+6. `async_fire_update_times()` (util.py:333) pushes new start/end datetimes
+   to Keymaster via `datetime.set_value` service calls
+
+**Decision**: No changes needed to the downstream pipeline. When the coordinator
+builds a CalendarEvent with calendar times (instead of override times), the
+existing mechanism automatically detects the difference and propagates it.
+
+**Rationale**: The pipeline already handles exactly this scenario — it compares
+incoming times with stored override times and fires updates when they differ.
+The only change is what times go *into* the CalendarEvent.
+
+**Alternatives considered**: None — the existing mechanism is exactly what's
+needed.
+
+## Research Question 5: Impact on `async_reserve_or_get_slot()` Override Update
+
+**Context**: When "Honor event times" is enabled and times differ, we need to
+understand what happens to the stored override after the update.
+
+### Finding
+
+In `async_reserve_or_get_slot()` (event_overrides.py:226-233):
+
+```python
+if override is not None and (
+    override["start_time"] != start_time
+    or override["end_time"] != end_time
+):
+    override["start_time"] = start_time
+    override["end_time"] = end_time
+    return ReserveResult(existing, False, True)
+```
+
+When the CalendarEvent is built with calendar times (from "Honor event times"),
+and those differ from the stored override, the override's stored times are
+**updated in-place** to match the calendar times. After this update:
+
+- The override now reflects the PMS times
+- On the next refresh, if the PMS hasn't changed again, the calendar times will
+  match the (now-updated) override times, so no update fires (FR-007 satisfied)
+- If the PMS changes again, a new difference is detected and propagated
+
+**Decision**: This is the correct and desired behavior. The override becomes a
+cache of the most recently applied PMS times, enabling change detection on
+subsequent refreshes.
+
+**Rationale**: This prevents duplicate updates (FR-007) and ensures the system
+converges to a consistent state after each PMS change.
+
+## Research Question 6: Translation File Pattern
+
+**Context**: The new option needs UI labels in strings.json and translation files.
+
+### Finding
+
+Translation entries exist in three places:
+- `strings.json` — source of truth, duplicated for both `config.step.user.data`
+  and `options.step.init.data`
+- `translations/en.json` — English translations (identical content to strings.json)
+- `translations/fr.json` — French translations
+
+The existing `should_update_code` entry provides the pattern:
+```json
+"should_update_code": "For date based codes, update the code if future events change start or end dates"
+```
+
+**Decision**: Add `honor_event_times` key to all three files in both
+`config.step.user.data` and `options.step.init.data` sections.
+
+**Rationale**: Follows existing pattern exactly. Label wording should be clear
+about what it does: "Use calendar event times instead of stored override times".

--- a/specs/007-honor-pms-times/tasks.md
+++ b/specs/007-honor-pms-times/tasks.md
@@ -1,0 +1,222 @@
+<!--
+SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Tasks: Honor PMS Calendar Event Times
+
+**Input**: Design documents from `/specs/007-honor-pms-times/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/time-resolution.md ✅, quickstart.md ✅
+
+**Tests**: Included — the plan.md constitution check requires full test coverage (Principle I).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story. US1 and US2 are both P1 priority and share foundational work; US3 is P2 and builds on their foundation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Source**: `custom_components/rental_control/`
+- **Tests**: `tests/unit/`
+- **Translations**: `custom_components/rental_control/translations/`
+
+---
+
+## Phase 1: Setup (Constants & Shared Infrastructure)
+
+**Purpose**: Add the new constant and default that all subsequent phases depend on
+
+- [ ] T001 Add `CONF_HONOR_EVENT_TIMES = "honor_event_times"` and `DEFAULT_HONOR_EVENT_TIMES = False` to `custom_components/rental_control/const.py` after the existing `CONF_SHOULD_UPDATE_CODE` / `DEFAULT_SHOULD_UPDATE_CODE` entries (after line 95)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Config migration and translation strings that MUST be complete before user story implementation can proceed
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete — the config entry must have the new key and the UI must have labels
+
+- [ ] T002 Add v7→v8 migration in `custom_components/rental_control/__init__.py`: import `CONF_HONOR_EVENT_TIMES` from `.const`, add migration block after the existing v6→v7 block (after line 237) that copies `config_entry.data`, sets `data[CONF_HONOR_EVENT_TIMES] = False`, and calls `hass.config_entries.async_update_entry()` with `version=8`
+- [ ] T003 [P] Add `honor_event_times` key with label string to `config.step.user.data` and `options.step.init.data` sections in `custom_components/rental_control/strings.json` — use label: "Honor calendar event times from PMS instead of stored override times"
+- [ ] T004 [P] Add `honor_event_times` key with identical English label to `config.step.user.data` and `options.step.init.data` sections in `custom_components/rental_control/translations/en.json`
+- [ ] T005 [P] Add `honor_event_times` key with French translation to `config.step.user.data` and `options.step.init.data` sections in `custom_components/rental_control/translations/fr.json` — use label: "Utiliser les heures des événements du calendrier PMS au lieu des heures de remplacement enregistrées"
+
+**Checkpoint**: Migration and translation strings complete — config entries will have the new key on load
+
+---
+
+## Phase 3: User Story 2 — New Configuration Option in Options Flow (Priority: P1)
+
+**Goal**: Add the "Honor event times" boolean toggle to the integration's options flow so users can enable/disable the feature. This is implemented first because US1 (time resolution) depends on the config option being available.
+
+**Independent Test**: Open the integration's options flow, verify the toggle appears, toggle it on/off, save, reload, and confirm the setting persists.
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T006 [P] [US2] Add test in `tests/unit/test_config_flow.py` that verifies `VERSION` is 8 on `RentalControlFlowHandler`
+- [ ] T007 [P] [US2] Add test in `tests/unit/test_config_flow.py` that verifies `honor_event_times` toggle appears in the options flow schema and defaults to `False`
+- [ ] T008 [P] [US2] Add test in `tests/unit/test_config_flow.py` that verifies toggling `honor_event_times` to `True` in the options flow persists the value in `config_entry.data` after `update_listener` runs
+- [ ] T009 [P] [US2] Add test in `tests/unit/test_init.py` that verifies v7→v8 migration sets `honor_event_times` to `False` for an existing config entry that lacks the key
+
+### Implementation for User Story 2
+
+- [ ] T010 [US2] Add `honor_event_times` toggle to config flow schema in `custom_components/rental_control/config_flow.py`: import `CONF_HONOR_EVENT_TIMES` and `DEFAULT_HONOR_EVENT_TIMES` from `.const`, add `CONF_HONOR_EVENT_TIMES: DEFAULT_HONOR_EVENT_TIMES` to `DEFAULTS` dict (after `CONF_SHOULD_UPDATE_CODE` entry around line 77), add `vol.Optional(CONF_HONOR_EVENT_TIMES, default=_get_default(CONF_HONOR_EVENT_TIMES, DEFAULT_HONOR_EVENT_TIMES)): cv.boolean` to `_get_schema()` after the `CONF_SHOULD_UPDATE_CODE` entry (after line 287), and bump `VERSION` from 7 to 8
+- [ ] T011 [US2] Verify all US2 tests pass — run `uv run pytest tests/unit/test_config_flow.py tests/unit/test_init.py -v -k "honor"` from worktree root
+
+**Checkpoint**: At this point, the "Honor event times" toggle is visible in the UI, persists across reloads, and migration handles existing entries. User Story 2 is fully functional and testable independently.
+
+---
+
+## Phase 4: User Story 1 — PMS Time Changes Flow Through to Lock Codes (Priority: P1) 🎯 MVP
+
+**Goal**: When "Honor event times" is enabled, calendar-provided check-in/check-out times take precedence over stored override times for events with explicit times, causing PMS time changes to propagate to Keymaster via the existing time-update pipeline.
+
+**Independent Test**: Enable "Honor event times," create a test calendar with a timed reservation, assign it to a Keymaster slot, change the reservation's start time, trigger a refresh, and verify the override times are updated and a time-update event fires.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T012 [P] [US1] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event has explicit times and override exists, `_ical_parser` builds `CalendarEvent` with calendar times (not override times)
+- [ ] T013 [P] [US1] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=False` and override exists, `_ical_parser` builds `CalendarEvent` with override times (current behavior preserved — FR-005)
+- [ ] T014 [P] [US1] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event has explicit times and no override exists, `_ical_parser` builds `CalendarEvent` with calendar times
+- [ ] T015 [P] [US1] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and calendar times match stored override times, no unnecessary time-update event fires (FR-007)
+
+### Implementation for User Story 1
+
+- [ ] T016 [US1] Read and store `honor_event_times` config in `custom_components/rental_control/coordinator.py`: import `CONF_HONOR_EVENT_TIMES` from `.const`, add `self.honor_event_times: bool = bool(config.get(CONF_HONOR_EVENT_TIMES))` in `__init__()` (after line 115 near the existing `self.should_update_code` assignment), and add `self.honor_event_times = bool(config.get(CONF_HONOR_EVENT_TIMES))` in `update_config()` (after line 518 near the existing `self.should_update_code` assignment)
+- [ ] T017 [US1] Modify time resolution logic in `custom_components/rental_control/coordinator.py` `_ical_parser()` method (lines 607–631): replace the current override-first / try-except block with the new three-way branching: (1) if `self.honor_event_times` and `isinstance(event["DTSTART"].dt, datetime)` → use calendar times, (2) elif override exists → use override times, (3) else try calendar `.time()` with `AttributeError` fallback to defaults
+- [ ] T018 [US1] Verify all US1 tests pass — run `uv run pytest tests/unit/test_coordinator.py -v -k "honor"` from worktree root
+
+**Checkpoint**: At this point, PMS time changes flow through to Keymaster when "Honor event times" is enabled. The core feature is complete. User Stories 1 AND 2 are both independently functional.
+
+---
+
+## Phase 5: User Story 3 — All-Day Events Fall Back to Default Times (Priority: P2)
+
+**Goal**: When "Honor event times" is enabled, all-day events (no explicit times) correctly fall back to stored override times or configured defaults — no regression from the current behavior.
+
+**Independent Test**: Enable "Honor event times," create an all-day calendar event, verify it uses configured default check-in/check-out times. Then assign it to a slot with override times and verify it uses override times.
+
+### Tests for User Story 3
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T019 [P] [US3] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event is all-day (date-only DTSTART) and no override exists, `_ical_parser` uses configured default checkin/checkout times
+- [ ] T020 [P] [US3] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event is all-day and override exists, `_ical_parser` uses override times (not defaults)
+- [ ] T021 [P] [US3] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=False` and event is all-day and no override exists, `_ical_parser` uses configured default times (existing behavior)
+
+### Implementation for User Story 3
+
+> **NOTE**: The time resolution logic implemented in T017 already handles all-day event fallback via the three-way branching. These tests validate that the existing implementation is correct for all-day edge cases — no additional source code changes should be needed.
+
+- [ ] T022 [US3] Verify all US3 tests pass — run `uv run pytest tests/unit/test_coordinator.py -v -k "all_day or allday"` from worktree root
+- [ ] T023 [US3] If any US3 test fails, fix the time resolution logic in `custom_components/rental_control/coordinator.py` `_ical_parser()` to ensure all-day events (where `isinstance(event["DTSTART"].dt, datetime)` is `False`) always fall through to the override or default branches
+
+**Checkpoint**: All user stories are now independently functional. All-day events confirmed to work correctly with honor_event_times enabled/disabled.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Full test suite validation, edge cases, and pre-commit compliance
+
+- [ ] T024 [P] Add edge case test in `tests/unit/test_coordinator.py` that verifies transitioning an event from explicit times to all-day (between refreshes) with `honor_event_times=True` falls back to defaults gracefully
+- [ ] T025 [P] Add edge case test in `tests/unit/test_coordinator.py` that verifies enabling `honor_event_times` mid-session (via `update_config`) causes the next refresh to use calendar times for timed events with existing overrides
+- [ ] T026 Run full test suite from worktree root: `uv run pytest tests/ -v --cov=custom_components/rental_control --cov-report=term-missing` — verify no regressions across all existing tests
+- [ ] T027 Run pre-commit hooks from worktree root: `pre-commit run --all-files` — verify ruff, mypy, interrogate (100% docstring coverage), reuse (SPDX headers), and gitlint all pass
+- [ ] T028 Validate quickstart.md test commands work: run `uv run pytest tests/unit/test_coordinator.py -v -k "honor"` and `uv run pytest tests/unit/test_config_flow.py -v -k "honor"` from worktree root
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (constants must exist) — BLOCKS all user stories
+- **User Story 2 (Phase 3)**: Depends on Phase 2 — config flow needs migration + strings
+- **User Story 1 (Phase 4)**: Depends on Phase 3 — coordinator needs the config option to be in config_entry.data
+- **User Story 3 (Phase 5)**: Depends on Phase 4 — tests validate the same logic implemented in T017
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 2 (P1 — config)**: Can start after Foundational (Phase 2). No dependencies on other stories. Implemented first because it provides the config plumbing.
+- **User Story 1 (P1 — core logic)**: Depends on US2 completion — the coordinator reads `honor_event_times` from config, which must be in the schema and migrated first.
+- **User Story 3 (P2 — all-day fallback)**: Depends on US1 — validates that the time resolution logic from T017 correctly handles all-day events. No new source code expected.
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Config plumbing before core logic
+- Core implementation before integration validation
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- **Phase 2**: T003, T004, T005 (translation files) can all run in parallel
+- **Phase 3**: T006, T007, T008, T009 (US2 tests) can all run in parallel
+- **Phase 4**: T012, T013, T014, T015 (US1 tests) can all run in parallel
+- **Phase 5**: T019, T020, T021 (US3 tests) can all run in parallel
+- **Phase 6**: T024, T025 (edge case tests) can run in parallel
+
+---
+
+## Parallel Example: User Story 1 Tests
+
+```bash
+# Launch all US1 test tasks together (all write to different test functions in the same file):
+Task T012: "Test honor=True + timed event + override → calendar times"
+Task T013: "Test honor=False + override → override times (FR-005)"
+Task T014: "Test honor=True + timed event + no override → calendar times"
+Task T015: "Test honor=True + times match → no update event (FR-007)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2)
+
+1. Complete Phase 1: Setup (T001 — single constant addition)
+2. Complete Phase 2: Foundational (T002–T005 — migration + strings)
+3. Complete Phase 3: User Story 2 (T006–T011 — config toggle)
+4. Complete Phase 4: User Story 1 (T012–T018 — core time resolution)
+5. **STOP and VALIDATE**: Test US1 + US2 independently
+6. This delivers the full core feature — PMS times flow through when enabled
+
+### Incremental Delivery
+
+1. Setup + Foundational → Config infrastructure ready
+2. Add User Story 2 → Config toggle available in UI → Validate independently
+3. Add User Story 1 → Core feature works → Validate independently (MVP!)
+4. Add User Story 3 → All-day event behavior confirmed → Validate independently
+5. Polish → Full test suite passes, pre-commit clean
+
+### Atomic Commit Strategy (from quickstart.md)
+
+Each phase maps to one atomic commit:
+1. `const.py` — Add constants
+2. `config_flow.py` — Add toggle + bump VERSION
+3. `__init__.py` — Add v7→v8 migration
+4. `coordinator.py` — Read config + modify time resolution
+5. `strings.json` + `translations/` — Add UI strings
+6. `tests/` — Add all tests
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent test functions, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US2 (config) is implemented before US1 (logic) despite both being P1, because US1 depends on the config plumbing from US2
+- US3 tests validate the same code path implemented in US1's T017 — no new source code is expected for US3
+- The downstream time-update pipeline (event_overrides.py → calsensor.py → util.py) is UNCHANGED per research.md findings
+- All file paths are relative to worktree root: `/home/tykeal/repos/personal/homeassistant/worktrees/007-honor-pms-times/`


### PR DESCRIPTION
## Plan & Tasks: Honor PMS Calendar Event Times

Adds implementation artifacts for spec 007:

### Artifacts
- **plan.md** — Implementation plan with constitution check
- **research.md** — 6 research questions resolved
- **data-model.md** — Config entity model and state transitions
- **contracts/time-resolution.md** — Interface contracts
- **quickstart.md** — Developer quickstart guide
- **tasks.md** — 28-task breakdown (US1: 7, US2: 6, US3: 5, setup/polish: 10)

### Core Insight
No downstream changes needed. The existing `async_reserve_or_get_slot()` → `async_fire_update_times()` pipeline already handles time updates. The only production code change is in `coordinator._build_events()` to reorder time resolution priority when the new option is enabled.