### PR TITLE
Fix(test): Freeze time in linger timing test

### DIFF
--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -807,6 +807,7 @@ class TestAutoCheckoutRescheduling:
 class TestPostCheckoutLinger:
     """Tests for post-checkout linger timing (related to T014)."""
 
+    @freeze_time("2025-03-10T12:00:00+00:00")
     async def test_same_day_turnover_linger_timing(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
The `test_same_day_turnover_linger_timing` test was flaky because it lacked a `@freeze_time` decorator. Without frozen time, `dt_util.now()` called during event setup and again inside `_transition_to_checked_out` returned different wall-clock values, causing the half-gap linger calculation to fail the `< 1 second` tolerance assertion.