### PR TITLE
Fix(config): Remove function from schema

### DIFF
--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -270,7 +270,7 @@ def _get_schema(
             ): cv.positive_int,
             vol.Optional(
                 CONF_LOCK_ENTRY, default=_get_default(CONF_LOCK_ENTRY, "(none)")
-            ): vol.All(_normalize_lock_entry, vol.In(_available_lock_managers(hass))),
+            ): vol.Any(vol.In(_available_lock_managers(hass)), None, ""),
             vol.Required(
                 CONF_START_SLOT,
                 default=_get_default(CONF_START_SLOT, DEFAULT_START_SLOT),
@@ -349,6 +349,13 @@ async def _start_config_flow(
     description_placeholders: dict[str, str] = {}
 
     if user_input is not None:
+        # Normalize lock entry outside the schema to keep the
+        # schema JSON-serializable for the HA frontend.
+        if CONF_LOCK_ENTRY in user_input:
+            user_input[CONF_LOCK_ENTRY] = _normalize_lock_entry(
+                user_input[CONF_LOCK_ENTRY]
+            )
+
         # Regular flow has an async function
         if hasattr(cls, "_get_unique_id"):
             errors.update(await cls._get_unique_id(user_input))


### PR DESCRIPTION
## Problem

Reconfiguring a lock entry in v3.0.0 crashes with:

```
ValueError: Unable to convert schema: <function _normalize_lock_entry at 0x...>
```

`voluptuous_serialize` cannot convert a custom Python function inside
`vol.All()` to JSON schema for the HA frontend.

## Fix

- Remove `_normalize_lock_entry` from the `vol.All()` schema chain
- Call it in `_start_config_flow()` before schema validation instead
- Schema now accepts `None` and `""` directly via `vol.Any()` so the
  HA framework's pre-validation passes before our handler normalizes

All 633 tests pass.