### PR TITLE
Fix(overrides): Normalize tz in comparisons

### DIFF
--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -41,15 +41,22 @@ _LOGGER = logging.getLogger(__name__)
 def _to_utc(value: datetime) -> datetime:
     """Normalize a datetime to UTC for timezone-safe comparison.
 
-    Aware datetimes are converted directly.  Naive datetimes (missing
-    ``tzinfo`` or returning ``None`` from ``utcoffset()``) are assumed
-    to represent Home Assistant's configured local timezone before
-    conversion to UTC.
+    Aware datetimes are converted via ``dt.as_utc``.  Naive datetimes
+    (missing ``tzinfo`` or returning ``None`` from ``utcoffset()``)
+    are assumed to represent Home Assistant's configured local timezone
+    before conversion.
+
+    ``dt.as_utc`` is intentionally **not** used for naive values because
+    it treats them as already-UTC, whereas values arriving here without
+    timezone info (e.g. from ``dt.parse_datetime`` on a tz-less string)
+    are more likely to be in the user's configured local timezone.
     """
     if value.tzinfo is None or value.utcoffset() is None:
         local: datetime = dt.as_local(value)
-        return local.astimezone(dt.UTC)
-    return value.astimezone(dt.UTC)
+        result: datetime = dt.as_utc(local)
+        return result
+    utc: datetime = dt.as_utc(value)
+    return utc
 
 
 def _strip_prefix(slot_name: str, prefix: str) -> str:

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -219,6 +219,8 @@ class EventOverrides:
                         return slot
 
         # Phase 2: name + strict interval overlap + UID negative gate
+        start_utc = _to_utc(start_time)
+        end_utc = _to_utc(end_time)
         for slot in self.__get_slots_with_values():
             if slot == exclude_slot:
                 continue
@@ -228,8 +230,8 @@ class EventOverrides:
             if override["slot_name"] != slot_name:
                 continue
             if not (
-                _to_utc(start_time) < _to_utc(override["end_time"])
-                and _to_utc(override["start_time"]) < _to_utc(end_time)
+                start_utc < _to_utc(override["end_time"])
+                and _to_utc(override["start_time"]) < end_utc
             ):
                 continue
             stored_uid = normalize_uid(self._slot_uids.get(slot))
@@ -263,9 +265,11 @@ class EventOverrides:
                 if uid is not None:
                     self._slot_uids[existing] = normalize_uid(uid)
                 override = self._overrides[existing]
+                start_utc = _to_utc(start_time)
+                end_utc = _to_utc(end_time)
                 if override is not None and (
-                    _to_utc(override["start_time"]) != _to_utc(start_time)
-                    or _to_utc(override["end_time"]) != _to_utc(end_time)
+                    _to_utc(override["start_time"]) != start_utc
+                    or _to_utc(override["end_time"]) != end_utc
                 ):
                     override["start_time"] = start_time
                     override["end_time"] = end_time
@@ -403,12 +407,13 @@ class EventOverrides:
                     return True
 
         # Phase 2: name + strict interval overlap + UID negative gate
+        slot_start_utc = _to_utc(slot_start)
+        slot_end_utc = _to_utc(slot_end)
         for ev in events:
             if ev.name != slot_name:
                 continue
             if not (
-                _to_utc(slot_start) < _to_utc(ev.end)
-                and _to_utc(ev.start) < _to_utc(slot_end)
+                slot_start_utc < _to_utc(ev.end) and _to_utc(ev.start) < slot_end_utc
             ):
                 continue
             ev_uid = normalize_uid(ev.uid)

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -1755,18 +1755,19 @@ class TestToUtc:
 
         from custom_components.rental_control.event_overrides import _to_utc
 
-        # Set HA default timezone to US/Eastern (UTC-5, no DST here)
+        # Set HA default timezone to a fixed UTC-5 offset
+        previous_tz = dt_util.get_default_time_zone()
         eastern = timezone(timedelta(hours=-5))
         dt_util.set_default_time_zone(eastern)
         try:
             naive = datetime(2025, 8, 1, 12, 0)
             result = _to_utc(naive)
-            # 12:00 Eastern (UTC-5) => 17:00 UTC
+            # 12:00 at UTC-5 => 17:00 UTC
             assert result.tzinfo is not None
             assert result.utcoffset() == timedelta(0)
             assert result == datetime(2025, 8, 1, 17, 0, tzinfo=dt_util.UTC)
         finally:
-            dt_util.set_default_time_zone(dt_util.UTC)
+            dt_util.set_default_time_zone(previous_tz)
 
 
 class TestTimezoneSafeComparison:

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -1751,13 +1751,22 @@ class TestToUtc:
 
     def test_naive_treated_as_local(self) -> None:
         """Naive datetimes are assumed to be HA local time."""
+        from datetime import timezone
+
         from custom_components.rental_control.event_overrides import _to_utc
 
-        naive = datetime(2025, 8, 1, 12, 0)
-        result = _to_utc(naive)
-        # Result must be timezone-aware in UTC
-        assert result.tzinfo is not None
-        assert result.utcoffset() == timedelta(0)
+        # Set HA default timezone to US/Eastern (UTC-5, no DST here)
+        eastern = timezone(timedelta(hours=-5))
+        dt_util.set_default_time_zone(eastern)
+        try:
+            naive = datetime(2025, 8, 1, 12, 0)
+            result = _to_utc(naive)
+            # 12:00 Eastern (UTC-5) => 17:00 UTC
+            assert result.tzinfo is not None
+            assert result.utcoffset() == timedelta(0)
+            assert result == datetime(2025, 8, 1, 17, 0, tzinfo=dt_util.UTC)
+        finally:
+            dt_util.set_default_time_zone(dt_util.UTC)
 
 
 class TestTimezoneSafeComparison:


### PR DESCRIPTION
## Summary

Normalize datetime timezone representations before comparison in
EventOverrides to prevent false `times_updated=True` on every
coordinator cycle.

## Problem

Bootstrap-populated overrides (from Keymaster entity states) and
CalendarEvent times (from iCal parser) may carry different timezone
representations. Python datetime `!=` between naive and aware objects
always returns `False` for equality, causing `times_updated=True`
every coordinator cycle. This triggers unnecessary Keymaster entity
writes every 2 minutes, which in turn can trigger Keymaster's PIN
mismatch detection feedback loop (FutureTense/keymaster#605).

## Changes

- **`_to_utc()` helper** — Normalizes datetimes to UTC for safe
  comparison. Aware datetimes convert directly; naive datetimes are
  assumed to be in HA's local timezone.
- **`_find_overlapping_slot()`** — Overlap comparison now uses
  `_to_utc()` on both sides.
- **`async_reserve_or_get_slot()`** — Equality comparison for
  `times_updated` detection now uses `_to_utc()`.
- **`_slot_has_matching_event()`** — Overlap comparison uses
  `_to_utc()`.
- **Tests** — `TestToUtc` (3 tests) and `TestTimezoneSafeComparison`
  (3 tests) covering UTC passthrough, cross-tz conversion, naive
  handling, same-instant equality, cross-tz overlap, and cross-tz
  event matching.

Closes #513