### PR TITLE
Feat(coordinator): Extract check-in/out times from event description

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -626,7 +626,8 @@ Please update Keymaster to at least v0.1.0-b0
                     checkout: time = event["DTEND"].dt.time()
                 elif self.honor_event_times and not has_explicit_times:
                     # Priority 2: description-extracted times (NEW)
-                    description = str(event.get("DESCRIPTION", ""))
+                    raw_desc = event.get("DESCRIPTION")
+                    description = str(raw_desc) if raw_desc else ""
                     desc_checkin = extract_checkin_time(description)
                     desc_checkout = extract_checkout_time(description)
 

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -71,6 +71,8 @@ from .const import EVENT_AGE_THRESHOLD_DAYS
 from .const import LOCK_MANAGER
 from .const import REQUEST_TIMEOUT
 from .const import VERSION
+from .description_parser import extract_checkin_time
+from .description_parser import extract_checkout_time
 from .event_overrides import EventOverrides
 from .util import get_slot_name
 
@@ -622,6 +624,36 @@ Please update Keymaster to at least v0.1.0-b0
                     # FR-003: PMS times take priority for timed events
                     checkin: time = event["DTSTART"].dt.time()
                     checkout: time = event["DTEND"].dt.time()
+                elif self.honor_event_times and not has_explicit_times:
+                    # Priority 2: description-extracted times (NEW)
+                    description = str(event.get("DESCRIPTION", ""))
+                    desc_checkin = extract_checkin_time(description)
+                    desc_checkout = extract_checkout_time(description)
+
+                    if override:
+                        # Priority 3 fallback for missing description times
+                        start_tz = override["start_time"].astimezone(self.timezone)
+                        end_tz = override["end_time"].astimezone(self.timezone)
+                        checkin = (
+                            desc_checkin
+                            if desc_checkin is not None
+                            else start_tz.time()
+                        )
+                        checkout = (
+                            desc_checkout
+                            if desc_checkout is not None
+                            else end_tz.time()
+                        )
+                    else:
+                        # Priority 4 fallback for missing description times
+                        checkin = (
+                            desc_checkin if desc_checkin is not None else self.checkin
+                        )
+                        checkout = (
+                            desc_checkout
+                            if desc_checkout is not None
+                            else self.checkout
+                        )
                 elif override:
                     # FR-005 (disabled) or FR-004 (all-day with override)
                     # Get start & end overrides in the correct timezone

--- a/custom_components/rental_control/description_parser.py
+++ b/custom_components/rental_control/description_parser.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+"""Parse check-in/check-out times from iCal event descriptions."""
+
+from __future__ import annotations
+
+from datetime import time
+import re
+
+_CHECKIN_PATTERN = re.compile(
+    r"check-?in(?:\s+time)?\s*:\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?",
+    re.IGNORECASE,
+)
+
+_CHECKOUT_PATTERN = re.compile(
+    r"check-?out(?:\s+time)?\s*:\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?",
+    re.IGNORECASE,
+)
+
+
+def _parse_time_match(
+    hour_str: str, minute_str: str | None, ampm: str | None
+) -> time | None:
+    """Convert regex capture groups to a validated time object.
+
+    Args:
+        hour_str: Matched hour digits (1-2 chars).
+        minute_str: Matched minute digits or None.
+        ampm: "AM", "PM", or None.
+
+    Returns:
+        A valid datetime.time or None if values are out of range.
+    """
+    hour = int(hour_str)
+    minute = int(minute_str) if minute_str else 0
+
+    if ampm:
+        ampm_upper = ampm.upper()
+        if hour < 1 or hour > 12:
+            return None
+        if ampm_upper == "AM":
+            hour = 0 if hour == 12 else hour
+        else:  # PM
+            hour = hour if hour == 12 else hour + 12
+    else:
+        if hour < 0 or hour > 23:
+            return None
+
+    if minute < 0 or minute > 59:
+        return None
+
+    return time(hour, minute)
+
+
+def extract_checkin_time(description: str) -> time | None:
+    """Extract check-in time from an event description.
+
+    Searches for patterns like "Checkin time: 16", "Check-in: 4 PM",
+    "Check-in time: 16:30" (case-insensitive). Returns the first match.
+
+    Args:
+        description: The event DESCRIPTION field as a string.
+
+    Returns:
+        A datetime.time object if a valid check-in time is found, None otherwise.
+    """
+    match = _CHECKIN_PATTERN.search(description)
+    if not match:
+        return None
+    return _parse_time_match(match.group(1), match.group(2), match.group(3))
+
+
+def extract_checkout_time(description: str) -> time | None:
+    """Extract check-out time from an event description.
+
+    Searches for patterns like "Checkout time: 11", "Check-out: 11 AM",
+    "Check-out time: 11:30" (case-insensitive). Returns the first match.
+
+    Args:
+        description: The event DESCRIPTION field as a string.
+
+    Returns:
+        A datetime.time object if a valid check-out time is found, None otherwise.
+    """
+    match = _CHECKOUT_PATTERN.search(description)
+    if not match:
+        return None
+    return _parse_time_match(match.group(1), match.group(2), match.group(3))

--- a/custom_components/rental_control/description_parser.py
+++ b/custom_components/rental_control/description_parser.py
@@ -8,31 +8,29 @@ from datetime import time
 import re
 
 _CHECKIN_PATTERN = re.compile(
-    r"check-?in(?:\s+time)?\s*:\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?",
+    r"check-?in(?:\s+time)?\s*:\s*(\d{1,2}(?::\d{2})?)(?!\d|:)\s*(AM|PM)?",
     re.IGNORECASE,
 )
 
 _CHECKOUT_PATTERN = re.compile(
-    r"check-?out(?:\s+time)?\s*:\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?",
+    r"check-?out(?:\s+time)?\s*:\s*(\d{1,2}(?::\d{2})?)(?!\d|:)\s*(AM|PM)?",
     re.IGNORECASE,
 )
 
 
-def _parse_time_match(
-    hour_str: str, minute_str: str | None, ampm: str | None
-) -> time | None:
+def _parse_time_match(time_str: str, ampm: str | None) -> time | None:
     """Convert regex capture groups to a validated time object.
 
     Args:
-        hour_str: Matched hour digits (1-2 chars).
-        minute_str: Matched minute digits or None.
+        time_str: Matched time string (e.g., "16" or "16:30").
         ampm: "AM", "PM", or None.
 
     Returns:
         A valid datetime.time or None if values are out of range.
     """
-    hour = int(hour_str)
-    minute = int(minute_str) if minute_str else 0
+    parts = time_str.split(":")
+    hour = int(parts[0])
+    minute = int(parts[1]) if len(parts) > 1 else 0
 
     if ampm:
         ampm_upper = ampm.upper()
@@ -67,7 +65,7 @@ def extract_checkin_time(description: str) -> time | None:
     match = _CHECKIN_PATTERN.search(description)
     if not match:
         return None
-    return _parse_time_match(match.group(1), match.group(2), match.group(3))
+    return _parse_time_match(match.group(1), match.group(2))
 
 
 def extract_checkout_time(description: str) -> time | None:
@@ -85,4 +83,4 @@ def extract_checkout_time(description: str) -> time | None:
     match = _CHECKOUT_PATTERN.search(description)
     if not match:
         return None
-    return _parse_time_match(match.group(1), match.group(2), match.group(3))
+    return _parse_time_match(match.group(1), match.group(2))

--- a/specs/007-honor-pms-times/tasks.md
+++ b/specs/007-honor-pms-times/tasks.md
@@ -3,135 +3,172 @@ SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Tasks: Honor PMS Calendar Event Times
+# Tasks: Extract Check-in/Check-out Times from Event Description
 
 **Input**: Design documents from `/specs/007-honor-pms-times/`
 **Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/time-resolution.md ✅, quickstart.md ✅
 
-**Tests**: Included — the plan.md constitution check requires full test coverage (Principle I).
+**Tests**: Included — the plan.md constitution check requires full test coverage (Principle I), and the spec explicitly lists unit tests and integration tests as in-scope.
 
-**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story. US1 and US2 are both P1 priority and share foundational work; US3 is P2 and builds on their foundation.
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story. US1 (extract times) and US2 (preserve priority) are both P1; US3 (partial/missing) and US4 (multiple formats) are P2.
+
+**Foundation**: This task list builds upon the already-completed `honor_event_times` config plumbing (config flow, migration, coordinator attribute). The description parser is a new module that integrates into the existing time resolution chain.
 
 ## Format: `[ID] [P?] [Story] Description`
 
 - **[P]**: Can run in parallel (different files, no dependencies)
-- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
 - Include exact file paths in descriptions
 
 ## Path Conventions
 
 - **Source**: `custom_components/rental_control/`
 - **Tests**: `tests/unit/`
-- **Translations**: `custom_components/rental_control/translations/`
 
 ---
 
-## Phase 1: Setup (Constants & Shared Infrastructure)
+## Phase 1: Setup (New Module Scaffold)
 
-**Purpose**: Add the new constant and default that all subsequent phases depend on
+**Purpose**: Create the description parser module file with SPDX headers, imports, and compiled regex constants — no logic yet
 
