### PR TITLE
Fix(deps): Exclude icalendar 7.1.0

### DIFF
--- a/custom_components/rental_control/manifest.json
+++ b/custom_components/rental_control/manifest.json
@@ -1,14 +1,21 @@
 {
   "domain": "rental_control",
   "name": "Rental Control",
-  "after_dependencies": ["keymaster"],
-  "codeowners": ["@tykeal"],
+  "after_dependencies": [
+    "keymaster"
+  ],
+  "codeowners": [
+    "@tykeal"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/tykeal/homeassistant-rental-control",
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tykeal/homeassistant-rental-control/issues",
-  "requirements": ["icalendar>=7.0.0", "x-wr-timezone>=2.0.0"],
+  "requirements": [
+    "icalendar>=7.0.0,!=7.1.0",
+    "x-wr-timezone>=2.0.0"
+  ],
   "version": "0.0.0"
 }


### PR DESCRIPTION
## Problem

`icalendar 7.1.0` (released April 30, 2026) has a broken `METADATA` file in its `dist-info` directory — the `Name` field is missing. When Home Assistant 2026.5.0 uses `uv` to verify installed packages, it fails to read the metadata, causing rental_control to not load:

```
Unable to install package icalendar>=7.0.0: × Failed to read `icalendar==7.1.0`
  ├─▶ Failed to read metadata from installed package `icalendar==7.1.0`
  ├─▶ Failed to parse METADATA file
  ╰─▶ Metadata field Name not found
```

## Fix

Exclude `icalendar==7.1.0` from the requirements using PEP 440 version exclusion. This allows any version `>=7.0.0` except the broken `7.1.0` release.