### PR TITLE
Fix(overrides): UID-based positive slot match

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -75,6 +75,7 @@ from .description_parser import extract_checkin_time
 from .description_parser import extract_checkout_time
 from .event_overrides import EventOverrides
 from .util import get_slot_name
+from .util import normalize_uid
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -748,7 +749,7 @@ Please update Keymaster to at least v0.1.0-b0
             location=event.get("LOCATION"),
             summary=event.get("SUMMARY", "Unknown"),
             start=start.astimezone(self.timezone),
-            uid=str(raw_uid) if raw_uid is not None else None,
+            uid=normalize_uid(str(raw_uid) if raw_uid is not None else None),
         )
 
         _LOGGER.debug("Event to add: %s", cal_event)

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -30,6 +30,7 @@ from .const import DEFAULT_MAX_RETRY_CYCLES
 from .util import EventIdentity
 from .util import async_fire_clear_code
 from .util import get_event_identities
+from .util import normalize_uid
 
 if TYPE_CHECKING:
     from homeassistant.components.calendar import CalendarEvent
@@ -171,16 +172,39 @@ class EventOverrides:
         uid: str | None = None,
         exclude_slot: int | None = None,
     ) -> int | None:
-        """Find existing slot with same name and overlapping time range.
+        """Find existing slot matching by UID or overlapping time range.
 
-        Uses strict interval overlap: start_a < end_b AND start_b < end_a.
-        If both incoming uid and stored uid are non-None and differ,
-        the slot is skipped (distinct reservations with same name).
+        Uses a two-phase search:
+
+        Phase 1 — UID positive match.  When both the incoming event and
+        a stored slot carry a non-None UID that is equal, the slot is
+        returned immediately (provided the name also matches).  This
+        ensures that a reservation whose dates shifted beyond the
+        original overlap window is still recognised as the same booking.
+
+        Phase 2 — Strict interval overlap with UID negative gate
+        (original logic).  ``start_a < end_b AND start_b < end_a``.
+        If both UIDs are non-None and differ the slot is skipped
+        (distinct reservations with the same guest name).
 
         When *exclude_slot* is set that slot number is skipped entirely,
         allowing ``async_update`` to avoid matching the slot it is about
         to write to.
         """
+        uid = normalize_uid(uid)
+
+        # Phase 1: UID positive match
+        if uid is not None:
+            for slot in self.__get_slots_with_values():
+                if slot == exclude_slot:
+                    continue
+                stored_uid = normalize_uid(self._slot_uids.get(slot))
+                if stored_uid is not None and stored_uid == uid:
+                    override = self._overrides[slot]
+                    if override is not None and override["slot_name"] == slot_name:
+                        return slot
+
+        # Phase 2: name + strict interval overlap + UID negative gate
         for slot in self.__get_slots_with_values():
             if slot == exclude_slot:
                 continue
@@ -193,7 +217,7 @@ class EventOverrides:
                 start_time < override["end_time"] and override["start_time"] < end_time
             ):
                 continue
-            stored_uid = self._slot_uids.get(slot)
+            stored_uid = normalize_uid(self._slot_uids.get(slot))
             if uid is not None and stored_uid is not None and uid != stored_uid:
                 continue
             return slot
@@ -222,7 +246,7 @@ class EventOverrides:
             existing = self._find_overlapping_slot(slot_name, start_time, end_time, uid)
             if existing is not None:
                 if uid is not None:
-                    self._slot_uids[existing] = uid
+                    self._slot_uids[existing] = normalize_uid(uid)
                 override = self._overrides[existing]
                 if override is not None and (
                     override["start_time"] != start_time
@@ -243,7 +267,7 @@ class EventOverrides:
                 }
                 self._overrides[new_slot] = new_override
                 if uid is not None:
-                    self._slot_uids[new_slot] = uid
+                    self._slot_uids[new_slot] = normalize_uid(uid)
                 self.__assign_next_slot()
                 return ReserveResult(new_slot, True, False)
 
@@ -339,9 +363,13 @@ class EventOverrides:
     ) -> bool:
         """Check if an override slot matches any current calendar event.
 