-- [X] T001 Add `CONF_HONOR_EVENT_TIMES = "honor_event_times"` and `DEFAULT_HONOR_EVENT_TIMES = False` to `custom_components/rental_control/const.py` after the existing `CONF_SHOULD_UPDATE_CODE` / `DEFAULT_SHOULD_UPDATE_CODE` entries (after line 95)
-
----
-
-## Phase 2: Foundational (Blocking Prerequisites)
-
-**Purpose**: Config migration and translation strings that MUST be complete before user story implementation can proceed
-
-**⚠️ CRITICAL**: No user story work can begin until this phase is complete — the config entry must have the new key and the UI must have labels
-
-- [X] T002 Add v7→v8 migration in `custom_components/rental_control/__init__.py`: import `CONF_HONOR_EVENT_TIMES` from `.const`, add migration block after the existing v6→v7 block (after line 237) that copies `config_entry.data`, sets `data[CONF_HONOR_EVENT_TIMES] = False`, and calls `hass.config_entries.async_update_entry()` with `version=8`
-- [X] T003 [P] Add `honor_event_times` key with label string to `config.step.user.data` and `options.step.init.data` sections in `custom_components/rental_control/strings.json` — use label: "Honor calendar event times from PMS instead of stored override times"
-- [X] T004 [P] Add `honor_event_times` key with identical English label to `config.step.user.data` and `options.step.init.data` sections in `custom_components/rental_control/translations/en.json`
-- [X] T005 [P] Add `honor_event_times` key with French translation to `config.step.user.data` and `options.step.init.data` sections in `custom_components/rental_control/translations/fr.json` — use label: "Utiliser les heures des événements du calendrier PMS au lieu des heures de remplacement enregistrées"
-
-**Checkpoint**: Migration and translation strings complete — config entries will have the new key on load
+- [X] T001 Create `custom_components/rental_control/description_parser.py` with SPDX license header (`Apache-2.0`), `"""Parse check-in/check-out times from iCal event descriptions."""` module docstring, `from __future__ import annotations` import, `import re` and `from datetime import time` imports, and the two compiled regex constants `_CHECKIN_PATTERN` and `_CHECKOUT_PATTERN` per data-model.md patterns (no functions yet)
 
 ---
 
-## Phase 3: User Story 2 — New Configuration Option in Options Flow (Priority: P1)
+## Phase 2: Foundational (Internal Helper)
 
-**Goal**: Add the "Honor event times" boolean toggle to the integration's options flow so users can enable/disable the feature. This is implemented first because US1 (time resolution) depends on the config option being available.
+**Purpose**: Implement the shared `_parse_time_match` helper that ALL user stories depend on for time conversion
 
-**Independent Test**: Open the integration's options flow, verify the toggle appears, toggle it on/off, save, reload, and confirm the setting persists.
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete — all extraction functions depend on this helper
 
-### Tests for User Story 2
+- [X] T002 Implement `_parse_time_match(hour_str: str, minute_str: str | None, ampm: str | None) -> time | None` in `custom_components/rental_control/description_parser.py`: convert regex capture groups to a validated `datetime.time` object following the 12-hour conversion table and validation rules from data-model.md (reject hour > 23 without AM/PM, reject hour < 1 or > 12 with AM/PM, reject minute > 59, handle 12 AM → 0 and 12 PM → 12)
 
-> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
-
-- [X] T006 [P] [US2] Add test in `tests/unit/test_config_flow.py` that verifies `VERSION` is 8 on `RentalControlFlowHandler`
-- [X] T007 [P] [US2] Add test in `tests/unit/test_config_flow.py` that verifies `honor_event_times` toggle appears in the options flow schema and defaults to `False`
-- [X] T008 [P] [US2] Add test in `tests/unit/test_config_flow.py` that verifies toggling `honor_event_times` to `True` in the options flow persists the value in `config_entry.data` after `update_listener` runs
-- [X] T009 [P] [US2] Add test in `tests/unit/test_init.py` that verifies v7→v8 migration sets `honor_event_times` to `False` for an existing config entry that lacks the key
-
-### Implementation for User Story 2
-
-- [X] T010 [US2] Add `honor_event_times` toggle to config flow schema in `custom_components/rental_control/config_flow.py`: import `CONF_HONOR_EVENT_TIMES` and `DEFAULT_HONOR_EVENT_TIMES` from `.const`, add `CONF_HONOR_EVENT_TIMES: DEFAULT_HONOR_EVENT_TIMES` to `DEFAULTS` dict (after `CONF_SHOULD_UPDATE_CODE` entry around line 77), add `vol.Optional(CONF_HONOR_EVENT_TIMES, default=_get_default(CONF_HONOR_EVENT_TIMES, DEFAULT_HONOR_EVENT_TIMES)): cv.boolean` to `_get_schema()` after the `CONF_SHOULD_UPDATE_CODE` entry (after line 287), and bump `VERSION` from 7 to 8
-- [X] T011 [US2] Verify all US2 tests pass — run `uv run pytest tests/unit/test_config_flow.py tests/unit/test_init.py -v -k "honor"` from worktree root
-
-**Checkpoint**: At this point, the "Honor event times" toggle is visible in the UI, persists across reloads, and migration handles existing entries. User Story 2 is fully functional and testable independently.
+**Checkpoint**: Foundation ready — the time conversion helper is available for all extraction functions
 
 ---
 
-## Phase 4: User Story 1 — PMS Time Changes Flow Through to Lock Codes (Priority: P1) 🎯 MVP
+## Phase 3: User Story 1 — Extract Times from All-Day Event Descriptions (Priority: P1) 🎯 MVP
 
-**Goal**: When "Honor event times" is enabled, calendar-provided check-in/check-out times take precedence over stored override times for events with explicit times, causing PMS time changes to propagate to Keymaster via the existing time-update pipeline.
+**Goal**: Parse check-in/check-out times from all-day event descriptions (e.g., "Checkin time: 16\nCheckout time: 11") and use them to set the calendar entity's start/end times when `honor_event_times` is enabled.
 
