### PR TITLE
Fix(core): Handle partial Keymaster slot resets

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -74,6 +74,7 @@ from .const import VERSION
 from .description_parser import extract_checkin_time
 from .description_parser import extract_checkout_time
 from .event_overrides import EventOverrides
+from .util import async_fire_clear_code
 from .util import get_slot_name
 from .util import normalize_uid
 
@@ -291,6 +292,36 @@ Please update Keymaster to at least v0.1.0-b0
             use_date_range = self.hass.states.get(
                 f"{SWITCH}.{self.lockname}_code_slot_{i}_use_date_range_limits"
             )
+
+            if (
+                slot_name_value
+                and slot_code.state == ""
+                and not slot_code_value
+                and (use_date_range is None or use_date_range.state == "off")
+            ):
+                # Partially-reset slot: name persists but code was cleared
+                # and date-range limits are off.  Only trigger when the raw
+                # PIN state is explicitly empty, not when it is
+                # unknown/unavailable (entity not yet loaded).
+                _LOGGER.warning(
+                    "Slot %d has name '%s' but no code; forcing "
+                    "reset (Keymaster may not have fully cleared "
+                    "the slot)",
+                    i,
+                    slot_name_value,
+                )
+                try:
+                    await async_fire_clear_code(self, i)
+                except Exception:
+                    _LOGGER.exception(
+                        "Failed to force-reset partially-cleared slot %d",
+                        i,
+                    )
+                # Register the slot as empty so the overrides map
+                # reaches max_slots and ready becomes True.
+                slot_name_value = ""
+                slot_code_value = ""
+
             if use_date_range and use_date_range.state == "on":
                 start_time_state = self.hass.states.get(
                     f"{DATETIME}.{self.lockname}_code_slot_{i}_date_range_start"

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -200,6 +200,37 @@ async def async_fire_clear_code(
             )
         raise
 
+    # Give Keymaster time to propagate the state change
+    await asyncio.sleep(0.5)
+
+    # Verify the slot name was actually cleared
+    name_entity = f"{TEXT}.{coordinator.lockname}_code_slot_{slot}_name"
+    name_state = hass.states.get(name_entity)
+    if name_state is not None and name_state.state not in (
+        "",
+        "unknown",
+        "unavailable",
+    ):
+        _LOGGER.warning(
+            "Slot %d name '%s' persisted after reset; "
+            "forcing name clear via text.set_value",
+            slot,
+            name_state.state,
+        )
+        try:
+            await hass.services.async_call(
+                domain=TEXT,
+                service="set_value",
+                target={"entity_id": name_entity},
+                service_data={"value": ""},
+                blocking=True,
+            )
+        except Exception:
+            _LOGGER.exception(
+                "Failed to force-clear name for slot %d",
+                slot,
+            )
+
     was_escalated = coordinator.event_overrides._escalated.get(slot, False)
     coordinator.event_overrides.record_retry_success(slot)
     if was_escalated:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1067,6 +1067,191 @@ class TestSlotBootstrapping:
 
 
 # ---------------------------------------------------------------------------
+# Partial slot reset detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestPartialSlotResetDetection:
+    """Tests for detecting and resetting partially-cleared slots."""
+
+    async def test_startup_detects_partial_reset_and_forces_clear(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify slot with name but no code triggers force-reset."""
+        mock_config_entry.add_to_hass(hass)
+
+        with patch.object(
+            dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY
+        ):
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            coordinator.lockname = "front_door"
+            mock_overrides = MagicMock()
+            mock_overrides.ready = False
+            mock_overrides.async_check_overrides = AsyncMock()
+            coordinator.event_overrides = mock_overrides
+            mock_update = AsyncMock()
+            object.__setattr__(coordinator, "update_event_overrides", mock_update)
+
+            hass.states.async_set("text.front_door_code_slot_10_pin", "")
+            hass.states.async_set("text.front_door_code_slot_10_name", "Ghost")
+
+            with patch(
+                "custom_components.rental_control.coordinator.async_fire_clear_code",
+                new_callable=AsyncMock,
+            ) as mock_clear:
+                await coordinator.async_setup_keymaster_overrides()
+
+        mock_clear.assert_awaited_once_with(coordinator, 10)
+        # Slot is registered as empty so ready can become True
+        mock_update.assert_awaited_once()
+        call_args = mock_update.call_args[0]
+        assert call_args[1] == ""
+        assert call_args[2] == ""
+
+    async def test_startup_skips_fully_empty_slots(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify fully empty slots do not trigger force-reset."""
+        mock_config_entry.add_to_hass(hass)
+
+        with patch.object(
+            dt_util,
+            "start_of_local_day",
+            return_value=FROZEN_START_OF_DAY,
+        ):
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            coordinator.lockname = "front_door"
+            mock_overrides = MagicMock()
+            mock_overrides.ready = False
+            mock_overrides.async_check_overrides = AsyncMock()
+            coordinator.event_overrides = mock_overrides
+            mock_update = AsyncMock()
+            object.__setattr__(coordinator, "update_event_overrides", mock_update)
+
+            hass.states.async_set("text.front_door_code_slot_10_pin", "")
+            hass.states.async_set("text.front_door_code_slot_10_name", "")
+
+            with patch(
+                "custom_components.rental_control.coordinator.async_fire_clear_code",
+                new_callable=AsyncMock,
+            ) as mock_clear:
+                await coordinator.async_setup_keymaster_overrides()
+
+        mock_clear.assert_not_awaited()
+
+    async def test_startup_loads_normal_slots(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify slots with both name and code load normally."""
+        mock_config_entry.add_to_hass(hass)
+
+        with patch.object(
+            dt_util,
+            "start_of_local_day",
+            return_value=FROZEN_START_OF_DAY,
+        ):
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            coordinator.lockname = "front_door"
+            mock_overrides = MagicMock()
+            mock_overrides.ready = False
+            mock_overrides.async_check_overrides = AsyncMock()
+            coordinator.event_overrides = mock_overrides
+            mock_update = AsyncMock()
+            object.__setattr__(coordinator, "update_event_overrides", mock_update)
+
+            hass.states.async_set("text.front_door_code_slot_10_pin", "1234")
+            hass.states.async_set("text.front_door_code_slot_10_name", "Guest")
+
+            with patch(
+                "custom_components.rental_control.coordinator.async_fire_clear_code",
+                new_callable=AsyncMock,
+            ) as mock_clear:
+                await coordinator.async_setup_keymaster_overrides()
+
+        mock_clear.assert_not_awaited()
+        mock_update.assert_awaited_once()
+        call_args = mock_update.call_args[0]
+        assert call_args[1] == "1234"
+        assert call_args[2] == "Guest"
+
+    async def test_startup_handles_force_reset_failure(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify force-reset failure is logged but does not crash."""
+        mock_config_entry.add_to_hass(hass)
+
+        with patch.object(
+            dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY
+        ):
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            coordinator.lockname = "front_door"
+            mock_overrides = MagicMock()
+            mock_overrides.ready = False
+            mock_overrides.async_check_overrides = AsyncMock()
+            coordinator.event_overrides = mock_overrides
+            mock_update = AsyncMock()
+            object.__setattr__(coordinator, "update_event_overrides", mock_update)
+
+            hass.states.async_set("text.front_door_code_slot_10_pin", "")
+            hass.states.async_set("text.front_door_code_slot_10_name", "Ghost")
+
+            with patch(
+                "custom_components.rental_control.coordinator.async_fire_clear_code",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("lock offline"),
+            ) as mock_clear:
+                await coordinator.async_setup_keymaster_overrides()
+
+        mock_clear.assert_awaited_once_with(coordinator, 10)
+        # Slot still registered as empty despite reset failure
+        mock_update.assert_awaited_once()
+        call_args = mock_update.call_args[0]
+        assert call_args[1] == ""
+        assert call_args[2] == ""
+
+    async def test_startup_skips_reset_when_pin_unknown(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify unknown PIN state does not trigger force-reset."""
+        mock_config_entry.add_to_hass(hass)
+
+        with patch.object(
+            dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY
+        ):
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            coordinator.lockname = "front_door"
+            mock_overrides = MagicMock()
+            mock_overrides.ready = False
+            mock_overrides.async_check_overrides = AsyncMock()
+            coordinator.event_overrides = mock_overrides
+            mock_update = AsyncMock()
+            object.__setattr__(coordinator, "update_event_overrides", mock_update)
+
+            hass.states.async_set("text.front_door_code_slot_10_pin", "unknown")
+            hass.states.async_set("text.front_door_code_slot_10_name", "Guest")
+
+            with patch(
+                "custom_components.rental_control.coordinator.async_fire_clear_code",
+                new_callable=AsyncMock,
+            ) as mock_clear:
+                await coordinator.async_setup_keymaster_overrides()
+
+        mock_clear.assert_not_awaited()
+        # Normal load path with normalized empty code
+        mock_update.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
 # Lockname slugification tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1109,6 +1109,7 @@ class TestAsyncFireClearCode:
         coordinator.name = "Test Rental"
         coordinator.lockname = "front_door"
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = None
 
         await async_fire_clear_code(coordinator, 10)
 
@@ -1140,6 +1141,119 @@ class TestAsyncFireClearCode:
         await async_fire_clear_code(coordinator, 10)
 
         coordinator.hass.services.async_call.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# async_fire_clear_code post-clear verification tests
+# ---------------------------------------------------------------------------
+
+
+class TestClearCodePostClearVerification:
+    """Tests for post-clear name verification in async_fire_clear_code."""
+
+    async def test_clear_code_verifies_name_cleared(self) -> None:
+        """Verify text.set_value is NOT called when name is empty."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        name_state = MagicMock()
+        name_state.state = ""
+        coordinator.hass.states.get.return_value = name_state
+
+        await async_fire_clear_code(coordinator, 10)
+
+        # Only the button.press call should have been made
+        coordinator.hass.services.async_call.assert_awaited_once_with(
+            domain="button",
+            service="press",
+            target={
+                "entity_id": "button.front_door_code_slot_10_reset",
+            },
+            blocking=True,
+        )
+
+    async def test_clear_code_forces_name_clear_on_persist(
+        self,
+    ) -> None:
+        """Verify text.set_value is called when name persists."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        name_state = MagicMock()
+        name_state.state = "Ghost"
+        coordinator.hass.states.get.return_value = name_state
+
+        await async_fire_clear_code(coordinator, 10)
+
+        calls = coordinator.hass.services.async_call.await_args_list
+        assert len(calls) == 2
+        set_call = calls[1]
+        assert set_call.kwargs["domain"] == "text"
+        assert set_call.kwargs["service"] == "set_value"
+        assert set_call.kwargs["target"] == {
+            "entity_id": "text.front_door_code_slot_10_name",
+        }
+        assert set_call.kwargs["service_data"] == {"value": ""}
+
+    async def test_clear_code_handles_force_clear_failure(
+        self,
+    ) -> None:
+        """Verify force-clear exception is logged, not propagated."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+
+        name_state = MagicMock()
+        name_state.state = "Ghost"
+        coordinator.hass.states.get.return_value = name_state
+
+        # First call (button.press) succeeds; second (set_value) fails
+        coordinator.hass.services.async_call = AsyncMock(
+            side_effect=[None, RuntimeError("set_value failed")],
+        )
+
+        # Should not raise
+        await async_fire_clear_code(coordinator, 10)
+
+        assert coordinator.hass.services.async_call.await_count == 2
+
+    async def test_clear_code_skips_unknown_name_state(
+        self,
+    ) -> None:
+        """Verify no force-clear when name state is 'unknown'."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        name_state = MagicMock()
+        name_state.state = "unknown"
+        coordinator.hass.states.get.return_value = name_state
+
+        await async_fire_clear_code(coordinator, 10)
+
+        coordinator.hass.services.async_call.assert_awaited_once()
+
+    async def test_clear_code_skips_unavailable_name_state(
+        self,
+    ) -> None:
+        """Verify no force-clear when name state is 'unavailable'."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        name_state = MagicMock()
+        name_state.state = "unavailable"
+        coordinator.hass.states.get.return_value = name_state
+
+        await async_fire_clear_code(coordinator, 10)
+
+        coordinator.hass.services.async_call.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1576,6 +1690,7 @@ class TestRetryEscalation:
         coordinator.name = "Test Rental"
         coordinator.lockname = "front_door"
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = None
         coordinator.event_overrides.verify_slot_ownership.return_value = True
         coordinator.event_overrides._escalated = {10: True}
 
@@ -1685,6 +1800,7 @@ class TestSlugifiedLocknameEntityIds:
         coordinator.name = "Test Rental"
         coordinator.lockname = "front_door"
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = None
 
         await async_fire_clear_code(coordinator, 10)
 


### PR DESCRIPTION
## Summary

Fix phantom occupied slots caused by Keymaster not fully clearing slot names after reset.

### Fix 1: Startup detection (coordinator.py)

During `async_setup_keymaster_overrides()`, detect partially-reset slots where the name persists but the code was already cleared. Force-reset such slots via `async_fire_clear_code()` and skip loading them as overrides.

### Fix 2: Post-clear verification (util.py)

After the successful `button.press` service call in `async_fire_clear_code()`, verify that the slot name was actually cleared. If it persists, force-clear it via `text.set_value` as a fallback.

### Tests

- Coordinator: startup detects partial reset and forces clear, skips fully empty slots, loads normal slots, handles force-reset failure gracefully
- Util: post-clear verifies name cleared, forces name clear on persist, handles force-clear failure, skips unknown/unavailable states

Closes #521