-        Uses name + strict interval overlap + UID tiebreaker, the same
-        logic as ``_find_overlapping_slot`` but searching calendar
-        events instead of other override slots.
+        Uses a two-phase search mirroring ``_find_overlapping_slot``:
+
+        Phase 1 — UID positive match.  If the stored slot UID equals an
+        event UID and the names match, the slot is considered matched
+        regardless of time overlap.
+
+        Phase 2 — name + strict interval overlap + UID negative gate.
         """
         override = self._overrides[slot]
         if override is None:
@@ -350,14 +378,23 @@ class EventOverrides:
         slot_name = override["slot_name"]
         slot_start = override["start_time"]
         slot_end = override["end_time"]
-        stored_uid = self._slot_uids.get(slot)
+        stored_uid = normalize_uid(self._slot_uids.get(slot))
 
+        # Phase 1: UID positive match
+        if stored_uid is not None:
+            for ev in events:
+                ev_uid = normalize_uid(ev.uid)
+                if ev_uid is not None and ev_uid == stored_uid and ev.name == slot_name:
+                    return True
+
+        # Phase 2: name + strict interval overlap + UID negative gate
         for ev in events:
             if ev.name != slot_name:
                 continue
             if not (slot_start < ev.end and ev.start < slot_end):
                 continue
-            if stored_uid is not None and ev.uid is not None and stored_uid != ev.uid:
+            ev_uid = normalize_uid(ev.uid)
+            if stored_uid is not None and ev_uid is not None and stored_uid != ev_uid:
                 continue
             return True
 

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -27,6 +27,7 @@ from ..util import async_fire_set_code
 from ..util import async_fire_update_times
 from ..util import gen_uuid
 from ..util import get_slot_name
+from ..util import normalize_uid
 
 if TYPE_CHECKING:
     from ..coordinator import RentalControlCoordinator
@@ -473,7 +474,9 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             # Gate on overrides.ready to avoid spurious overflow
             # warnings during bootstrap when _next_slot is still None.
             if overrides and overrides.ready and slot_name is not None:
-                event_uid: str | None = event.uid if hasattr(event, "uid") else None
+                event_uid: str | None = normalize_uid(
+                    event.uid if hasattr(event, "uid") else None
+                )
                 self.hass.async_create_task(
                     self._async_handle_slot_assignment(
                         slot_name=slot_name,
@@ -558,10 +561,14 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         # itself is still valid, but Keymaster side effects must not
         # fire for a stale event.
         current_attrs = self._event_attributes
+        current_uid = normalize_uid(
+            str(current_attrs["uid"]) if current_attrs.get("uid") is not None else None
+        )
         if (
             current_attrs.get("slot_name") != slot_name
             or current_attrs.get("start") != start_time
             or current_attrs.get("end") != end_time
+            or current_uid != uid
         ):
             _LOGGER.debug(
                 "Slot assignment for '%s' is stale, skipping "
@@ -597,4 +604,4 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
                 )
                 await async_fire_clear_code(self.coordinator, result.slot)
             else:
-                await async_fire_update_times(self.coordinator, self)
+                await async_fire_update_times(self.coordinator, self, result.slot)

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -58,6 +58,19 @@ from .const import NAME
 _LOGGER = logging.getLogger(__name__)
 
 
+def normalize_uid(value: str | None) -> str | None:
+    """Normalize a calendar UID for consistent comparison.
+
+    Strips surrounding whitespace and converts empty strings
+    to ``None`` so that all UID storage and comparison paths
+    use an identical canonical form.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
 def check_gather_results(
     results: Sequence[object],
     context: str,
@@ -330,13 +343,12 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         )
 
 
-async def async_fire_update_times(coordinator, event) -> None:
+async def async_fire_update_times(coordinator, event, slot: int) -> None:
     """Update times on slot."""
 
     lockname: str = coordinator.lockname
     coro: list[Coroutine] = []
     slot_name: str = event.extra_state_attributes["slot_name"]