-**Independent Test**: Enable "Honor event times," create a test calendar with a timed reservation, assign it to a Keymaster slot, change the reservation's start time, trigger a refresh, and verify the override times are updated and a time-update event fires.
+**Independent Test**: Create a calendar with an all-day event containing "Checkin time: 16\nCheckout time: 11" in the description, enable `honor_event_times`, and verify the resulting calendar entity shows 16:00 start and 11:00 end times.
 
 ### Tests for User Story 1
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [X] T012 [P] [US1] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event has explicit times and override exists, `_ical_parser` builds `CalendarEvent` with calendar times (not override times)
-- [X] T013 [P] [US1] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=False` and override exists, `_ical_parser` builds `CalendarEvent` with override times (current behavior preserved — FR-005)
-- [X] T014 [P] [US1] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event has explicit times and no override exists, `_ical_parser` builds `CalendarEvent` with calendar times
-- [X] T015 [P] [US1] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and calendar times match stored override times, no unnecessary time-update event fires (FR-007)
+- [X] T003 [P] [US1] Add test in `tests/unit/test_description_parser.py` that verifies `extract_checkin_time("Checkin time: 16\nCheckout time: 11")` returns `time(16, 0)`
+- [X] T004 [P] [US1] Add test in `tests/unit/test_description_parser.py` that verifies `extract_checkout_time("Checkin time: 16\nCheckout time: 11")` returns `time(11, 0)`
+- [X] T005 [P] [US1] Add test in `tests/unit/test_description_parser.py` that verifies `extract_checkin_time("Check-in time: 16:30")` returns `time(16, 30)`
+- [X] T006 [P] [US1] Add test in `tests/unit/test_description_parser.py` that verifies `extract_checkout_time("Check-out time: 11:30")` returns `time(11, 30)`
+- [X] T007 [P] [US1] Add test in `tests/unit/test_description_parser.py` that verifies `extract_checkin_time("Check-in: 4 PM")` returns `time(16, 0)` and `extract_checkout_time("Checkout: 11 AM")` returns `time(11, 0)`
+- [X] T008 [P] [US1] Add integration test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event is all-day with "Checkin time: 16\nCheckout time: 11" in DESCRIPTION, `_ical_parser` builds `CalendarEvent` with start time 16:00 and end time 11:00
 
 ### Implementation for User Story 1
 
-- [X] T016 [US1] Read and store `honor_event_times` config in `custom_components/rental_control/coordinator.py`: import `CONF_HONOR_EVENT_TIMES` from `.const`, add `self.honor_event_times: bool = bool(config.get(CONF_HONOR_EVENT_TIMES))` in `__init__()` (after line 115 near the existing `self.should_update_code` assignment), and add `self.honor_event_times = bool(config.get(CONF_HONOR_EVENT_TIMES))` in `update_config()` (after line 518 near the existing `self.should_update_code` assignment)
-- [X] T017 [US1] Modify time resolution logic in `custom_components/rental_control/coordinator.py` `_ical_parser()` method (lines 607–631): replace the current override-first / try-except block with the new three-way branching: (1) if `self.honor_event_times` and `isinstance(event["DTSTART"].dt, datetime)` → use calendar times, (2) elif override exists → use override times, (3) else try calendar `.time()` with `AttributeError` fallback to defaults
-- [X] T018 [US1] Verify all US1 tests pass — run `uv run pytest tests/unit/test_coordinator.py -v -k "honor"` from worktree root
+- [X] T009 [US1] Implement `extract_checkin_time(description: str) -> time | None` in `custom_components/rental_control/description_parser.py`: use `_CHECKIN_PATTERN.search(description)` and pass match groups to `_parse_time_match()`; return None if no match
+- [X] T010 [US1] Implement `extract_checkout_time(description: str) -> time | None` in `custom_components/rental_control/description_parser.py`: use `_CHECKOUT_PATTERN.search(description)` and pass match groups to `_parse_time_match()`; return None if no match
+- [X] T011 [US1] Integrate description parser into coordinator time resolution in `custom_components/rental_control/coordinator.py`: import `extract_checkin_time` and `extract_checkout_time` from `.description_parser`, add new `elif self.honor_event_times and not has_explicit_times:` branch after line 624 (after the existing `has_explicit_times` block) that extracts description from `str(event.get("DESCRIPTION", ""))`, calls both extraction functions, and resolves checkin/checkout per the partial extraction logic in data-model.md (use extracted value if not None, otherwise fall through to override or default)
+- [X] T012 [US1] Verify all US1 tests pass — run `uv run pytest tests/unit/test_description_parser.py tests/unit/test_coordinator.py -v -k "checkin_time or checkout_time or description"` from repository root
 
-**Checkpoint**: At this point, PMS time changes flow through to Keymaster when "Honor event times" is enabled. The core feature is complete. User Stories 1 AND 2 are both independently functional.
+**Checkpoint**: At this point, User Story 1 is fully functional — all-day events with description times produce correct calendar entity times.
 
 ---
 
-## Phase 5: User Story 3 — All-Day Events Fall Back to Default Times (Priority: P2)
+## Phase 4: User Story 2 — Preserve Existing Time Resolution Priority (Priority: P1)
 
-**Goal**: When "Honor event times" is enabled, all-day events (no explicit times) correctly fall back to stored override times or configured defaults — no regression from the current behavior.
+**Goal**: Ensure the new description parsing does NOT interfere with existing behavior: timed events still use explicit times, overrides still take precedence when `honor_event_times` is disabled, and the feature is entirely gated by the toggle.
 
-**Independent Test**: Enable "Honor event times," create an all-day calendar event, verify it uses configured default check-in/check-out times. Then assign it to a slot with override times and verify it uses override times.
+**Independent Test**: Verify that timed events (with datetime DTSTART/DTEND) still use their explicit times regardless of description content, and that `honor_event_times=False` completely skips description parsing.
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T013 [P] [US2] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event has explicit datetime DTSTART/DTEND AND description contains "Checkin time: 9\nCheckout time: 18", `_ical_parser` uses the explicit event times (not description times) — validates FR-009 Priority 1 > Priority 2
+- [X] T014 [P] [US2] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=False` and event is all-day with description times, `_ical_parser` uses configured defaults (description parsing is skipped entirely per FR-012)
+- [X] T015 [P] [US2] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event is all-day with description times AND an override exists, `_ical_parser` uses description-extracted times (Priority 2 beats Priority 3 override)
+
+### Implementation for User Story 2
+
+> **NOTE**: The time resolution logic implemented in T011 already handles these priority cases via the branching structure. These tests validate that the existing implementation correctly preserves priorities — no additional source code changes should be needed.
+
+- [X] T016 [US2] Verify all US2 tests pass — run `uv run pytest tests/unit/test_coordinator.py -v -k "priority or preserve or honor_false"` from repository root
+- [X] T017 [US2] If any US2 test fails, fix the time resolution branching in `custom_components/rental_control/coordinator.py` `_ical_parser()` to ensure: (a) explicit datetime events always use event times when honor=True, (b) description times are never parsed when honor=False, (c) description times beat overrides for all-day events when honor=True
+
+**Checkpoint**: At this point, User Stories 1 AND 2 are both independently functional. Existing behavior is confirmed preserved.
+
+---
+
+## Phase 5: User Story 3 — Graceful Handling of Missing or Partial Description Times (Priority: P2)
+
+**Goal**: When description times are absent or only partially present, the system gracefully falls through to defaults without errors.
+
+**Independent Test**: Process events with no description, empty description, only check-in time in description, or only check-out time — all should produce valid calendar entities without errors.
 
 ### Tests for User Story 3
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [X] T019 [P] [US3] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event is all-day (date-only DTSTART) and no override exists, `_ical_parser` uses configured default checkin/checkout times
-- [X] T020 [P] [US3] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event is all-day and override exists, `_ical_parser` uses override times (not defaults)
-- [X] T021 [P] [US3] Add test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=False` and event is all-day and no override exists, `_ical_parser` uses configured default times (existing behavior)
+- [X] T018 [P] [US3] Add test in `tests/unit/test_description_parser.py` that verifies `extract_checkin_time("")` returns `None` and `extract_checkout_time("")` returns `None`
+- [X] T019 [P] [US3] Add test in `tests/unit/test_description_parser.py` that verifies `extract_checkin_time("Guest phone: +1234567890\nNotes: no times here")` returns `None`
+- [X] T020 [P] [US3] Add test in `tests/unit/test_description_parser.py` that verifies partial extraction: `extract_checkin_time("Checkin time: 16\nGuest: John")` returns `time(16, 0)` and `extract_checkout_time("Checkin time: 16\nGuest: John")` returns `None`
+- [X] T021 [P] [US3] Add test in `tests/unit/test_description_parser.py` that verifies partial extraction: `extract_checkout_time("Checkout time: 11\nGuest: Jane")` returns `time(11, 0)` and `extract_checkin_time("Checkout time: 11\nGuest: Jane")` returns `None`
+- [X] T022 [P] [US3] Add integration test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event is all-day with only "Checkin time: 14" in description (no checkout), `_ical_parser` uses extracted check-in time (14:00) and configured default checkout time
+- [X] T023 [P] [US3] Add integration test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event is all-day with only "Checkout time: 10" in description (no checkin), `_ical_parser` uses configured default checkin time and extracted checkout time (10:00)
+- [X] T024 [P] [US3] Add integration test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and event is all-day with no description times and no override, `_ical_parser` uses configured default checkin/checkout times
 
 ### Implementation for User Story 3
 
-> **NOTE**: The time resolution logic implemented in T017 already handles all-day event fallback via the three-way branching. These tests validate that the existing implementation is correct for all-day edge cases — no additional source code changes should be needed.
+> **NOTE**: The parser functions already return `None` for missing patterns (T009, T010), and the coordinator integration (T011) already handles partial extraction with fallthrough. These tests validate the existing implementation.
 
-- [X] T022 [US3] Verify all US3 tests pass — run `uv run pytest tests/unit/test_coordinator.py -v -k "all_day or allday"` from worktree root
-- [X] T023 [US3] If any US3 test fails, fix the time resolution logic in `custom_components/rental_control/coordinator.py` `_ical_parser()` to ensure all-day events (where `isinstance(event["DTSTART"].dt, datetime)` is `False`) always fall through to the override or default branches
+- [X] T025 [US3] Verify all US3 tests pass — run `uv run pytest tests/unit/test_description_parser.py tests/unit/test_coordinator.py -v -k "partial or missing or empty or none"` from repository root
+- [X] T026 [US3] If any US3 test fails, fix either the parser in `custom_components/rental_control/description_parser.py` (ensure None is returned for no-match) or the coordinator fallthrough logic in `custom_components/rental_control/coordinator.py` (ensure None values fall through to override/default per data-model.md)
 
-**Checkpoint**: All user stories are now independently functional. All-day events confirmed to work correctly with honor_event_times enabled/disabled.
+**Checkpoint**: Partial and missing description times handled gracefully. All user stories 1-3 are independently functional.
 
 ---
 
-## Phase 6: Polish & Cross-Cutting Concerns
+## Phase 6: User Story 4 — Support Multiple Time Formats (Priority: P2)
+
+**Goal**: Parser recognizes integer hours, HH:MM format, and 12-hour AM/PM format including edge cases (12 AM = midnight, 12 PM = noon).
+
+**Independent Test**: Create events with various time formats ("16", "16:30", "4 PM", "12 AM", "12 PM") in descriptions and verify correct extraction for each.
+
+### Tests for User Story 4
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T027 [P] [US4] Add test in `tests/unit/test_description_parser.py` that verifies integer hour parsing: `extract_checkin_time("Checkin time: 0")` returns `time(0, 0)`, `extract_checkin_time("Checkin time: 23")` returns `time(23, 0)`
+- [X] T028 [P] [US4] Add test in `tests/unit/test_description_parser.py` that verifies HH:MM parsing: `extract_checkin_time("Checkin time: 16:30")` returns `time(16, 30)`, `extract_checkout_time("Checkout time: 00:00")` returns `time(0, 0)`, `extract_checkout_time("Checkout time: 23:59")` returns `time(23, 59)`
+- [X] T029 [P] [US4] Add test in `tests/unit/test_description_parser.py` that verifies 12-hour AM/PM: `extract_checkin_time("Checkin time: 4 PM")` returns `time(16, 0)`, `extract_checkout_time("Checkout time: 11 AM")` returns `time(11, 0)`
+- [X] T030 [P] [US4] Add test in `tests/unit/test_description_parser.py` that verifies 12-hour edge cases: `extract_checkin_time("Checkin time: 12 AM")` returns `time(0, 0)`, `extract_checkin_time("Checkin time: 12 PM")` returns `time(12, 0)`
+- [X] T031 [P] [US4] Add test in `tests/unit/test_description_parser.py` that verifies invalid values return None: `extract_checkin_time("Checkin time: 25")` returns `None`, `extract_checkin_time("Checkin time: 16:75")` returns `None`, `extract_checkin_time("Checkin time: 13 AM")` returns `None`, `extract_checkin_time("Checkin time: 0 PM")` returns `None`
+- [X] T032 [P] [US4] Add test in `tests/unit/test_description_parser.py` that verifies case-insensitivity: `extract_checkin_time("CHECKIN TIME: 14")` returns `time(14, 0)`, `extract_checkout_time("CHECKOUT: 11")` returns `time(11, 0)`
+- [X] T033 [P] [US4] Add test in `tests/unit/test_description_parser.py` that verifies all label variants: "Checkin time:", "Check-in time:", "Check-in:", "Checkout time:", "Check-out time:", "Check-out:", "Checkout:" all produce correct results
+- [X] T034 [P] [US4] Add test in `tests/unit/test_description_parser.py` that verifies first-match-wins: `extract_checkin_time("Checkin time: 14\nCheckin time: 16")` returns `time(14, 0)` (first match used)
+
+### Implementation for User Story 4
+
+> **NOTE**: The regex patterns (_CHECKIN_PATTERN, _CHECKOUT_PATTERN) and `_parse_time_match()` helper implemented in T001 and T002 already handle all these formats. These tests validate comprehensive format coverage.
+
+- [X] T035 [US4] Verify all US4 tests pass — run `uv run pytest tests/unit/test_description_parser.py -v` from repository root
+- [X] T036 [US4] If any US4 test fails, fix the regex patterns or `_parse_time_match()` logic in `custom_components/rental_control/description_parser.py` to handle the failing format case per data-model.md validation rules and 12-hour conversion table
+
+**Checkpoint**: All time formats fully supported. All four user stories are independently functional.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
 
 **Purpose**: Full test suite validation, edge cases, and pre-commit compliance
 
-- [X] T024 [P] Add edge case test in `tests/unit/test_coordinator.py` that verifies transitioning an event from explicit times to all-day (between refreshes) with `honor_event_times=True` falls back to defaults gracefully
-- [X] T025 [P] Add edge case test in `tests/unit/test_coordinator.py` that verifies enabling `honor_event_times` mid-session (via `update_config`) causes the next refresh to use calendar times for timed events with existing overrides
-- [X] T026 Run full test suite from worktree root: `uv run pytest tests/ -v --cov=custom_components/rental_control --cov-report=term-missing` — verify no regressions across all existing tests
-- [X] T027 Run pre-commit hooks from worktree root: `pre-commit run --all-files` — verify ruff, mypy, interrogate (100% docstring coverage), reuse (SPDX headers), and gitlint all pass
-- [X] T028 Validate quickstart.md test commands work: run `uv run pytest tests/unit/test_coordinator.py -v -k "honor"` and `uv run pytest tests/unit/test_config_flow.py -v -k "honor"` from worktree root
+- [X] T037 [P] Add edge case test in `tests/unit/test_coordinator.py` that verifies when event DESCRIPTION is `None` (no DESCRIPTION field in iCal), coordinator handles gracefully without error (the `str(event.get("DESCRIPTION", ""))` pattern produces empty string)
+- [X] T038 [P] Add edge case test in `tests/unit/test_coordinator.py` that verifies when event transitions from timed to all-day between refreshes with `honor_event_times=True`, the description parser is correctly invoked on the now all-day event
+- [X] T039 [P] Add edge case test in `tests/unit/test_coordinator.py` that verifies when `honor_event_times=True` and all-day event has description times AND override exists, the description times win (Priority 2 > Priority 3) and the override is updated via the existing time-update pipeline
+- [X] T040 Run full test suite: `uv run pytest tests/ -v --cov=custom_components/rental_control --cov-report=term-missing` — verify no regressions across all existing tests and coverage meets requirements
+- [X] T041 Run pre-commit hooks: `pre-commit run --all-files` — verify ruff, mypy, interrogate (100% docstring coverage on new module), reuse (SPDX headers), and all other hooks pass
+- [X] T042 Validate quickstart.md test commands work: run `uv run pytest tests/unit/test_description_parser.py -v` and `uv run pytest tests/unit/test_coordinator.py -v -k "description or honor"` from repository root
 
 ---
 
@@ -140,75 +177,96 @@ SPDX-License-Identifier: Apache-2.0
 ### Phase Dependencies
 
 - **Setup (Phase 1)**: No dependencies — can start immediately
-- **Foundational (Phase 2)**: Depends on Phase 1 (constants must exist) — BLOCKS all user stories
-- **User Story 2 (Phase 3)**: Depends on Phase 2 — config flow needs migration + strings
-- **User Story 1 (Phase 4)**: Depends on Phase 3 — coordinator needs the config option to be in config_entry.data
-- **User Story 3 (Phase 5)**: Depends on Phase 4 — tests validate the same logic implemented in T017
-- **Polish (Phase 6)**: Depends on all user stories being complete
+- **Foundational (Phase 2)**: Depends on Phase 1 (module must exist with regex constants) — BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Phase 2 — extraction functions use the helper
+- **User Story 2 (Phase 4)**: Depends on Phase 3 — validates that US1 implementation preserves existing priorities
+- **User Story 3 (Phase 5)**: Depends on Phase 3 — validates partial extraction behavior of US1 implementation
+- **User Story 4 (Phase 6)**: Depends on Phase 2 — validates format handling in the foundational helper
+- **Polish (Phase 7)**: Depends on all user stories being complete
 
 ### User Story Dependencies
 
-- **User Story 2 (P1 — config)**: Can start after Foundational (Phase 2). No dependencies on other stories. Implemented first because it provides the config plumbing.
-- **User Story 1 (P1 — core logic)**: Depends on US2 completion — the coordinator reads `honor_event_times` from config, which must be in the schema and migrated first.
-- **User Story 3 (P2 — all-day fallback)**: Depends on US1 — validates that the time resolution logic from T017 correctly handles all-day events. No new source code expected.
+- **User Story 1 (P1 — core extraction)**: Can start after Foundational (Phase 2). This is the MVP — all other stories validate aspects of US1's implementation.
+- **User Story 2 (P1 — preserve priority)**: Can start after US1 (Phase 3). Tests validate US1's coordinator integration preserves existing priority chain.
+- **User Story 3 (P2 — partial/missing)**: Can start after US1 (Phase 3). Tests validate US1's None-handling and fallthrough behavior.
+- **User Story 4 (P2 — format support)**: Can start after Foundational (Phase 2). Tests validate the regex patterns and `_parse_time_match()` helper. **Can run in parallel with US2 and US3.**
 
 ### Within Each User Story
 
 - Tests MUST be written and FAIL before implementation
-- Config plumbing before core logic
+- Parser module before coordinator integration
 - Core implementation before integration validation
 - Story complete before moving to next priority
 
 ### Parallel Opportunities
 
-- **Phase 2**: T003, T004, T005 (translation files) can all run in parallel
-- **Phase 3**: T006, T007, T008, T009 (US2 tests) can all run in parallel
-- **Phase 4**: T012, T013, T014, T015 (US1 tests) can all run in parallel
-- **Phase 5**: T019, T020, T021 (US3 tests) can all run in parallel
-- **Phase 6**: T024, T025 (edge case tests) can run in parallel
+- **Phase 3**: T003–T008 (US1 tests) can all run in parallel — all are independent test functions
+- **Phase 4**: T013, T014, T015 (US2 tests) can all run in parallel
+- **Phase 5**: T018–T024 (US3 tests) can all run in parallel
+- **Phase 6**: T027–T034 (US4 tests) can all run in parallel
+- **Phase 7**: T037, T038, T039 (edge case tests) can run in parallel
+- **Cross-phase**: Phase 5 (US3) and Phase 6 (US4) can execute in parallel once Phase 3 (US1) is complete
 
 ---
 
-## Parallel Example: User Story 1 Tests
+## Parallel Example: User Story 1
 
 ```bash
