### PR TITLE
Fix: run from_ical in executor thread

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -365,8 +365,12 @@ Please update Keymaster to at least v0.1.0-b0
 
         try:
             # Some calendars are filled with NULL-bytes that break
-            # parsing
-            event_list = Calendar.from_ical(text.replace("\x00", ""))
+            # parsing.  from_ical triggers blocking timezone file I/O
+            # so run it in the executor.
+            cleaned = text.replace("\x00", "")
+            event_list = await self.hass.async_add_executor_job(
+                Calendar.from_ical, cleaned
+            )
 
             # Convert non-standard timezone definitions
             if "X-WR-TIMEZONE" in event_list:


### PR DESCRIPTION
## Fix Blocking I/O in Event Loop

`Calendar.from_ical()` triggers blocking filesystem I/O through Python's `zoneinfo` module (reading timezone files via `open`, `walk`, `scandir`). HA 2025.x detects this and logs warnings.

### Fix
Move `Calendar.from_ical()` to `async_add_executor_job()`, matching the existing pattern already used for `x_wr_timezone.to_standard()` on the very next line.

### Log warnings fixed
- `Detected blocking call to open with args...tzdata/zones`
- `Detected blocking call to walk with args.../usr/share/zoneinfo`
- `Detected blocking call to scandir with args.../usr/share/zoneinfo`
- `Detected blocking call to open with args...posixrules`