### PR TITLE
Fix(checkin): Drop unmonitored diag events

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -424,8 +424,14 @@ def async_register_keymaster_listener(
 
         monitored = coordinator.monitored_locknames
         if event_lockname not in monitored:
-            if diagnostics_enabled:
-                _record("rejected_not_monitored")
+            # Drop unmonitored-lock events without recording: in
+            # deployments with many RC integrations, every integration
+            # sees every event on the HA bus, and recording
+            # "rejected_not_monitored" would quickly flood the 10-entry
+            # ring buffer with noise from other integrations' locks.
+            # The "rejected_not_monitored" disposition string is
+            # retained as a reserved value for schema stability with
+            # downstream consumers but is no longer emitted.
             return
 
         # Validate state is unlocked

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -389,6 +389,20 @@ def async_register_keymaster_listener(
             if raw_lockname and isinstance(raw_lockname, str)
             else ""
         )
+
+        # Drop unmonitored-lock events as early as possible: in
+        # deployments with many RC integrations, every integration
+        # sees every event on the HA bus, and the unmonitored case
+        # is by far the hottest path. Recording these events with
+        # disposition "rejected_not_monitored" would flood the
+        # 10-entry diagnostics ring buffer with noise from other
+        # integrations' locks. The "rejected_not_monitored"
+        # disposition string is retained as a reserved value for
+        # schema stability with downstream consumers but is no
+        # longer emitted.
+        if event_lockname not in coordinator.monitored_locknames:
+            return
+
         code_slot_num = event_data.get("code_slot_num")
 
         diagnostics_enabled = config_entry.data.get(
@@ -421,18 +435,6 @@ def async_register_keymaster_listener(
             )
             if sensor is not None and sensor.hass is not None:
                 sensor.async_write_ha_state()
-
-        monitored = coordinator.monitored_locknames
-        if event_lockname not in monitored:
-            # Drop unmonitored-lock events without recording: in
-            # deployments with many RC integrations, every integration
-            # sees every event on the HA bus, and recording
-            # "rejected_not_monitored" would quickly flood the 10-entry
-            # ring buffer with noise from other integrations' locks.
-            # The "rejected_not_monitored" disposition string is
-            # retained as a reserved value for schema stability with
-            # downstream consumers but is no longer emitted.
-            return
 
         # Validate state is unlocked
         if event_data.get("state") != "unlocked":

--- a/tests/unit/test_keymaster_event_diagnostics.py
+++ b/tests/unit/test_keymaster_event_diagnostics.py
@@ -231,30 +231,33 @@ class TestDiagnosticsBuffer:
     ) -> None:
         """Twelve events leave exactly the last 10 in the buffer."""
         _setup_entry(hass, mock_checkin_coordinator, mock_checkin_config_entry)
+        # Widen the managed slot range so each event maps to a unique
+        # code_slot_num, allowing unambiguous assertions about which
+        # entries were evicted vs retained.
+        mock_checkin_coordinator.max_events = 12
         _set_diag(mock_checkin_config_entry, hass, True)
         async_register_keymaster_listener(hass, mock_checkin_config_entry)
 
         for i in range(12):
             # Use the monitored lockname so each event takes the
-            # accepted path and is recorded; vary code_slot_num within
-            # the configured range (start_slot=10, max_events=3) so we
-            # can identify the dropped ones.
+            # accepted path and is recorded. Vary code_slot_num
+            # uniquely across all 12 events (slots 10..21) so the
+            # ordering of retained entries can be verified exactly.
             hass.bus.async_fire(
                 "keymaster_lock_state_changed",
                 {
                     "lockname": "front_door",
                     "state": "unlocked",
-                    "code_slot_num": 10 + (i % 3),
+                    "code_slot_num": 10 + i,
                 },
             )
         await hass.async_block_till_done()
 
         buf = list(mock_checkin_coordinator.keymaster_event_diagnostics)
         assert len(buf) == 10
-        # The first two events (i=0,1) were evicted; i=2 is the oldest
-        # remaining and i=11 is the newest.
-        assert buf[0]["code_slot_num"] == 10 + (2 % 3)
-        assert buf[-1]["code_slot_num"] == 10 + (11 % 3)
+        # The first two events (slots 10 and 11) were evicted; slot 12
+        # is the oldest remaining and slot 21 is the newest.
+        assert [e["code_slot_num"] for e in buf] == list(range(12, 22))
 
     async def test_unmonitored_events_not_recorded(
         self,
@@ -380,9 +383,11 @@ class TestDiagnosticsBuffer:
     ) -> None:
         """Non-string lockname values do not crash; events are dropped.
 
-        Non-string locknames slugify to the empty string, which is not
-        in ``monitored_locknames``. After the unmonitored-event drop
-        fix (#529) these events are silently discarded rather than
+        Non-string locknames are treated as an empty slug (the
+        listener avoids calling ``slugify()`` on non-strings and sets
+        ``event_lockname`` to ``""`` directly), which is not in
+        ``monitored_locknames``. After the unmonitored-event drop fix
+        (#529) these events are silently discarded rather than
         recorded as ``rejected_not_monitored``.
         """
         _setup_entry(hass, mock_checkin_coordinator, mock_checkin_config_entry)

--- a/tests/unit/test_keymaster_event_diagnostics.py
+++ b/tests/unit/test_keymaster_event_diagnostics.py
@@ -127,14 +127,6 @@ class TestDiagnosticsBuffer:
         [
             (
                 {
-                    "lockname": "back_door",
-                    "state": "unlocked",
-                    "code_slot_num": 11,
-                },
-                "rejected_not_monitored",
-            ),
-            (
-                {
                     "lockname": "front_door",
                     "state": "locked",
                     "code_slot_num": 11,
@@ -243,18 +235,74 @@ class TestDiagnosticsBuffer:
         async_register_keymaster_listener(hass, mock_checkin_config_entry)
 
         for i in range(12):
-            # Vary lockname so we can identify the dropped ones; all
-            # take the rejected_not_monitored path.
+            # Use the monitored lockname so each event takes the
+            # accepted path and is recorded; vary code_slot_num within
+            # the configured range (start_slot=10, max_events=3) so we
+            # can identify the dropped ones.
             hass.bus.async_fire(
                 "keymaster_lock_state_changed",
-                {"lockname": f"other_{i}", "state": "unlocked", "code_slot_num": 11},
+                {
+                    "lockname": "front_door",
+                    "state": "unlocked",
+                    "code_slot_num": 10 + (i % 3),
+                },
             )
         await hass.async_block_till_done()
 
         buf = list(mock_checkin_coordinator.keymaster_event_diagnostics)
         assert len(buf) == 10
-        assert buf[0]["lockname"] == "other_2"
-        assert buf[-1]["lockname"] == "other_11"
+        # The first two events (i=0,1) were evicted; i=2 is the oldest
+        # remaining and i=11 is the newest.
+        assert buf[0]["code_slot_num"] == 10 + (2 % 3)
+        assert buf[-1]["code_slot_num"] == 10 + (11 % 3)
+
+    async def test_unmonitored_events_not_recorded(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Unmonitored-lock events must not consume buffer slots.
+
+        Regression test for #529: in deployments with many RC
+        integrations, every integration's listener sees events from
+        every Keymaster lock. Previously these were recorded with
+        disposition ``rejected_not_monitored`` and flooded the 10-entry
+        buffer, evicting useful signal from monitored locks. Now they
+        are dropped without recording.
+        """
+        _setup_entry(hass, mock_checkin_coordinator, mock_checkin_config_entry)
+        _set_diag(mock_checkin_config_entry, hass, True)
+        async_register_keymaster_listener(hass, mock_checkin_config_entry)
+
+        # 12 events from unmonitored locks — must NOT be recorded.
+        for i in range(12):
+            hass.bus.async_fire(
+                "keymaster_lock_state_changed",
+                {
+                    "lockname": f"other_{i}",
+                    "state": "unlocked",
+                    "code_slot_num": 11,
+                },
+            )
+        await hass.async_block_till_done()
+        assert len(mock_checkin_coordinator.keymaster_event_diagnostics) == 0
+
+        # One event for the monitored lock — must be recorded.
+        hass.bus.async_fire(
+            "keymaster_lock_state_changed",
+            {
+                "lockname": "front_door",
+                "state": "unlocked",
+                "code_slot_num": 11,
+            },
+        )
+        await hass.async_block_till_done()
+
+        buf = list(mock_checkin_coordinator.keymaster_event_diagnostics)
+        assert len(buf) == 1
+        assert buf[0]["lockname"] == "front_door"
+        assert buf[0]["disposition"] == "accepted"
 
     async def test_toggle_takes_effect_immediately(
         self,
@@ -302,10 +350,13 @@ class TestDiagnosticsBuffer:
         _set_diag(mock_checkin_config_entry, hass, True)
         async_register_keymaster_listener(hass, mock_checkin_config_entry)
 
-        # An event taking a rejected path must still write state
+        # An event taking a recorded rejected path must still write
+        # state. Use state=locked (rejected_state) on the monitored
+        # lockname so the event is recorded rather than silently
+        # dropped as unmonitored.
         hass.bus.async_fire(
             "keymaster_lock_state_changed",
-            {"lockname": "back_door", "state": "unlocked", "code_slot_num": 11},
+            {"lockname": "front_door", "state": "locked", "code_slot_num": 11},
         )
         await hass.async_block_till_done()
         sensor.async_write_ha_state.assert_called()
@@ -327,7 +378,13 @@ class TestDiagnosticsBuffer:
         mock_checkin_config_entry: MockConfigEntry,
         bad_lockname: object,
     ) -> None:
-        """Non-string lockname values do not crash and are coerced."""
+        """Non-string lockname values do not crash; events are dropped.
+
+        Non-string locknames slugify to the empty string, which is not
+        in ``monitored_locknames``. After the unmonitored-event drop
+        fix (#529) these events are silently discarded rather than
+        recorded as ``rejected_not_monitored``.
+        """
         _setup_entry(hass, mock_checkin_coordinator, mock_checkin_config_entry)
         _set_diag(mock_checkin_config_entry, hass, True)
         async_register_keymaster_listener(hass, mock_checkin_config_entry)
@@ -342,11 +399,9 @@ class TestDiagnosticsBuffer:
         )
         await hass.async_block_till_done()
 
-        buf = list(mock_checkin_coordinator.keymaster_event_diagnostics)
-        assert len(buf) == 1
-        assert buf[0]["lockname"] == str(bad_lockname)
-        assert buf[0]["lockname_slug"] == ""
-        assert buf[0]["disposition"] == "rejected_not_monitored"
+        # No crash; nothing recorded because the empty slug is not in
+        # monitored_locknames.
+        assert len(mock_checkin_coordinator.keymaster_event_diagnostics) == 0
 
 
 class TestDiagnosticsAttribute:


### PR DESCRIPTION
## Problem

The keymaster event diagnostics ring buffer (added in PR #526, released in v3.3.0) records every `keymaster_lock_state_changed` event the integration's bus listener sees — including events for locks NOT in `coordinator.monitored_locknames`, which were stored with disposition `rejected_not_monitored`.

The Home Assistant event bus is global. In multi-integration deployments every RC integration's listener fires for every keymaster event from every Keymaster lock. With **N** RC integrations and **M** Keymaster locks, each PIN entry generated N entries across the various ring buffers — only 1 was meaningful.

### Reported production context

10 RC integrations + 13 Keymaster locks. Diagnostics were working but flooded with unmonitored-lock noise, evicting useful signal from the 10-entry buffer within seconds.

## Fix

In `_handle_keymaster_event` drop events whose slugified lockname is not in `coordinator.monitored_locknames` **before** appending to the ring buffer. All other `_record(...)` calls remain unchanged.

The `rejected_not_monitored` disposition string is no longer emitted. It is preserved (mentioned in a code comment) as a reserved value so the diagnostic schema remains stable for downstream consumers.

## Trade-off

We lose the ability to surface a slugify mismatch (e.g., lockname changed in Keymaster but RC's config still has the old slug) as a "near miss" diagnostic. Given the noise levels in multi-integration deployments this is an acceptable trade-off.

## Tests

- Removed `rejected_not_monitored` case from the rejected-disposition parametrized test.
- Updated `test_ring_buffer_truncates_at_ten` to use the monitored lockname (the previous version relied on the now-removed recording path).
- Updated `test_non_string_lockname_defensive` to assert the buffer remains empty (non-string locknames slugify to `""` which is not monitored).
- Updated `test_recording_writes_sensor_state` rejected-path case to use a recorded disposition (`rejected_state` on the monitored lock).
- **New** regression test `test_unmonitored_events_not_recorded`: fires 12 unmonitored-lock events followed by 1 monitored event; asserts the buffer contains exactly the 1 monitored entry.

All 786 tests pass; ruff and mypy clean.

Closes #529