### PR TITLE
Fix(config_flow): Normalize cleared lock select

### DIFF
--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -133,6 +133,18 @@ class RentalControlOptionsFlow(config_entries.OptionsFlow):
         )
 
 
+def _normalize_lock_entry(value: Any) -> str:
+    """Normalize cleared lock entry values to '(none)'.
+
+    The HA frontend sends None or empty string when the user
+    clears a select field via the X button. Map those to the
+    explicit '(none)' sentinel so vol.In validation passes.
+    """
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return "(none)"
+    return str(value)
+
+
 def _available_lock_managers(
     hass: HomeAssistant,
 ) -> list:
@@ -258,7 +270,7 @@ def _get_schema(
             ): cv.positive_int,
             vol.Optional(
                 CONF_LOCK_ENTRY, default=_get_default(CONF_LOCK_ENTRY, "(none)")
-            ): vol.In(_available_lock_managers(hass)),
+            ): vol.All(_normalize_lock_entry, vol.In(_available_lock_managers(hass))),
             vol.Required(
                 CONF_START_SLOT,
                 default=_get_default(CONF_START_SLOT, DEFAULT_START_SLOT),

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -13,8 +13,10 @@ from homeassistant.const import CONF_NAME
 from homeassistant.const import CONF_URL
 from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.data_entry_flow import FlowResultType
+import pytest
 import voluptuous as vol
 
+from custom_components.rental_control.config_flow import _normalize_lock_entry
 from custom_components.rental_control.const import CONF_CHECKIN
 from custom_components.rental_control.const import CONF_CHECKOUT
 from custom_components.rental_control.const import CONF_CODE_GENERATION
@@ -1147,3 +1149,197 @@ async def test_honor_event_times_toggle_persists(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
     assert updated_entry.data[CONF_HONOR_EVENT_TIMES] is True
+
+
+@pytest.mark.parametrize(
+    ("input_val", "expected"),
+    [
+        (None, "(none)"),
+        ("", "(none)"),
+        ("  ", "(none)"),
+        ("(none)", "(none)"),
+        ("Front Door", "Front Door"),
+    ],
+)
+def test_normalize_lock_entry(input_val: str | None, expected: str) -> None:
+    """Test _normalize_lock_entry maps empty values to (none).
+
+    Verifies that:
+    - None, empty string, and whitespace map to '(none)'
+    - Valid lock names pass through unchanged
+    - The explicit '(none)' sentinel passes through
+    """
+    assert _normalize_lock_entry(input_val) == expected
+
+
+async def test_config_flow_lock_entry_none_normalized(
+    hass: HomeAssistant,
+) -> None:
+    """Test clearing lock via X button stores None lock entry.
+
+    When the HA frontend X-clear button sends None for the lock
+    select field, the normalizer converts it to '(none)' so
+    schema validation passes and the entry saves with no lock.
+    """
+    with aioresponses() as mock_aiohttp:
+        test_url = "https://example.com/calendar.ics"
+        mock_aiohttp.get(
+            test_url,
+            status=200,
+            body=calendar_data.AIRBNB_ICS_CALENDAR,
+            headers={"content-type": "text/calendar"},
+            repeat=True,
+        )
+
+        config_result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={
+                CONF_NAME: "Test Lock Clear",
+                CONF_URL: test_url,
+                CONF_VERIFY_SSL: True,
+                CONF_IGNORE_NON_RESERVED: True,
+                CONF_LOCK_ENTRY: "(none)",
+                CONF_REFRESH_FREQUENCY: DEFAULT_REFRESH_FREQUENCY,
+                CONF_TIMEZONE: "UTC",
+                CONF_EVENT_PREFIX: "",
+                CONF_CHECKIN: DEFAULT_CHECKIN,
+                CONF_CHECKOUT: DEFAULT_CHECKOUT,
+                CONF_DAYS: DEFAULT_DAYS,
+                CONF_MAX_EVENTS: DEFAULT_MAX_EVENTS,
+                CONF_START_SLOT: DEFAULT_START_SLOT,
+                CONF_CODE_LENGTH: DEFAULT_CODE_LENGTH,
+                CONF_CODE_GENERATION: "Start/End Date",
+                CONF_SHOULD_UPDATE_CODE: True,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert config_result["type"] == FlowResultType.CREATE_ENTRY
+    entry = config_result["result"]
+    assert entry.data[CONF_LOCK_ENTRY] is None
+
+    # Simulate X-clear button: send None for lock_entry
+    with aioresponses() as mock_aiohttp:
+        mock_aiohttp.get(
+            test_url,
+            status=200,
+            body=calendar_data.AIRBNB_ICS_CALENDAR,
+            headers={"content-type": "text/calendar"},
+            repeat=True,
+        )
+
+        result = await hass.config_entries.options.async_init(
+            entry.entry_id,
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_NAME: "Test Lock Clear",
+                CONF_URL: test_url,
+                CONF_VERIFY_SSL: True,
+                CONF_IGNORE_NON_RESERVED: True,
+                CONF_LOCK_ENTRY: None,
+                CONF_REFRESH_FREQUENCY: DEFAULT_REFRESH_FREQUENCY,
+                CONF_TIMEZONE: "UTC",
+                CONF_EVENT_PREFIX: "",
+                CONF_CHECKIN: DEFAULT_CHECKIN,
+                CONF_CHECKOUT: DEFAULT_CHECKOUT,
+                CONF_DAYS: DEFAULT_DAYS,
+                CONF_MAX_EVENTS: DEFAULT_MAX_EVENTS,
+                CONF_START_SLOT: DEFAULT_START_SLOT,
+                CONF_CODE_LENGTH: DEFAULT_CODE_LENGTH,
+                CONF_CODE_GENERATION: "Start/End Date",
+                CONF_SHOULD_UPDATE_CODE: True,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated_entry.data[CONF_LOCK_ENTRY] is None
+
+
+async def test_config_flow_lock_entry_empty_string_normalized(
+    hass: HomeAssistant,
+) -> None:
+    """Test clearing lock via empty string stores None lock entry.
+
+    When the HA frontend sends an empty string for a cleared
+    select field, the normalizer converts it to '(none)' so
+    schema validation passes and the entry saves with no lock.
+    """
+    with aioresponses() as mock_aiohttp:
+        test_url = "https://example.com/calendar.ics"
+        mock_aiohttp.get(
+            test_url,
+            status=200,
+            body=calendar_data.AIRBNB_ICS_CALENDAR,
+            headers={"content-type": "text/calendar"},
+            repeat=True,
+        )
+
+        config_result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={
+                CONF_NAME: "Test Lock Empty",
+                CONF_URL: test_url,
+                CONF_VERIFY_SSL: True,
+                CONF_IGNORE_NON_RESERVED: True,
+                CONF_LOCK_ENTRY: "(none)",
+                CONF_REFRESH_FREQUENCY: DEFAULT_REFRESH_FREQUENCY,
+                CONF_TIMEZONE: "UTC",
+                CONF_EVENT_PREFIX: "",
+                CONF_CHECKIN: DEFAULT_CHECKIN,
+                CONF_CHECKOUT: DEFAULT_CHECKOUT,
+                CONF_DAYS: DEFAULT_DAYS,
+                CONF_MAX_EVENTS: DEFAULT_MAX_EVENTS,
+                CONF_START_SLOT: DEFAULT_START_SLOT,
+                CONF_CODE_LENGTH: DEFAULT_CODE_LENGTH,
+                CONF_CODE_GENERATION: "Start/End Date",
+                CONF_SHOULD_UPDATE_CODE: True,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert config_result["type"] == FlowResultType.CREATE_ENTRY
+    entry = config_result["result"]
+
+    # Simulate X-clear button: send empty string for lock_entry
+    with aioresponses() as mock_aiohttp:
+        mock_aiohttp.get(
+            test_url,
+            status=200,
+            body=calendar_data.AIRBNB_ICS_CALENDAR,
+            headers={"content-type": "text/calendar"},
+            repeat=True,
+        )
+
+        result = await hass.config_entries.options.async_init(
+            entry.entry_id,
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_NAME: "Test Lock Empty",
+                CONF_URL: test_url,
+                CONF_VERIFY_SSL: True,
+                CONF_IGNORE_NON_RESERVED: True,
+                CONF_LOCK_ENTRY: "",
+                CONF_REFRESH_FREQUENCY: DEFAULT_REFRESH_FREQUENCY,
+                CONF_TIMEZONE: "UTC",
+                CONF_EVENT_PREFIX: "",
+                CONF_CHECKIN: DEFAULT_CHECKIN,
+                CONF_CHECKOUT: DEFAULT_CHECKOUT,
+                CONF_DAYS: DEFAULT_DAYS,
+                CONF_MAX_EVENTS: DEFAULT_MAX_EVENTS,
+                CONF_START_SLOT: DEFAULT_START_SLOT,
+                CONF_CODE_LENGTH: DEFAULT_CODE_LENGTH,
+                CONF_CODE_GENERATION: "Start/End Date",
+                CONF_SHOULD_UPDATE_CODE: True,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated_entry.data[CONF_LOCK_ENTRY] is None


### PR DESCRIPTION
## Summary

The HA frontend's "X" clear button on select dropdowns sends `None` or
an empty string instead of a value from the allowed list. `vol.In`
rejects these, causing HA to silently re-show the form with old values
— the lock disconnect never actually saves.

## Changes

- Add `_normalize_lock_entry()` in `config_flow.py` that converts
  `None`, empty strings, and whitespace-only strings to the `"(none)"`
  sentinel value
- Wrap the `CONF_LOCK_ENTRY` schema validator with
  `vol.All(_normalize_lock_entry, vol.In(...))` so normalization runs
  before list membership validation
- Add parametrized unit tests for the normalizer function
- Add unit tests verifying that `None` and `""` lock entry values
  pass through the options flow and store `CONF_LOCK_ENTRY = None`