-# Launch all US1 test tasks together (all write to different test functions in the same file):
-Task T012: "Test honor=True + timed event + override → calendar times"
-Task T013: "Test honor=False + override → override times (FR-005)"
-Task T014: "Test honor=True + timed event + no override → calendar times"
-Task T015: "Test honor=True + times match → no update event (FR-007)"
+# Launch all US1 unit tests together (all write to independent test functions):
+Task T003: "Test extract_checkin_time returns time(16, 0) for 'Checkin time: 16'"
+Task T004: "Test extract_checkout_time returns time(11, 0) for 'Checkout time: 11'"
+Task T005: "Test extract_checkin_time returns time(16, 30) for HH:MM format"
+Task T006: "Test extract_checkout_time returns time(11, 30) for HH:MM format"
+Task T007: "Test 12-hour AM/PM format extraction"
+Task T008: "Integration test: coordinator uses description times for all-day event"
+
+# After tests exist and fail, launch implementation (sequential within story):
+Task T009: "Implement extract_checkin_time"
+Task T010: "Implement extract_checkout_time"
+Task T011: "Integrate into coordinator"
+```
+
+---
+
+## Parallel Example: US3 + US4 After US1
+
+```bash
+# Once US1 (Phase 3) is complete, US3 and US4 tests can launch in parallel:
+
+# US3 tests (partial/missing handling):
+Task T018–T024: All partial extraction tests
+
+# US4 tests (format coverage) — runs in parallel with US3:
+Task T027–T034: All format validation tests
 ```
 
 ---
 
 ## Implementation Strategy
 
-### MVP First (User Stories 1 + 2)
+### MVP First (User Story 1 Only)
 
-1. Complete Phase 1: Setup (T001 — single constant addition)
-2. Complete Phase 2: Foundational (T002–T005 — migration + strings)
-3. Complete Phase 3: User Story 2 (T006–T011 — config toggle)
-4. Complete Phase 4: User Story 1 (T012–T018 — core time resolution)
-5. **STOP and VALIDATE**: Test US1 + US2 independently
-6. This delivers the full core feature — PMS times flow through when enabled
+1. Complete Phase 1: Setup (T001 — module scaffold)
+2. Complete Phase 2: Foundational (T002 — `_parse_time_match` helper)
+3. Complete Phase 3: User Story 1 (T003–T012 — core extraction + coordinator integration)
+4. **STOP and VALIDATE**: Test US1 independently — all-day events with description times produce correct calendar entity times
+5. This delivers the core value: Hostaway-style calendars work without manual overrides
 
 ### Incremental Delivery
 
-1. Setup + Foundational → Config infrastructure ready
-2. Add User Story 2 → Config toggle available in UI → Validate independently
-3. Add User Story 1 → Core feature works → Validate independently (MVP!)
-4. Add User Story 3 → All-day event behavior confirmed → Validate independently
+1. Setup + Foundational → Parser module scaffold ready
+2. Add User Story 1 → Core extraction works → Validate independently (MVP!)
+3. Add User Story 2 → Existing behavior confirmed preserved → Validate independently
+4. Add User Stories 3 + 4 (parallel) → Edge cases + format coverage confirmed → Validate independently
 5. Polish → Full test suite passes, pre-commit clean
 
 ### Atomic Commit Strategy (from quickstart.md)
 
 Each phase maps to one atomic commit:
-1. `const.py` — Add constants
-2. `config_flow.py` — Add toggle + bump VERSION
-3. `__init__.py` — Add v7→v8 migration
-4. `coordinator.py` — Read config + modify time resolution
-5. `strings.json` + `translations/` — Add UI strings
-6. `tests/` — Add all tests
+1. `Feat: Add description parser for event time extraction` — T001, T002, T009, T010
+2. `Test: Add unit tests for description time parser` — T003–T007, T018–T021, T027–T034
+3. `Feat: Integrate description time extraction into time resolution` — T011
+4. `Test: Add coordinator integration tests for description extraction` — T008, T013–T015, T022–T024, T037–T039
 
 ---
 
@@ -216,7 +274,8 @@ Each phase maps to one atomic commit:
 
 - [P] tasks = different files or independent test functions, no dependencies
 - [Story] label maps task to specific user story for traceability
-- US2 (config) is implemented before US1 (logic) despite both being P1, because US1 depends on the config plumbing from US2
-- US3 tests validate the same code path implemented in US1's T017 — no new source code is expected for US3
-- The downstream time-update pipeline (event_overrides.py → calsensor.py → util.py) is UNCHANGED per research.md findings
-- All file paths are relative to worktree root: `/home/tykeal/repos/personal/homeassistant/worktrees/007-honor-pms-times/`
+- This feature builds on the already-completed `honor_event_times` config toggle (previous tasks.md, all marked [X])
+- The `description_parser.py` module is independently testable without HA mocking (pure functions)
+- The coordinator integration modifies existing time resolution branching (lines 621–646 of coordinator.py)
+- All downstream pipeline code (event_overrides.py, calsensor.py, util.py) is UNCHANGED per research.md
+- All file paths are relative to repository root: `/home/tykeal/repos/personal/homeassistant/rental-control/`

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -2917,3 +2917,858 @@ END:VCALENDAR
         # Now enabled
         assert coordinator.honor_event_times is True
         assert coordinator.async_request_refresh.called
+
+
+# ---------------------------------------------------------------------------
+# Description-based time extraction integration tests (spec 007)
+# ---------------------------------------------------------------------------
+
+
+class TestHonorEventTimesDescriptionExtraction:
+    """Integration tests for description-based time extraction."""
+
+    async def test_honor_true_allday_description_times_no_override(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T008/T013: honor=True + all-day + description times → extracted.
+
+        When honor_event_times is True and the event is all-day with
+        check-in/out times in the description and no override, the
+        description times are used.
+        """
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+        future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+
+        allday_ics = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:{future_start}
+DTEND;VALUE=DATE:{future_end}
+UID:desc-test-1@example.com
+SUMMARY:Reserved: Desc Guest
+DESCRIPTION:Check-in time: 15\\nCheck-out time: 10\\nEmail: test@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Desc Test",
+            version=8,
+            unique_id="desc-test-1",
+            data={
+                "name": "Desc Test",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+            },
+            entry_id="desc_test_1",
+        )
+        entry.add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=allday_ics,
+            )
+
+            coordinator = RentalControlCoordinator(hass, entry)
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        event = result[0]
+        from datetime import time as time_cls
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        # Description times: 15:00 checkin, 10:00 checkout
+        expected_start = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 25).date(),
+                time_cls(15, 0),
+                tz,
+            )
+        )
+        expected_end = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 30).date(),
+                time_cls(10, 0),
+                tz,
+            )
+        )
+        assert event.start == expected_start
+        assert event.end == expected_end
+
+    async def test_honor_true_allday_description_checkin_only_no_override(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T014: honor=True + all-day + only checkin in description.
+
+        When only check-in time is in the description, check-out
+        falls back to configured default.
+        """
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+        future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+
+        allday_ics = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:{future_start}
+DTEND;VALUE=DATE:{future_end}
+UID:desc-test-2@example.com
+SUMMARY:Reserved: Desc Guest
+DESCRIPTION:Check-in time: 15\\nEmail: test@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Desc Test",
+            version=8,
+            unique_id="desc-test-2",
+            data={
+                "name": "Desc Test",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+            },
+            entry_id="desc_test_2",
+        )
+        entry.add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=allday_ics,
+            )
+
+            coordinator = RentalControlCoordinator(hass, entry)
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        event = result[0]
+        from datetime import time as time_cls
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        # Description checkin: 15:00, checkout falls back to default 11:00
+        expected_start = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 25).date(),
+                time_cls(15, 0),
+                tz,
+            )
+        )
+        expected_end = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 30).date(),
+                time_cls(11, 0),
+                tz,
+            )
+        )
+        assert event.start == expected_start
+        assert event.end == expected_end
+
+    async def test_honor_true_allday_no_description_times_no_override(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T015: honor=True + all-day + no desc times + no override.
+
+        Falls back to configured default checkin/checkout times.
+        """
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+        future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+
+        allday_ics = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:{future_start}
+DTEND;VALUE=DATE:{future_end}
+UID:desc-test-3@example.com
+SUMMARY:Reserved: Desc Guest
+DESCRIPTION:Email: test@example.com\\nNo times here
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Desc Test",
+            version=8,
+            unique_id="desc-test-3",
+            data={
+                "name": "Desc Test",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+            },
+            entry_id="desc_test_3",
+        )
+        entry.add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=allday_ics,
+            )
+
+            coordinator = RentalControlCoordinator(hass, entry)
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        event = result[0]
+        from datetime import time as time_cls
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        # No description times, falls back to defaults: 16:00 / 11:00
+        expected_start = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 25).date(),
+                time_cls(16, 0),
+                tz,
+            )
+        )
+        expected_end = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 30).date(),
+                time_cls(11, 0),
+                tz,
+            )
+        )
+        assert event.start == expected_start
+        assert event.end == expected_end
+
+    async def test_honor_true_allday_description_times_with_override(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T022: honor=True + all-day + desc times + override.
+
+        Description times take priority over override times.
+        """
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+        future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+
+        allday_ics = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:{future_start}
+DTEND;VALUE=DATE:{future_end}
+UID:desc-test-4@example.com
+SUMMARY:Reserved: Desc Guest
+DESCRIPTION:Check-in time: 15\\nCheck-out time: 10\\nEmail: test@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Desc Test",
+            version=8,
+            unique_id="desc-test-4",
+            data={
+                "name": "Desc Test",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+                CONF_LOCK_ENTRY: "front_door",
+            },
+            entry_id="desc_test_4",
+        )
+        entry.add_to_hass(hass)
+
+        km_entry = MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": "front_door"},
+            entry_id="km_desc_4",
+        )
+        km_entry.add_to_hass(hass)
+
+        override_start_utc = datetime(2024, 12, 25, 21, 0, 0, tzinfo=dt_util.UTC)
+        override_end_utc = datetime(2024, 12, 30, 14, 0, 0, tzinfo=dt_util.UTC)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=allday_ics,
+            )
+
+            coordinator = RentalControlCoordinator(hass, entry)
+
+            from custom_components.rental_control.event_overrides import EventOverrides
+
+            coordinator.event_overrides = EventOverrides(10, 3)
+            coordinator.event_overrides._overrides[10] = {
+                "slot_name": "Reserved: Desc Guest",
+                "slot_code": "1234",
+                "start_time": override_start_utc,
+                "end_time": override_end_utc,
+            }
+            coordinator.event_overrides.async_check_overrides = AsyncMock()  # type: ignore[method-assign]
+
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        event = result[0]
+        from datetime import time as time_cls
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        # Description times: 15:00 checkin, 10:00 checkout (override ignored)
+        expected_start = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 25).date(),
+                time_cls(15, 0),
+                tz,
+            )
+        )
+        expected_end = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 30).date(),
+                time_cls(10, 0),
+                tz,
+            )
+        )
+        assert event.start == expected_start
+        assert event.end == expected_end
+
+    async def test_honor_true_allday_partial_desc_with_override_fallback(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T023: honor=True + all-day + partial desc + override fallback.
+
+        When only check-in is in the description, check-out falls
+        back to override time (not default).
+        """
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+        future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+
+        allday_ics = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:{future_start}
+DTEND;VALUE=DATE:{future_end}
+UID:desc-test-5@example.com
+SUMMARY:Reserved: Desc Guest
+DESCRIPTION:Check-in time: 15\\nEmail: test@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Desc Test",
+            version=8,
+            unique_id="desc-test-5",
+            data={
+                "name": "Desc Test",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+                CONF_LOCK_ENTRY: "front_door",
+            },
+            entry_id="desc_test_5",
+        )
+        entry.add_to_hass(hass)
+
+        km_entry = MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": "front_door"},
+            entry_id="km_desc_5",
+        )
+        km_entry.add_to_hass(hass)
+
+        # Override: 18:00 UTC start, 14:00 UTC end
+        # In America/New_York: 13:00 start, 09:00 end
+        override_start_utc = datetime(2024, 12, 25, 18, 0, 0, tzinfo=dt_util.UTC)
+        override_end_utc = datetime(2024, 12, 30, 14, 0, 0, tzinfo=dt_util.UTC)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=allday_ics,
+            )
+
+            coordinator = RentalControlCoordinator(hass, entry)
+
+            from custom_components.rental_control.event_overrides import EventOverrides
+
+            coordinator.event_overrides = EventOverrides(10, 3)
+            coordinator.event_overrides._overrides[10] = {
+                "slot_name": "Reserved: Desc Guest",
+                "slot_code": "1234",
+                "start_time": override_start_utc,
+                "end_time": override_end_utc,
+            }
+            coordinator.event_overrides.async_check_overrides = AsyncMock()  # type: ignore[method-assign]
+
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        event = result[0]
+        from datetime import time as time_cls
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        # Checkin from description: 15:00
+        # Checkout falls back to override: 14:00 UTC → 09:00 EST
+        override_end_local = override_end_utc.astimezone(tz)
+        expected_start = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 25).date(),
+                time_cls(15, 0),
+                tz,
+            )
+        )
+        expected_end = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 30).date(),
+                override_end_local.time(),
+                tz,
+            )
+        )
+        assert event.start == expected_start
+        assert event.end == expected_end
+
+    async def test_honor_true_allday_no_desc_times_with_override_fallback(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T024: honor=True + all-day + no desc times + override.
+
+        When no description times are found, falls back to override.
+        """
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+        future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+
+        allday_ics = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:{future_start}
+DTEND;VALUE=DATE:{future_end}
+UID:desc-test-6@example.com
+SUMMARY:Reserved: Desc Guest
+DESCRIPTION:Email: test@example.com\\nNo times here
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Desc Test",
+            version=8,
+            unique_id="desc-test-6",
+            data={
+                "name": "Desc Test",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+                CONF_LOCK_ENTRY: "front_door",
+            },
+            entry_id="desc_test_6",
+        )
+        entry.add_to_hass(hass)
+
+        km_entry = MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": "front_door"},
+            entry_id="km_desc_6",
+        )
+        km_entry.add_to_hass(hass)
+
+        # Override: 18:00 UTC start, 14:00 UTC end
+        override_start_utc = datetime(2024, 12, 25, 18, 0, 0, tzinfo=dt_util.UTC)
+        override_end_utc = datetime(2024, 12, 30, 14, 0, 0, tzinfo=dt_util.UTC)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=allday_ics,
+            )
+
+            coordinator = RentalControlCoordinator(hass, entry)
+
+            from custom_components.rental_control.event_overrides import EventOverrides
+
+            coordinator.event_overrides = EventOverrides(10, 3)
+            coordinator.event_overrides._overrides[10] = {
+                "slot_name": "Reserved: Desc Guest",
+                "slot_code": "1234",
+                "start_time": override_start_utc,
+                "end_time": override_end_utc,
+            }
+            coordinator.event_overrides.async_check_overrides = AsyncMock()  # type: ignore[method-assign]
+
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        event = result[0]
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        # No desc times → falls back to override times
+        override_start_local = override_start_utc.astimezone(tz)
+        override_end_local = override_end_utc.astimezone(tz)
+        expected_start = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 25).date(),
+                override_start_local.time(),
+                tz,
+            )
+        )
+        expected_end = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 30).date(),
+                override_end_local.time(),
+                tz,
+            )
+        )
+        assert event.start == expected_start
+        assert event.end == expected_end
+
+    async def test_honor_false_allday_description_times_ignored(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T037: honor=False + all-day + description times → ignored.
+
+        When honor_event_times is False, description times are not
+        extracted; default times are used.
+        """
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+        future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+
+        allday_ics = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:{future_start}
+DTEND;VALUE=DATE:{future_end}
+UID:desc-test-7@example.com
+SUMMARY:Reserved: Desc Guest
+DESCRIPTION:Check-in time: 15\\nCheck-out time: 10\\nEmail: test@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Desc Test",
+            version=8,
+            unique_id="desc-test-7",
+            data={
+                "name": "Desc Test",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+            },
+            entry_id="desc_test_7",
+        )
+        entry.add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=allday_ics,
+            )
+
+            coordinator = RentalControlCoordinator(hass, entry)
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        event = result[0]
+        from datetime import time as time_cls
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        # honor=False → description times ignored, uses defaults 16/11
+        expected_start = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 25).date(),
+                time_cls(16, 0),
+                tz,
+            )
+        )
+        expected_end = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 30).date(),
+                time_cls(11, 0),
+                tz,
+            )
+        )
+        assert event.start == expected_start
+        assert event.end == expected_end
+
+    async def test_honor_true_timed_event_description_times_ignored(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T038: honor=True + timed event + desc times → PMS wins.
+
+        When the event has explicit times (datetime), PMS times take
+        priority even if description also has times.
+        """
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+        future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+
+        # Timed event with 15:00 / 10:00 but description says 14/09
+        timed_ics = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART:{future_start}T150000
+DTEND:{future_end}T100000
+UID:desc-test-8@example.com
+SUMMARY:Reserved: Desc Guest
+DESCRIPTION:Check-in time: 14\\nCheck-out time: 9\\nEmail: test@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Desc Test",
+            version=8,
+            unique_id="desc-test-8",
+            data={
+                "name": "Desc Test",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+            },
+            entry_id="desc_test_8",
+        )
+        entry.add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=timed_ics,
+            )
+
+            coordinator = RentalControlCoordinator(hass, entry)
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        event = result[0]
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        # PMS/calendar times: 15:00 / 10:00 (not description 14/09)
+        expected_start = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 25).date(),
+                datetime(2024, 12, 25, 15, 0, 0).time(),
+                tz,
+            )
+        )
+        expected_end = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 30).date(),
+                datetime(2024, 12, 30, 10, 0, 0).time(),
+                tz,
+            )
+        )
+        assert event.start == expected_start
+        assert event.end == expected_end
+
+    async def test_honor_true_allday_12h_description_times(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T039: honor=True + all-day + 12h description times.
+
+        12-hour format times in descriptions are correctly parsed.
+        """
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = (frozen_time + timedelta(days=5)).strftime("%Y%m%d")
+        future_end = (frozen_time + timedelta(days=10)).strftime("%Y%m%d")
+
+        allday_ics = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:{future_start}
+DTEND;VALUE=DATE:{future_end}
+UID:desc-test-9@example.com
+SUMMARY:Reserved: Desc Guest
+DESCRIPTION:Check-in: 4 PM\\nCheck-out: 11 AM\\nEmail: test@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Desc Test",
+            version=8,
+            unique_id="desc-test-9",
+            data={
+                "name": "Desc Test",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "14:00",
+                "checkout": "10:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+            },
+            entry_id="desc_test_9",
+        )
+        entry.add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=allday_ics,
+            )
+
+            coordinator = RentalControlCoordinator(hass, entry)
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        event = result[0]
+        from datetime import time as time_cls
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        # Description: "4 PM" → 16:00, "11 AM" → 11:00
+        expected_start = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 25).date(),
+                time_cls(16, 0),
+                tz,
+            )
+        )
+        expected_end = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, 30).date(),
+                time_cls(11, 0),
+                tz,
+            )
+        )
+        assert event.start == expected_start
+        assert event.end == expected_end

--- a/tests/unit/test_description_parser.py
+++ b/tests/unit/test_description_parser.py
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: 2025 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for description_parser module."""
+
+from __future__ import annotations
+
+from datetime import time
+
+from custom_components.rental_control.description_parser import _parse_time_match
+from custom_components.rental_control.description_parser import extract_checkin_time
+from custom_components.rental_control.description_parser import extract_checkout_time
+
+# ---------------------------------------------------------------------------
+# T003-T007: _parse_time_match unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseTimeMatch:
+    """Tests for _parse_time_match internal helper."""
+
+    def test_24h_hour_only(self) -> None:
+        """T003: 24-hour format with hour only returns correct time."""
+        assert _parse_time_match("16", None, None) == time(16, 0)
+
+    def test_24h_hour_and_minutes(self) -> None:
+        """T003: 24-hour format with hour and minutes."""
+        assert _parse_time_match("16", "30", None) == time(16, 30)
+
+    def test_24h_midnight(self) -> None:
+        """T003: 24-hour format midnight."""
+        assert _parse_time_match("0", None, None) == time(0, 0)
+
+    def test_24h_hour_23(self) -> None:
+        """T003: 24-hour format hour 23."""
+        assert _parse_time_match("23", "59", None) == time(23, 59)
+
+    def test_12h_am(self) -> None:
+        """T004: 12-hour AM format."""
+        assert _parse_time_match("9", None, "AM") == time(9, 0)
+
+    def test_12h_pm(self) -> None:
+        """T004: 12-hour PM format."""
+        assert _parse_time_match("4", None, "PM") == time(16, 0)
+
+    def test_12h_pm_with_minutes(self) -> None:
+        """T004: 12-hour PM format with minutes."""
+        assert _parse_time_match("4", "30", "PM") == time(16, 30)
+
+    def test_12h_12pm_is_noon(self) -> None:
+        """T004: 12 PM is noon (12:00)."""
+        assert _parse_time_match("12", None, "PM") == time(12, 0)
+
+    def test_12h_12am_is_midnight(self) -> None:
+        """T004: 12 AM is midnight (00:00)."""
+        assert _parse_time_match("12", None, "AM") == time(0, 0)
+
+    def test_12h_am_lowercase(self) -> None:
+        """T004: Case-insensitive AM/PM."""
+        assert _parse_time_match("9", None, "am") == time(9, 0)
+
+    def test_12h_pm_lowercase(self) -> None:
+        """T004: Case-insensitive PM."""
+        assert _parse_time_match("4", None, "pm") == time(16, 0)
+
+    def test_invalid_24h_hour_24(self) -> None:
+        """T005: Hour 24 in 24h mode is invalid."""
+        assert _parse_time_match("24", None, None) is None
+
+    def test_invalid_24h_hour_25(self) -> None:
+        """T005: Hour 25 in 24h mode is invalid."""
+        assert _parse_time_match("25", None, None) is None
+
+    def test_invalid_12h_hour_0(self) -> None:
+        """T005: Hour 0 in 12h mode is invalid."""
+        assert _parse_time_match("0", None, "AM") is None
+
+    def test_invalid_12h_hour_13(self) -> None:
+        """T005: Hour 13 in 12h mode is invalid."""
+        assert _parse_time_match("13", None, "PM") is None
+
+    def test_invalid_minute_60(self) -> None:
+        """T006: Minute 60 is invalid."""
+        assert _parse_time_match("10", "60", None) is None
+
+    def test_invalid_minute_99(self) -> None:
+        """T006: Minute 99 is invalid."""
+        assert _parse_time_match("10", "99", None) is None
+
+    def test_valid_minute_00(self) -> None:
+        """T007: Minute 00 is valid."""
+        assert _parse_time_match("10", "00", None) == time(10, 0)
+
+    def test_valid_minute_59(self) -> None:
+        """T007: Minute 59 is valid."""
+        assert _parse_time_match("10", "59", None) == time(10, 59)
+
+    def test_none_minute_defaults_to_0(self) -> None:
+        """T007: None minute defaults to 0."""
+        assert _parse_time_match("10", None, None) == time(10, 0)
+
+
+# ---------------------------------------------------------------------------
+# T018-T021: extract_checkin_time pattern matching tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCheckinTime:
+    """Tests for extract_checkin_time function."""
+
+    def test_checkin_24h_no_minutes(self) -> None:
+        """T018: 'Check-in time: 16' extracts 16:00."""
+        assert extract_checkin_time("Check-in time: 16") == time(16, 0)
+
+    def test_checkin_24h_with_minutes(self) -> None:
+        """T018: 'Check-in time: 16:30' extracts 16:30."""
+        assert extract_checkin_time("Check-in time: 16:30") == time(16, 30)
+
+    def test_checkin_12h_pm(self) -> None:
+        """T018: 'Check-in: 4 PM' extracts 16:00."""
+        assert extract_checkin_time("Check-in: 4 PM") == time(16, 0)
+
+    def test_checkin_12h_am(self) -> None:
+        """T018: 'Checkin time: 9 AM' extracts 09:00."""
+        assert extract_checkin_time("Checkin time: 9 AM") == time(9, 0)
+
+    def test_checkin_no_hyphen(self) -> None:
+        """T019: 'Checkin: 16' (no hyphen) extracts 16:00."""
+        assert extract_checkin_time("Checkin: 16") == time(16, 0)
+
+    def test_checkin_with_hyphen(self) -> None:
+        """T019: 'Check-in: 16' (with hyphen) extracts 16:00."""
+        assert extract_checkin_time("Check-in: 16") == time(16, 0)
+
+    def test_checkin_case_insensitive_upper(self) -> None:
+        """T019: 'CHECK-IN TIME: 16' (uppercase) extracts 16:00."""
+        assert extract_checkin_time("CHECK-IN TIME: 16") == time(16, 0)
+
+    def test_checkin_case_insensitive_mixed(self) -> None:
+        """T019: 'ChEcK-In time: 16' (mixed case) extracts 16:00."""
+        assert extract_checkin_time("ChEcK-In time: 16") == time(16, 0)
+
+    def test_checkin_with_time_keyword(self) -> None:
+        """T019: 'Check-in time: 16' (with 'time') extracts 16:00."""
+        assert extract_checkin_time("Check-in time: 16") == time(16, 0)
+
+    def test_checkin_without_time_keyword(self) -> None:
+        """T019: 'Check-in: 16' (without 'time') extracts 16:00."""
+        assert extract_checkin_time("Check-in: 16") == time(16, 0)
+
+    def test_checkin_embedded_in_multiline(self) -> None:
+        """T020: Check-in time extracted from multiline description."""
+        desc = "Guest: John\nCheck-in time: 15\nCheckout: 11\nNotes: none"
+        assert extract_checkin_time(desc) == time(15, 0)
+
+    def test_checkin_first_match_wins(self) -> None:
+        """T020: First check-in pattern match wins."""
+        desc = "Check-in: 14\nCheck-in time: 16"
+        assert extract_checkin_time(desc) == time(14, 0)
+
+    def test_checkin_no_match_returns_none(self) -> None:
+        """T021: No check-in pattern returns None."""
+        assert extract_checkin_time("No times here") is None
+
+    def test_checkin_empty_string_returns_none(self) -> None:
+        """T021: Empty string returns None."""
+        assert extract_checkin_time("") is None
+
+    def test_checkin_invalid_time_returns_none(self) -> None:
+        """T021: Invalid time value returns None."""
+        assert extract_checkin_time("Check-in: 25") is None
+
+    def test_checkin_partial_match_wrong_keyword(self) -> None:
+        """T021: Similar but wrong keyword does not match."""
+        assert extract_checkin_time("Checking: 16") is None
+
+    def test_checkin_12h_with_minutes(self) -> None:
+        """T018: '4:30 PM' format extracts correctly."""
+        assert extract_checkin_time("Check-in: 4:30 PM") == time(16, 30)
+
+    def test_checkin_noon_pm(self) -> None:
+        """T018: 'Check-in: 12 PM' is noon."""
+        assert extract_checkin_time("Check-in: 12 PM") == time(12, 0)
+
+    def test_checkin_midnight_am(self) -> None:
+        """T018: 'Check-in: 12 AM' is midnight."""
+        assert extract_checkin_time("Check-in: 12 AM") == time(0, 0)
+
+
+# ---------------------------------------------------------------------------
+# T027-T034: extract_checkout_time pattern matching tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCheckoutTime:
+    """Tests for extract_checkout_time function."""
+
+    def test_checkout_24h_no_minutes(self) -> None:
+        """T027: 'Check-out time: 11' extracts 11:00."""
+        assert extract_checkout_time("Check-out time: 11") == time(11, 0)
+
+    def test_checkout_24h_with_minutes(self) -> None:
+        """T027: 'Check-out time: 11:30' extracts 11:30."""
+        assert extract_checkout_time("Check-out time: 11:30") == time(11, 30)
+
+    def test_checkout_12h_am(self) -> None:
+        """T027: 'Check-out: 11 AM' extracts 11:00."""
+        assert extract_checkout_time("Check-out: 11 AM") == time(11, 0)
+
+    def test_checkout_12h_pm(self) -> None:
+        """T027: 'Check-out: 2 PM' extracts 14:00."""
+        assert extract_checkout_time("Check-out: 2 PM") == time(14, 0)
+
+    def test_checkout_no_hyphen(self) -> None:
+        """T028: 'Checkout: 11' (no hyphen) extracts 11:00."""
+        assert extract_checkout_time("Checkout: 11") == time(11, 0)
+
+    def test_checkout_with_hyphen(self) -> None:
+        """T028: 'Check-out: 11' (with hyphen) extracts 11:00."""
+        assert extract_checkout_time("Check-out: 11") == time(11, 0)
+
+    def test_checkout_case_insensitive_upper(self) -> None:
+        """T028: 'CHECK-OUT TIME: 11' (uppercase) extracts 11:00."""
+        assert extract_checkout_time("CHECK-OUT TIME: 11") == time(11, 0)
+
+    def test_checkout_case_insensitive_mixed(self) -> None:
+        """T028: 'ChEcK-Out time: 11' (mixed case) extracts 11:00."""
+        assert extract_checkout_time("ChEcK-Out time: 11") == time(11, 0)
+
+    def test_checkout_with_time_keyword(self) -> None:
+        """T028: 'Check-out time: 11' (with 'time') extracts 11:00."""
+        assert extract_checkout_time("Check-out time: 11") == time(11, 0)
+
+    def test_checkout_without_time_keyword(self) -> None:
+        """T028: 'Check-out: 11' (without 'time') extracts 11:00."""
+        assert extract_checkout_time("Check-out: 11") == time(11, 0)
+
+    def test_checkout_embedded_in_multiline(self) -> None:
+        """T029: Check-out time extracted from multiline description."""
+        desc = "Guest: John\nCheck-in: 16\nCheck-out time: 10\nNotes: none"
+        assert extract_checkout_time(desc) == time(10, 0)
+
+    def test_checkout_first_match_wins(self) -> None:
+        """T029: First check-out pattern match wins."""
+        desc = "Check-out: 10\nCheck-out time: 11"
+        assert extract_checkout_time(desc) == time(10, 0)
+
+    def test_checkout_no_match_returns_none(self) -> None:
+        """T030: No check-out pattern returns None."""
+        assert extract_checkout_time("No times here") is None
+
+    def test_checkout_empty_string_returns_none(self) -> None:
+        """T030: Empty string returns None."""
+        assert extract_checkout_time("") is None
+
+    def test_checkout_invalid_time_returns_none(self) -> None:
+        """T030: Invalid time value returns None."""
+        assert extract_checkout_time("Check-out: 25") is None
+
+    def test_checkout_partial_match_wrong_keyword(self) -> None:
+        """T030: Similar but wrong keyword does not match."""
+        assert extract_checkout_time("Checking out: 11") is None
+
+    def test_checkout_12h_with_minutes(self) -> None:
+        """T027: '11:30 AM' format extracts correctly."""
+        assert extract_checkout_time("Check-out: 11:30 AM") == time(11, 30)
+
+    def test_checkout_noon_pm(self) -> None:
+        """T027: 'Check-out: 12 PM' is noon."""
+        assert extract_checkout_time("Check-out: 12 PM") == time(12, 0)
+
+    def test_checkout_midnight_am(self) -> None:
+        """T027: 'Check-out: 12 AM' is midnight."""
+        assert extract_checkout_time("Check-out: 12 AM") == time(0, 0)
+
+
+# ---------------------------------------------------------------------------
+# T031-T034: Combined extraction from same description
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedExtraction:
+    """Tests for extracting both check-in and check-out from same text."""
+
+    def test_both_times_in_description(self) -> None:
+        """T031: Both check-in and check-out extracted from one text."""
+        desc = "Check-in time: 15\nCheck-out time: 10"
+        assert extract_checkin_time(desc) == time(15, 0)
+        assert extract_checkout_time(desc) == time(10, 0)
+
+    def test_only_checkin_present(self) -> None:
+        """T032: Only check-in present, check-out is None."""
+        desc = "Check-in time: 16\nGuest: John"
+        assert extract_checkin_time(desc) == time(16, 0)
+        assert extract_checkout_time(desc) is None
+
+    def test_only_checkout_present(self) -> None:
+        """T033: Only check-out present, check-in is None."""
+        desc = "Check-out: 11\nGuest: John"
+        assert extract_checkin_time(desc) is None
+        assert extract_checkout_time(desc) == time(11, 0)
+
+    def test_neither_present(self) -> None:
+        """T034: Neither check-in nor check-out present."""
+        desc = "Guest: John\nEmail: john@example.com"
+        assert extract_checkin_time(desc) is None
+        assert extract_checkout_time(desc) is None
+
+    def test_both_with_12h_format(self) -> None:
+        """T031: Both times in 12-hour format."""
+        desc = "Check-in: 4 PM\nCheck-out: 11 AM"
+        assert extract_checkin_time(desc) == time(16, 0)
+        assert extract_checkout_time(desc) == time(11, 0)
+
+    def test_both_with_minutes(self) -> None:
+        """T031: Both times with minutes."""
+        desc = "Check-in time: 15:30\nCheck-out time: 10:45"
+        assert extract_checkin_time(desc) == time(15, 30)
+        assert extract_checkout_time(desc) == time(10, 45)

--- a/tests/unit/test_description_parser.py
+++ b/tests/unit/test_description_parser.py
@@ -20,83 +20,83 @@ class TestParseTimeMatch:
 
     def test_24h_hour_only(self) -> None:
         """T003: 24-hour format with hour only returns correct time."""
-        assert _parse_time_match("16", None, None) == time(16, 0)
+        assert _parse_time_match("16", None) == time(16, 0)
 
     def test_24h_hour_and_minutes(self) -> None:
         """T003: 24-hour format with hour and minutes."""
-        assert _parse_time_match("16", "30", None) == time(16, 30)
+        assert _parse_time_match("16:30", None) == time(16, 30)
 
     def test_24h_midnight(self) -> None:
         """T003: 24-hour format midnight."""
-        assert _parse_time_match("0", None, None) == time(0, 0)
+        assert _parse_time_match("0", None) == time(0, 0)
 
     def test_24h_hour_23(self) -> None:
         """T003: 24-hour format hour 23."""
-        assert _parse_time_match("23", "59", None) == time(23, 59)
+        assert _parse_time_match("23:59", None) == time(23, 59)
 
     def test_12h_am(self) -> None:
         """T004: 12-hour AM format."""
-        assert _parse_time_match("9", None, "AM") == time(9, 0)
+        assert _parse_time_match("9", "AM") == time(9, 0)
 
     def test_12h_pm(self) -> None:
         """T004: 12-hour PM format."""
-        assert _parse_time_match("4", None, "PM") == time(16, 0)
+        assert _parse_time_match("4", "PM") == time(16, 0)
 
     def test_12h_pm_with_minutes(self) -> None:
         """T004: 12-hour PM format with minutes."""
-        assert _parse_time_match("4", "30", "PM") == time(16, 30)
+        assert _parse_time_match("4:30", "PM") == time(16, 30)
 
     def test_12h_12pm_is_noon(self) -> None:
         """T004: 12 PM is noon (12:00)."""
-        assert _parse_time_match("12", None, "PM") == time(12, 0)
+        assert _parse_time_match("12", "PM") == time(12, 0)
 
     def test_12h_12am_is_midnight(self) -> None:
         """T004: 12 AM is midnight (00:00)."""
-        assert _parse_time_match("12", None, "AM") == time(0, 0)
+        assert _parse_time_match("12", "AM") == time(0, 0)
 
     def test_12h_am_lowercase(self) -> None:
         """T004: Case-insensitive AM/PM."""
-        assert _parse_time_match("9", None, "am") == time(9, 0)
+        assert _parse_time_match("9", "am") == time(9, 0)
 
     def test_12h_pm_lowercase(self) -> None:
         """T004: Case-insensitive PM."""
-        assert _parse_time_match("4", None, "pm") == time(16, 0)
+        assert _parse_time_match("4", "pm") == time(16, 0)
 
     def test_invalid_24h_hour_24(self) -> None:
         """T005: Hour 24 in 24h mode is invalid."""
-        assert _parse_time_match("24", None, None) is None
+        assert _parse_time_match("24", None) is None
 
     def test_invalid_24h_hour_25(self) -> None:
         """T005: Hour 25 in 24h mode is invalid."""
-        assert _parse_time_match("25", None, None) is None
+        assert _parse_time_match("25", None) is None
 
     def test_invalid_12h_hour_0(self) -> None:
         """T005: Hour 0 in 12h mode is invalid."""
-        assert _parse_time_match("0", None, "AM") is None
+        assert _parse_time_match("0", "AM") is None
 
     def test_invalid_12h_hour_13(self) -> None:
         """T005: Hour 13 in 12h mode is invalid."""
-        assert _parse_time_match("13", None, "PM") is None
+        assert _parse_time_match("13", "PM") is None
 
     def test_invalid_minute_60(self) -> None:
         """T006: Minute 60 is invalid."""
-        assert _parse_time_match("10", "60", None) is None
+        assert _parse_time_match("10:60", None) is None
 
     def test_invalid_minute_99(self) -> None:
         """T006: Minute 99 is invalid."""
-        assert _parse_time_match("10", "99", None) is None
+        assert _parse_time_match("10:99", None) is None
 
     def test_valid_minute_00(self) -> None:
         """T007: Minute 00 is valid."""
-        assert _parse_time_match("10", "00", None) == time(10, 0)
+        assert _parse_time_match("10:00", None) == time(10, 0)
 
     def test_valid_minute_59(self) -> None:
         """T007: Minute 59 is valid."""
-        assert _parse_time_match("10", "59", None) == time(10, 59)
+        assert _parse_time_match("10:59", None) == time(10, 59)
 
     def test_none_minute_defaults_to_0(self) -> None:
         """T007: None minute defaults to 0."""
-        assert _parse_time_match("10", None, None) == time(10, 0)
+        assert _parse_time_match("10", None) == time(10, 0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Enhances the `honor_event_times` feature to extract check-in/check-out times from event descriptions when calendar events are all-day (VALUE=DATE). This supports PMS systems like Hostaway that embed times in the DESCRIPTION field rather than using datetime DTSTART/DTEND.

## Time Resolution Priority (Updated)

When `honor_event_times=True`:
1. Explicit DTSTART/DTEND datetime → use event times (existing)
2. **NEW**: All-day event + description contains check-in/out times → use extracted times
3. Override exists (fallback for partially missing description times) → use override times
4. Fallback → configured CONF_CHECKIN/CONF_CHECKOUT defaults

Description-extracted times take priority over overrides. If only one time (check-in or check-out) is found in the description, the other falls through to override or default.

## Supported Formats

- Integer hours: `Checkin time: 16` → 16:00
- HH:MM: `Check-in time: 16:30` → 16:30
- 12-hour: `Check-in: 4 PM` → 16:00
- Case-insensitive, multiple pattern variants
- Boundary-guarded: rejects malformed values like `16:300`

## New Files

- `custom_components/rental_control/description_parser.py` — Pure-function time extraction module
- `tests/unit/test_description_parser.py` — Comprehensive unit tests (all formats + edge cases)

## Test Results

All 710 tests pass, no regressions.

Closes #482