### PR TITLE
Feat(sensor): Add state icons to checkin sensor

### DIFF
--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -56,6 +56,13 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+_CHECKIN_STATE_ICONS: dict[str, str] = {
+    CHECKIN_STATE_AWAITING: "mdi:door-open",
+    CHECKIN_STATE_CHECKED_IN: "mdi:account-check",
+    CHECKIN_STATE_CHECKED_OUT: "mdi:airplane",
+    CHECKIN_STATE_NO_RESERVATION: "mdi:bed-empty",
+}
+
 
 class CheckinExtraStoredData(ExtraStoredData):
     """Extra stored data for persisting CheckinTrackingSensor state.
@@ -251,6 +258,11 @@ class CheckinTrackingSensor(
     def state(self) -> str:
         """Return the current check-in tracking state."""
         return self._state
+
+    @property
+    def icon(self) -> str:
+        """Return an icon reflecting the current check-in state."""
+        return _CHECKIN_STATE_ICONS.get(self._state, "mdi:bed-empty")
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -115,6 +115,29 @@ def _create_sensor(
 # ===========================================================================
 
 
+async def test_checkin_sensor_icon_per_state(
+    hass: HomeAssistant,
+    mock_checkin_coordinator: MagicMock,
+    mock_checkin_config_entry: MockConfigEntry,
+) -> None:
+    """Verify each check-in state returns the correct MDI icon."""
+    sensor = _create_sensor(hass, mock_checkin_coordinator, mock_checkin_config_entry)
+
+    expected = {
+        CHECKIN_STATE_AWAITING: "mdi:door-open",
+        CHECKIN_STATE_CHECKED_IN: "mdi:account-check",
+        CHECKIN_STATE_CHECKED_OUT: "mdi:airplane",
+        CHECKIN_STATE_NO_RESERVATION: "mdi:bed-empty",
+    }
+    for state, icon in expected.items():
+        sensor._state = state
+        assert sensor.icon == icon, f"State {state!r} should use {icon!r}"
+
+    # Unknown state falls back to bed-empty
+    sensor._state = "unknown_state"
+    assert sensor.icon == "mdi:bed-empty"
+
+
 class TestSensorEntityProperties:
     """Tests for CheckinTrackingSensor entity configuration."""
 


### PR DESCRIPTION
Add state-based MDI icons to the check-in tracking sensor.

The `icon` property now returns a context-appropriate icon based on
the current sensor state:

| State | Icon |
|-------|------|
| awaiting_checkin | mdi:door-open |
| checked_in | mdi:account-check |
| checked_out | mdi:airplane |
| no_reservation | mdi:bed-empty |

Unknown states fall back to `mdi:bed-empty`.

Includes a unit test verifying each state-to-icon mapping.