### PR TITLE
Feat(sensor): dynamic description attributes

### DIFF
--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -196,6 +196,55 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
                     return booking_id
         return None
 
+    # Field labels already handled by dedicated extractors.
+    _KNOWN_FIELDS: frozenset[str] = frozenset(
+        {
+            "email",
+            "last 4 digits",
+            "phone",
+            "phone number",
+            "phone (last 4)",
+            "guests",
+            "adults",
+            "children",
+            "booking id",
+        }
+    )
+
+    def _extract_dynamic_attributes(self) -> dict[str, str]:
+        """Extract unrecognised 'Field: Value' lines from description.
+
+        Parses each line for a ``<field>: <value>`` pattern and returns
+        a dict keyed by the slugified field name.  Lines whose field
+        label matches a dedicated extractor, or that look like URLs,
+        are skipped.
+        """
+        desc = self._event_attributes.get("description")
+        if not desc:
+            return {}
+
+        result: dict[str, str] = {}
+        line_re = re.compile(r"^([^:\n]+?):\s+(.+)$", re.MULTILINE)
+
+        for match in line_re.finditer(desc):
+            field = match.group(1).strip()
+            value = match.group(2).strip()
+
+            # Skip fields handled by dedicated extractors
+            if field.lower() in self._KNOWN_FIELDS:
+                continue
+
+            # Skip bare URLs that happen to contain ':'
+            if field.lower().startswith("http"):
+                continue
+
+            # Slugify: lowercase, replace non-alnum with underscore
+            key = re.sub(r"[^a-z0-9]+", "_", field.lower()).strip("_")
+            if key and value:
+                result[key] = value
+
+        return result
+
     def _generate_door_code(self) -> str:
         """Generate a door code based upon the selected type."""
 
@@ -384,6 +433,13 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             booking_id = self._extract_booking_id()
             if booking_id is not None:
                 parsed_attributes["booking_id"] = booking_id
+
+            # Capture any remaining "Field: Value" lines not already
+            # handled by the dedicated extractors above.
+            dynamic = self._extract_dynamic_attributes()
+            for key, value in dynamic.items():
+                if key not in parsed_attributes:
+                    parsed_attributes[key] = value
 
             self._parsed_attributes = parsed_attributes
 

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -582,6 +582,88 @@ class TestExtractBookingId:
         assert sensor._extract_booking_id() is None
 
 
+class TestExtractDynamicAttributes:
+    """Tests for _extract_dynamic_attributes parsing."""
+
+    def test_extracts_unknown_fields(self, hass) -> None:
+        """Verify unknown 'Field: Value' lines become attributes."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = "Listing: Beach House\nSource: Guesty"
+        result = sensor._extract_dynamic_attributes()
+        assert result == {"listing": "Beach House", "source": "Guesty"}
+
+    def test_skips_known_fields(self, hass) -> None:
+        """Verify fields handled by dedicated extractors are skipped."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = (
+            "Email: guest@example.com\n"
+            "Phone: +1 555-123-4567\n"
+            "Guests: 4\n"
+            "Booking ID: abc123\n"
+            "Custom Field: extra data"
+        )
+        result = sensor._extract_dynamic_attributes()
+        assert result == {"custom_field": "extra data"}
+
+    def test_skips_url_lines(self, hass) -> None:
+        """Verify URL lines are not captured as dynamic attributes."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = (
+            "https://example.com/booking/123\nPlatform: Airbnb"
+        )
+        result = sensor._extract_dynamic_attributes()
+        assert result == {"platform": "Airbnb"}
+
+    def test_returns_empty_when_no_description(self, hass) -> None:
+        """Verify empty dict when description is None."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = None
+        assert sensor._extract_dynamic_attributes() == {}
+
+    def test_returns_empty_when_no_fields(self, hass) -> None:
+        """Verify empty dict when description has no field patterns."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = "Just a plain text note"
+        assert sensor._extract_dynamic_attributes() == {}
+
+    def test_slugifies_field_names(self, hass) -> None:
+        """Verify field names are slugified to valid attribute keys."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = (
+            "Check-In Time: 3:00 PM\nNumber Of Pets: 2"
+        )
+        result = sensor._extract_dynamic_attributes()
+        assert result == {
+            "check_in_time": "3:00 PM",
+            "number_of_pets": "2",
+        }
+
+    def test_does_not_override_dedicated_attributes(self, hass) -> None:
+        """Verify dynamic attrs don't overwrite dedicated extractor results."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = (
+            "Adults: 2\nChildren: 1\nProperty: Lake Cabin"
+        )
+        result = sensor._extract_dynamic_attributes()
+        # Adults and Children are known fields, only Property comes through
+        assert result == {"property": "Lake Cabin"}
+
+    def test_skips_last_4_digits_field(self, hass) -> None:
+        """Verify 'Last 4 Digits' known field is skipped."""
+        coordinator = _make_coordinator()
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["description"] = "Last 4 Digits: 1234\nRegion: US West"
+        result = sensor._extract_dynamic_attributes()
+        assert result == {"region": "US West"}
+
+
 # ---------------------------------------------------------------------------
 # Code generation tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Dynamic Description Attributes

Parses unrecognised `Field: Value` lines from the calendar event DESCRIPTION and exposes them as extra state attributes on event sensors with slugified keys.

### Example
A description like:
```
Email: guest@example.com
Listing: Beach House
Source: Guesty
Check-In Time: 3:00 PM
```

Would produce attributes `listing`, `source`, and `check_in_time` (Email is already handled by the dedicated extractor).

### Implementation
- New `_extract_dynamic_attributes()` method on `RentalControlCalSensor`
- `_KNOWN_FIELDS` frozenset lists field labels already handled by dedicated extractors
- Slugified keys: lowercase, non-alphanumeric → underscore
- Skips: known fields, URL lines, empty values
- Dedicated extractor results always win (dynamic attrs never overwrite)

### Tests
8 new tests covering: unknown fields, known field skipping, URL skipping, None description, plain text, slugification, no-override guarantee, Last 4 Digits skip.

617 tests passing.