### PR TITLE
Fix(config): Use SelectSelector for lock entry

### DIFF
--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -16,6 +16,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import SelectOptionDict
+from homeassistant.helpers.selector import SelectSelector
+from homeassistant.helpers.selector import SelectSelectorConfig
+from homeassistant.helpers.selector import SelectSelectorMode
 from homeassistant.util import dt
 import voluptuous as vol
 from voluptuous.schema_builder import ALLOW_EXTRA
@@ -270,7 +274,15 @@ def _get_schema(
             ): cv.positive_int,
             vol.Optional(
                 CONF_LOCK_ENTRY, default=_get_default(CONF_LOCK_ENTRY, "(none)")
-            ): vol.Any(vol.In(_available_lock_managers(hass)), None, ""),
+            ): SelectSelector(
+                SelectSelectorConfig(
+                    options=[
+                        SelectOptionDict(value=v, label=v)
+                        for v in _available_lock_managers(hass)
+                    ],
+                    mode=SelectSelectorMode.DROPDOWN,
+                )
+            ),
             vol.Required(
                 CONF_START_SLOT,
                 default=_get_default(CONF_START_SLOT, DEFAULT_START_SLOT),

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -1175,11 +1175,11 @@ def test_normalize_lock_entry(input_val: str | None, expected: str) -> None:
 async def test_config_flow_lock_entry_none_normalized(
     hass: HomeAssistant,
 ) -> None:
-    """Test clearing lock via X button stores None lock entry.
+    """Test selecting '(none)' stores None lock entry.
 
-    When the HA frontend X-clear button sends None for the lock
-    select field, the normalizer converts it to '(none)' so
-    schema validation passes and the entry saves with no lock.
+    When the user selects '(none)' from the lock manager dropdown
+    to disconnect a lock, the config flow converts the sentinel to
+    None before saving the entry.
     """
     with aioresponses() as mock_aiohttp:
         test_url = "https://example.com/calendar.ics"
@@ -1219,7 +1219,7 @@ async def test_config_flow_lock_entry_none_normalized(
     entry = config_result["result"]
     assert entry.data[CONF_LOCK_ENTRY] is None
 
-    # Simulate X-clear button: send None for lock_entry
+    # Select '(none)' from the dropdown to disconnect lock
     with aioresponses() as mock_aiohttp:
         mock_aiohttp.get(
             test_url,
@@ -1239,7 +1239,7 @@ async def test_config_flow_lock_entry_none_normalized(
                 CONF_URL: test_url,
                 CONF_VERIFY_SSL: True,
                 CONF_IGNORE_NON_RESERVED: True,
-                CONF_LOCK_ENTRY: None,
+                CONF_LOCK_ENTRY: "(none)",
                 CONF_REFRESH_FREQUENCY: DEFAULT_REFRESH_FREQUENCY,
                 CONF_TIMEZONE: "UTC",
                 CONF_EVENT_PREFIX: "",
@@ -1262,84 +1262,15 @@ async def test_config_flow_lock_entry_none_normalized(
 async def test_config_flow_lock_entry_empty_string_normalized(
     hass: HomeAssistant,
 ) -> None:
-    """Test clearing lock via empty string stores None lock entry.
+    """Test _normalize_lock_entry converts empty string to sentinel.
 
-    When the HA frontend sends an empty string for a cleared
-    select field, the normalizer converts it to '(none)' so
-    schema validation passes and the entry saves with no lock.
+    Verify the normalizer utility itself handles empty strings,
+    even though the SelectSelector dropdown sends '(none)' directly.
     """
-    with aioresponses() as mock_aiohttp:
-        test_url = "https://example.com/calendar.ics"
-        mock_aiohttp.get(
-            test_url,
-            status=200,
-            body=calendar_data.AIRBNB_ICS_CALENDAR,
-            headers={"content-type": "text/calendar"},
-            repeat=True,
-        )
+    from custom_components.rental_control.config_flow import _normalize_lock_entry
 
-        config_result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data={
-                CONF_NAME: "Test Lock Empty",
-                CONF_URL: test_url,
-                CONF_VERIFY_SSL: True,
-                CONF_IGNORE_NON_RESERVED: True,
-                CONF_LOCK_ENTRY: "(none)",
-                CONF_REFRESH_FREQUENCY: DEFAULT_REFRESH_FREQUENCY,
-                CONF_TIMEZONE: "UTC",
-                CONF_EVENT_PREFIX: "",
-                CONF_CHECKIN: DEFAULT_CHECKIN,
-                CONF_CHECKOUT: DEFAULT_CHECKOUT,
-                CONF_DAYS: DEFAULT_DAYS,
-                CONF_MAX_EVENTS: DEFAULT_MAX_EVENTS,
-                CONF_START_SLOT: DEFAULT_START_SLOT,
-                CONF_CODE_LENGTH: DEFAULT_CODE_LENGTH,
-                CONF_CODE_GENERATION: "Start/End Date",
-                CONF_SHOULD_UPDATE_CODE: True,
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert config_result["type"] == FlowResultType.CREATE_ENTRY
-    entry = config_result["result"]
-
-    # Simulate X-clear button: send empty string for lock_entry
-    with aioresponses() as mock_aiohttp:
-        mock_aiohttp.get(
-            test_url,
-            status=200,
-            body=calendar_data.AIRBNB_ICS_CALENDAR,
-            headers={"content-type": "text/calendar"},
-            repeat=True,
-        )
-
-        result = await hass.config_entries.options.async_init(
-            entry.entry_id,
-        )
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_NAME: "Test Lock Empty",
-                CONF_URL: test_url,
-                CONF_VERIFY_SSL: True,
-                CONF_IGNORE_NON_RESERVED: True,
-                CONF_LOCK_ENTRY: "",
-                CONF_REFRESH_FREQUENCY: DEFAULT_REFRESH_FREQUENCY,
-                CONF_TIMEZONE: "UTC",
-                CONF_EVENT_PREFIX: "",
-                CONF_CHECKIN: DEFAULT_CHECKIN,
-                CONF_CHECKOUT: DEFAULT_CHECKOUT,
-                CONF_DAYS: DEFAULT_DAYS,
-                CONF_MAX_EVENTS: DEFAULT_MAX_EVENTS,
-                CONF_START_SLOT: DEFAULT_START_SLOT,
-                CONF_CODE_LENGTH: DEFAULT_CODE_LENGTH,
-                CONF_CODE_GENERATION: "Start/End Date",
-                CONF_SHOULD_UPDATE_CODE: True,
-            },
-        )
-
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated_entry.data[CONF_LOCK_ENTRY] is None
+    assert _normalize_lock_entry("") == "(none)"
+    assert _normalize_lock_entry("  ") == "(none)"
+    assert _normalize_lock_entry(None) == "(none)"
+    assert _normalize_lock_entry("Lock1") == "Lock1"
+    assert _normalize_lock_entry("(none)") == "(none)"


### PR DESCRIPTION
## Summary

Fixes the `voluptuous_serialize` crash when opening the config flow for entries with lock managers. This is a follow-up to PR #494 which was insufficient — `vol.Any()` with mixed types also cannot be serialized.

## Changes

- **config_flow.py**: Replace `vol.Any(vol.In(...), None, "")` with `SelectSelector` for the lock manager dropdown field. `SelectSelector` is the modern HA pattern for select fields and handles JSON serialization natively.
- **test_config_flow.py**: Update tests to match real HA frontend behavior. With `SelectSelector`, users select `"(none)"` from the dropdown rather than the frontend sending `None`/`""`. Simplified the empty-string test to a unit test of the normalizer utility.

## Root Cause

`voluptuous_serialize.convert()` cannot handle `vol.Any()` with mixed types like `None` and `""`. This function is called by HA's `_prepare_result_json()` when rendering config flow forms for the frontend, causing a `ValueError` crash.

## Testing

- All 633 tests pass
- Verified `SelectSelector` schema serializes correctly via `voluptuous_serialize`
- All pre-commit hooks pass

Closes #409