-    slot = coordinator.event_overrides.get_slot_key_by_name(slot_name)
 
     if not slot or not lockname:
         return
@@ -419,7 +431,7 @@ def get_event_identities(rc, calendar: list | None = None) -> list[EventIdentity
             rc.event_prefix or "",
         )
         if name:
-            uid = event.uid if hasattr(event, "uid") else None
+            uid = normalize_uid(event.uid if hasattr(event, "uid") else None)
             start = _ensure_datetime(event.start, rc)
             end = _ensure_datetime(event.end, rc)
             identities.append(EventIdentity(name, start, end, uid))

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -19,6 +19,7 @@ import pytest
 from custom_components.rental_control.event_overrides import EventOverride
 from custom_components.rental_control.event_overrides import EventOverrides
 from custom_components.rental_control.event_overrides import ReserveResult
+from custom_components.rental_control.util import EventIdentity
 
 # ---------------------------------------------------------------------------
 # Helpers / Fixtures
@@ -1607,3 +1608,114 @@ class TestUidTiebreaker:
         # Matches existing slot 3 (no stored UID → no tiebreaker skip)
         assert result.slot == 3
         assert result.is_new is False
+
+
+class TestUidPositiveMatch:
+    """Tests for UID-based positive matching in slot lookup."""
+
+    async def test_uid_positive_match_non_overlapping_dates(self) -> None:
+        """Same UID + name matches even when dates do not overlap.
+
+        Simulates a reservation whose dates shift entirely (e.g.,
+        extended stay moves end date past the original range).
+        """
+        eo = _make_ready_eo()
+        # Original reservation
+        r1 = await eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+            uid="UID-001",
+        )
+        assert r1.is_new is True
+
+        # Same UID, shifted dates (no overlap with original)
+        r2 = await eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="5678",
+            start_time=_make_dt(2025, 8, 6),
+            end_time=_make_dt(2025, 8, 10),
+            uid="UID-001",
+        )
+        assert r2.slot == r1.slot
+        assert r2.is_new is False
+        assert r2.times_updated is True
+
+    async def test_slot_has_matching_event_uid_positive_match(self) -> None:
+        """Slot matches event by UID even when dates shifted."""
+        eo = _make_ready_eo()
+        r1 = await eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+            uid="UID-001",
+        )
+        assert r1.slot is not None
+
+        # Event with same UID but shifted dates
+        events = [
+            EventIdentity(
+                name="Alice",
+                start=_make_dt(2025, 8, 6),
+                end=_make_dt(2025, 8, 10),
+                uid="UID-001",
+            )
+        ]
+        assert eo._slot_has_matching_event(r1.slot, events) is True
+
+    async def test_date_extension_updates_existing_slot(self) -> None:
+        """Extending end date of active reservation reuses slot."""
+        eo = _make_ready_eo()
+        # Original reservation: Aug 1-5
+        r1 = await eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="0105",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+            uid="UID-002",
+        )
+        assert r1.is_new is True
+
+        # Guest extends stay to Aug 10 (overlapping, same UID)
+        r2 = await eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="0110",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 10),
+            uid="UID-002",
+        )
+        assert r2.slot == r1.slot
+        assert r2.slot is not None
+        assert r2.is_new is False
+        assert r2.times_updated is True
+        # Code should remain original
+        override = eo.overrides[r2.slot]
+        assert override is not None
+        assert override["slot_code"] == "0105"
+        # End time should be updated
+        assert override["end_time"] == _make_dt(2025, 8, 10)
+
+    async def test_different_uid_still_creates_new_slot(self) -> None:
+        """Different UIDs with same name still get separate slots."""
+        eo = _make_ready_eo()
+        r1 = await eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2025, 8, 1),
+            end_time=_make_dt(2025, 8, 5),
+            uid="UID-AAA",
+        )
+        assert r1.is_new is True
+
+        # Different UID, overlapping dates
+        r2 = await eo.async_reserve_or_get_slot(
+            slot_name="Alice",
+            slot_code="5678",
+            start_time=_make_dt(2025, 8, 3),
+            end_time=_make_dt(2025, 8, 7),
+            uid="UID-BBB",
+        )
+        assert r2.slot != r1.slot
+        assert r2.is_new is True

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -1497,7 +1497,7 @@ class TestHandleCoordinatorUpdateOverrides:
             sensor._handle_coordinator_update()
             coro = sensor.hass.async_create_task.call_args[0][0]
             await coro
