### PR TITLE
CI(release): Add pip CVE to audit ignore

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -188,6 +188,7 @@ jobs:
         uses: lfreleng-actions/python-audit-action@1776538e768c52c55c3c96495f6e25f0762ad28f  # v0.2.6
         with:
           python_version: "${{ matrix.python-version }}"
+          ignore_vulns: 'GHSA-58qw-9mgm-455v'
 
   sbom:
     name: 'Generate SBOM'


### PR DESCRIPTION
## Problem

The v3.0.0 release failed at the Python Audit step because the release
workflow was missing the `ignore_vulns` for `GHSA-58qw-9mgm-455v`
(pip CVE-2026-3219). The build-test workflow had this ignore but the
release workflow did not.

## Fix

Add `ignore_vulns: 'GHSA-58qw-9mgm-455v'` to the release workflow's
audit step, matching the build-test workflow configuration.

pip is runner tooling, not a project dependency — the CVE has no patch
available yet.