-            mock_update_times.assert_called_once_with(coordinator, sensor)
+            mock_update_times.assert_called_once_with(coordinator, sensor, 10)
 
     @freeze_time("2025-03-10T12:00:00+00:00")
     async def test_fires_clear_code_on_date_shift_date_based(self, hass) -> None:
@@ -1631,7 +1631,7 @@ class TestHandleCoordinatorUpdateOverrides:
             coro = sensor.hass.async_create_task.call_args[0][0]
             await coro
             mock_clear_code.assert_not_called()
-            mock_update_times.assert_called_once_with(coordinator, sensor)
+            mock_update_times.assert_called_once_with(coordinator, sensor, 10)
 
     @freeze_time("2025-03-10T12:00:00+00:00")
     async def test_slot_number_set_on_assignment(self, hass) -> None:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -37,6 +37,7 @@ from custom_components.rental_control.util import get_event_identities
 from custom_components.rental_control.util import get_event_names
 from custom_components.rental_control.util import get_slot_name
 from custom_components.rental_control.util import handle_state_change
+from custom_components.rental_control.util import normalize_uid
 
 # ---------------------------------------------------------------------------
 # gen_uuid tests
@@ -1296,11 +1297,10 @@ class TestAsyncFireUpdateTimes:
         """Verify both datetime entities are updated."""
         coordinator = MagicMock()
         coordinator.lockname = "front_door"
-        coordinator.event_overrides.get_slot_key_by_name.return_value = 10
         coordinator.hass.services.async_call = AsyncMock()
 
         event = self._make_event()
-        await async_fire_update_times(coordinator, event)
+        await async_fire_update_times(coordinator, event, 10)
 
         calls = coordinator.hass.services.async_call.await_args_list
         assert len(calls) == 2
@@ -1313,21 +1313,19 @@ class TestAsyncFireUpdateTimes:
         """Verify no service calls when lockname is empty."""
         coordinator = MagicMock()
         coordinator.lockname = ""
-        coordinator.event_overrides.get_slot_key_by_name.return_value = 10
         coordinator.hass.services.async_call = AsyncMock()
 
-        await async_fire_update_times(coordinator, self._make_event())
+        await async_fire_update_times(coordinator, self._make_event(), 10)
 
         coordinator.hass.services.async_call.assert_not_awaited()
 
     async def test_no_slot_found_returns_early(self) -> None:
-        """Verify no service calls when slot name is not found."""
+        """Verify no service calls when slot is zero/falsy."""
         coordinator = MagicMock()
         coordinator.lockname = "front_door"
-        coordinator.event_overrides.get_slot_key_by_name.return_value = None
         coordinator.hass.services.async_call = AsyncMock()
 
-        await async_fire_update_times(coordinator, self._make_event())
+        await async_fire_update_times(coordinator, self._make_event(), 0)
 
         coordinator.hass.services.async_call.assert_not_awaited()
 
@@ -1337,7 +1335,6 @@ class TestAsyncFireUpdateTimes:
         """Verify a failing service call is logged but does not crash."""
         coordinator = MagicMock()
         coordinator.lockname = "front_door"
-        coordinator.event_overrides.get_slot_key_by_name.return_value = 10
         coordinator.hass.services.async_call = AsyncMock(
             side_effect=ServiceNotFound("datetime", "set_value")
         )
@@ -1345,7 +1342,7 @@ class TestAsyncFireUpdateTimes:
         with caplog.at_level(
             logging.ERROR, logger="custom_components.rental_control.util"
         ):
-            await async_fire_update_times(coordinator, self._make_event())
+            await async_fire_update_times(coordinator, self._make_event(), 10)
 
         assert "Lock slot operation" in caplog.text
 
@@ -1408,7 +1405,6 @@ class TestPreExecutionVerification:
         """Verify async_fire_update_times returns early when ownership fails."""
         coordinator = MagicMock()
         coordinator.lockname = "front_door"
-        coordinator.event_overrides.get_slot_key_by_name.return_value = 10
         coordinator.event_overrides.verify_slot_ownership.return_value = False
         coordinator.hass.services.async_call = AsyncMock()
 
@@ -1422,7 +1418,7 @@ class TestPreExecutionVerification:
         with caplog.at_level(
             logging.WARNING, logger="custom_components.rental_control.util"
         ):
-            await async_fire_update_times(coordinator, event)
+            await async_fire_update_times(coordinator, event, 10)
 
         coordinator.hass.services.async_call.assert_not_awaited()
         assert "ownership" in caplog.text.lower()
@@ -1846,3 +1842,31 @@ class TestComputeEarlyExpiryTime:
         original_end = now + timedelta(minutes=20)
         result = compute_early_expiry_time(now, original_end, grace_minutes=30)
         assert result == original_end
+
+
+class TestNormalizeUid:
+    """Tests for normalize_uid helper."""
+
+    def test_none_returns_none(self) -> None:
+        """Verify None input returns None."""
+        assert normalize_uid(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        """Verify empty string returns None."""
+        assert normalize_uid("") is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        """Verify whitespace-only string returns None."""
+        assert normalize_uid("   ") is None
+
+    def test_strips_whitespace(self) -> None:
+        """Verify leading/trailing whitespace is stripped."""
+        assert normalize_uid("  abc123  ") == "abc123"
+
+    def test_preserves_normal_uid(self) -> None:
+        """Verify normal UID is preserved unchanged."""
+        assert normalize_uid("abc123@example.com") == "abc123@example.com"
+
+    def test_strips_newlines(self) -> None:
+        """Verify trailing newlines are stripped."""
+        assert normalize_uid("abc123\n") == "abc123"


### PR DESCRIPTION
## Summary

When a reservation's dates change (e.g., guest extends their stay), the
integration was creating a **new** Keymaster slot instead of updating the
existing one. This resulted in duplicate lock codes for the same
reservation.

## Root Cause

`_find_overlapping_slot()` and `_slot_has_matching_event()` required
time overlap to match events to slots. UID comparison only acted as a
negative gate (reject if UIDs differ), never as a positive match. When
dates changed beyond the original overlap window, the existing slot
wasn't found.

## Changes

- **Two-phase slot lookup**: Phase 1 matches by UID + name (definitive
  identity regardless of date changes). Phase 2 falls back to name +
  time overlap with UID negative gate (existing logic).
- **Centralized UID normalization**: New `normalize_uid()` helper used
  consistently across coordinator parsing, event identity extraction,
  slot assignment, and reconciliation.
- **Direct slot number for update_times**: `async_fire_update_times()`
  now accepts slot number directly instead of name-based lookup.
- **UID in staleness guard**: The staleness check in
  `_async_handle_slot_assignment()` now includes UID comparison.

## Testing

- Added tests for UID positive match with non-overlapping dates
- Added tests for date extension scenario
- Added tests for `_slot_has_matching_event` UID positive match
- Added tests for `normalize_uid` helper
- Verified disambiguation still works (different UIDs create separate slots)

Closes #509