### PR TITLE
Docs(spec): Add 009 lock code buffer spec

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -25,6 +25,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-15
 - Home Assistant config entries (persisted via HA's `.storage/` JSON files) (007-honor-pms-times)
 - Python ≥3.14.2 + homeassistant core, voluptuous, icalendar, aiohttp (008-trim-event-names)
 - Home Assistant config entries (JSON-backed via `.storage/`) (008-trim-event-names)
+- Python 3.11+ + Home Assistant core, Keymaster integration, icalendar, voluptuous (009-lock-code-buffer)
+- HA config entries (persisted via `config_entry.data`) (009-lock-code-buffer)
 
 ## Project Structure
 
@@ -43,9 +45,9 @@ uv run ruff check custom_components/ tests/
 Python ≥3.14.2: Follow standard conventions, ruff formatting
 
 ## Recent Changes
+- 009-lock-code-buffer: Added Python 3.11+ + Home Assistant core, Keymaster integration, icalendar, voluptuous
 - 008-trim-event-names: Added Python ≥3.14.2 + homeassistant core, voluptuous, icalendar, aiohttp
 - 007-honor-pms-times: Added Python ≥ 3.14.2 + homeassistant (core), icalendar, voluptuous, x-wr-timezone, aiohttp
-- 005-fix-duplicate-slot: Added Python ≥3.13.2 + Home Assistant Core (≥2025.x), pytest-homeassistant-custom-component, Keymaster integration
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -25,7 +25,7 @@ Auto-generated from all feature plans. Last updated: 2026-05-15
 - Home Assistant config entries (persisted via HA's `.storage/` JSON files) (007-honor-pms-times)
 - Python ≥3.14.2 + homeassistant core, voluptuous, icalendar, aiohttp (008-trim-event-names)
 - Home Assistant config entries (JSON-backed via `.storage/`) (008-trim-event-names)
-- Python 3.11+ + Home Assistant core, Keymaster integration, icalendar, voluptuous (009-lock-code-buffer)
+- Python ≥3.14.2 + Home Assistant core, Keymaster integration, icalendar, voluptuous (009-lock-code-buffer)
 - HA config entries (persisted via `config_entry.data`) (009-lock-code-buffer)
 
 ## Project Structure
@@ -45,7 +45,7 @@ uv run ruff check custom_components/ tests/
 Python ≥3.14.2: Follow standard conventions, ruff formatting
 
 ## Recent Changes
-- 009-lock-code-buffer: Added Python 3.11+ + Home Assistant core, Keymaster integration, icalendar, voluptuous
+- 009-lock-code-buffer: Added Python ≥3.14.2 + Home Assistant core, Keymaster integration, icalendar, voluptuous
 - 008-trim-event-names: Added Python ≥3.14.2 + homeassistant core, voluptuous, icalendar, aiohttp
 - 007-honor-pms-times: Added Python ≥ 3.14.2 + homeassistant (core), icalendar, voluptuous, x-wr-timezone, aiohttp
 

--- a/specs/009-lock-code-buffer/checklists/requirements.md
+++ b/specs/009-lock-code-buffer/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Lock Code Buffer Times
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-07-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- FR-005 explicitly defines the scope boundary (what buffers do NOT affect), preventing scope creep.
+- Assumptions section documents reasonable defaults for Keymaster interaction, lock hardware precision, and overlapping windows.

--- a/specs/009-lock-code-buffer/contracts/internal-api.md
+++ b/specs/009-lock-code-buffer/contracts/internal-api.md
@@ -1,0 +1,150 @@
+# Internal API Contracts: Lock Code Buffer Times
+
+**Feature Branch**: `009-lock-code-buffer`
+**Date**: 2025-07-17
+
+> This feature has no external/REST/GraphQL APIs. All contracts are internal
+> Python function signatures and config entry schema changes.
+
+## Contract 1: Configuration Schema Additions
+
+### `const.py` — New Constants
+
+```python
+CONF_CODE_BUFFER_BEFORE: str = "code_buffer_before"
+CONF_CODE_BUFFER_AFTER: str = "code_buffer_after"
+DEFAULT_CODE_BUFFER_BEFORE: int = 0
+DEFAULT_CODE_BUFFER_AFTER: int = 0
+```
+
+### `config_flow.py` — Schema Fields (conditional on lock entry)
+
+```python
+# Added inside _get_schema when lock entry is configured:
+vol.Optional(
+    CONF_CODE_BUFFER_BEFORE,
+    default=_get_default(CONF_CODE_BUFFER_BEFORE, DEFAULT_CODE_BUFFER_BEFORE),
+): vol.All(vol.Coerce(int), vol.Range(min=0)),
+vol.Optional(
+    CONF_CODE_BUFFER_AFTER,
+    default=_get_default(CONF_CODE_BUFFER_AFTER, DEFAULT_CODE_BUFFER_AFTER),
+): vol.All(vol.Coerce(int), vol.Range(min=0)),
+```
+
+### `strings.json` — UI Labels
+
+```json
+{
+  "code_buffer_before": "Lock code buffer before check-in (minutes)",
+  "code_buffer_after": "Lock code buffer after checkout (minutes)"
+}
+```
+
+With descriptions:
+
+```json
+{
+  "code_buffer_before": "Minutes before check-in time that the lock code becomes active (0 = no buffer)",
+  "code_buffer_after": "Minutes after checkout time that the lock code remains active (0 = no buffer)"
+}
+```
+
+---
+
+## Contract 2: Coordinator Properties
+
+### `RentalControlCoordinator.__init__`
+
+```python
+self.code_buffer_before: int = int(
+    str(config.get(CONF_CODE_BUFFER_BEFORE, DEFAULT_CODE_BUFFER_BEFORE))
+)
+self.code_buffer_after: int = int(
+    str(config.get(CONF_CODE_BUFFER_AFTER, DEFAULT_CODE_BUFFER_AFTER))
+)
+```
+
+### `RentalControlCoordinator.update_config`
+
+```python
+self.code_buffer_before = int(
+    str(config.get(CONF_CODE_BUFFER_BEFORE, DEFAULT_CODE_BUFFER_BEFORE))
+)
+self.code_buffer_after = int(
+    str(config.get(CONF_CODE_BUFFER_AFTER, DEFAULT_CODE_BUFFER_AFTER))
+)
+```
+
+---
+
+## Contract 3: Buffer Application in Keymaster Service Calls
+
+### `async_fire_set_code(coordinator, event, slot: int) -> None`
+
+**Change**: Before sending `date_range_start` and `date_range_end` to Keymaster,
+apply buffer offsets:
+
+```python
+from datetime import timedelta
+
+# Compute buffered validity window
+buffered_start = event.extra_state_attributes["start"] - timedelta(
+    minutes=coordinator.code_buffer_before
+)
+buffered_end = event.extra_state_attributes["end"] + timedelta(
+    minutes=coordinator.code_buffer_after
+)
+
+# Use buffered values in service calls:
+# date_range_start → {"datetime": buffered_start}
+# date_range_end   → {"datetime": buffered_end}
+```
+
+### `async_fire_update_times(coordinator, event, slot: int) -> None`
+
+**Same change**: Apply identical buffer calculation before sending to Keymaster.
+
+---
+
+## Contract 4: Config Migration
+
+### `async_migrate_entry` — v9→v10
+
+```python
+# 9 -> 10: Add code buffer before/after to configuration
+if version == 9:
+    _LOGGER.debug("Migrating from version %s", version)
+
+    data = config_entry.data.copy()
+    data[CONF_CODE_BUFFER_BEFORE] = 0
+    data[CONF_CODE_BUFFER_AFTER] = 0
+    hass.config_entries.async_update_entry(
+        entry=config_entry,
+        unique_id=config_entry.unique_id,
+        data=data,
+        version=10,
+    )
+
+    version = 10
+    _LOGGER.debug("Migration to version %s complete", config_entry.version)
+```
+
+### `RentalControlFlowHandler.VERSION`
+
+```python
+VERSION = 10  # bumped from 9
+```
+
+---
+
+## Contract 5: Unchanged Interfaces (Explicit Non-Changes)
+
+The following interfaces are explicitly NOT modified:
+
+| Interface | Reason |
+|-----------|--------|
+| `event_overrides.async_update(slot, code, name, start, end, prefix)` | FR-005: unbuffered times for matching |
+| `event_overrides.verify_slot_ownership(slot, name)` | Uses stored unbuffered times |
+| `calsensor._event_attributes["start"]` / `["end"]` | Display and ETA use raw times |
+| `checkinsensor._tracked_event_start` / `_tracked_event_end` | Check-in timing uses raw times |
+| `EVENT_RENTAL_CONTROL_SET_CODE` event payload | Carries raw event times for automation consumers |

--- a/specs/009-lock-code-buffer/data-model.md
+++ b/specs/009-lock-code-buffer/data-model.md
@@ -1,0 +1,103 @@
+# Data Model: Lock Code Buffer Times
+
+**Feature Branch**: `009-lock-code-buffer`
+**Date**: 2025-07-17
+
+## Entities
+
+### Configuration Entity: Code Buffer Before
+
+| Property | Value |
+|----------|-------|
+| **Constant** | `CONF_CODE_BUFFER_BEFORE = "code_buffer_before"` |
+| **Default** | `DEFAULT_CODE_BUFFER_BEFORE = 0` |
+| **Type** | `int` (non-negative) |
+| **Storage** | `config_entry.data["code_buffer_before"]` |
+| **Validation** | `vol.All(vol.Coerce(int), vol.Range(min=0))` |
+| **Unit** | Minutes |
+| **Semantics** | Number of minutes before reservation start that lock code becomes valid |
+
+### Configuration Entity: Code Buffer After
+
+| Property | Value |
+|----------|-------|
+| **Constant** | `CONF_CODE_BUFFER_AFTER = "code_buffer_after"` |
+| **Default** | `DEFAULT_CODE_BUFFER_AFTER = 0` |
+| **Type** | `int` (non-negative) |
+| **Storage** | `config_entry.data["code_buffer_after"]` |
+| **Validation** | `vol.All(vol.Coerce(int), vol.Range(min=0))` |
+| **Unit** | Minutes |
+| **Semantics** | Number of minutes after reservation end that lock code remains valid |
+
+### Derived Value: Lock Code Validity Window
+
+| Property | Value |
+|----------|-------|
+| **Buffered Start** | `event_start - timedelta(minutes=code_buffer_before)` |
+| **Buffered End** | `event_end + timedelta(minutes=code_buffer_after)` |
+| **Not persisted** | Computed inline at Keymaster service call time |
+| **Consumers** | `async_fire_set_code`, `async_fire_update_times` only |
+
+## Relationships
+
+```text
+config_entry.data
+├── code_buffer_before: int    ──► RentalControlCoordinator.code_buffer_before
+├── code_buffer_after: int     ──► RentalControlCoordinator.code_buffer_after
+│
+RentalControlCoordinator
+├── .code_buffer_before ──► async_fire_set_code() ──► Keymaster date_range_start
+├── .code_buffer_after  ──► async_fire_set_code() ──► Keymaster date_range_end
+├── .code_buffer_before ──► async_fire_update_times() ──► Keymaster date_range_start
+└── .code_buffer_after  ──► async_fire_update_times() ──► Keymaster date_range_end
+```
+
+## State Transitions
+
+### Config Version Migration
+
+```text
+Version 9 ──► Version 10
+  Added: code_buffer_before = 0
+  Added: code_buffer_after = 0
+```
+
+### Buffer Value Lifecycle
+
+```text
+[Config Entry Created / Migrated]
+        │
+        ▼
+  code_buffer_before = 0 (default)
+  code_buffer_after = 0 (default)
+        │
+        ▼ (user modifies via options flow)
+  code_buffer_before = N
+  code_buffer_after = M
+        │
+        ▼ (update_listener fires)
+  coordinator.update_config(new_data)
+        │
+        ▼ (coordinator.async_request_refresh)
+  All active slots reprogrammed with new buffer offsets
+```
+
+## Validation Rules
+
+| Field | Rule | Error Key |
+|-------|------|-----------|
+| `code_buffer_before` | Must be non-negative integer (≥0) | Enforced by `vol.Range(min=0)` — no custom error needed |
+| `code_buffer_after` | Must be non-negative integer (≥0) | Enforced by `vol.Range(min=0)` — no custom error needed |
+
+## Boundary: What Buffers Do NOT Affect
+
+Per FR-005, the following use **unbuffered** times and must not be modified:
+
+| Component | File | Remains Unbuffered |
+|-----------|------|--------------------|
+| Calendar event display | `sensors/calsensor.py` | `_event_attributes["start"]`, `["end"]` |
+| Check-in sensor tracking | `sensors/checkinsensor.py` | `_tracked_event_start`, `_tracked_event_end` |
+| Event override matching | `event_overrides.py` | `override["start"]`, `override["end"]` |
+| Auto check-in/checkout timers | `sensors/checkinsensor.py` | Timer scheduling uses event times directly |
+| ETA calculations | `sensors/calsensor.py` | Uses raw `event.start` |
+| Slot ownership verification | `event_overrides.py` | Compares raw event times |

--- a/specs/009-lock-code-buffer/plan.md
+++ b/specs/009-lock-code-buffer/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Lock Code Buffer Times
+
+**Branch**: `009-lock-code-buffer` | **Date**: 2025-07-17 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/009-lock-code-buffer/spec.md`
+
+## Summary
+
+Add configurable pre-check-in and post-checkout buffer times (in minutes) for lock codes. The buffer offsets are applied only to the Keymaster `date_range_start`/`date_range_end` values sent via `async_fire_set_code` and `async_fire_update_times`. All internal integration logic (calendar display, check-in sensors, event overrides, auto check-in/checkout timers) continues to use unbuffered reservation times. Implementation follows the established `trim_names` pattern: new constants, config flow fields (conditional on lock entry), coordinator properties, migration v9→v10, and lazy update on next refresh cycle.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: Home Assistant core, Keymaster integration, icalendar, voluptuous
+**Storage**: HA config entries (persisted via `config_entry.data`)
+**Testing**: pytest via `uv run pytest tests/`
+**Target Platform**: Home Assistant (Linux/Docker, Raspberry Pi to full servers)
+**Project Type**: Single project — Home Assistant custom integration (HACS)
+**Performance Goals**: Lock code generation must complete within sensor update cycle (~30s); buffer calculation is O(1) datetime arithmetic — no performance concern
+**Constraints**: Must not block HA event loop; minute-granularity datetime arithmetic
+**Scale/Scope**: 2 new config fields, ~6 files modified, ~8 test files added/modified
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I: Code Quality & Testing | ✅ PASS | New code will have type hints, docstrings, full test coverage |
+| II: Atomic Commit Discipline | ✅ PASS | Feature decomposes into ~6 atomic commits (const, migration, coordinator, config_flow, util, tests) |
+| III: Licensing & Attribution | ✅ PASS | All modified files already have SPDX headers; new files will include them |
+| IV: Pre-Commit Integrity | ✅ PASS | ruff, mypy, interrogate, reuse-tool will be run before each commit |
+| V: Agent Co-Authorship & DCO | ✅ PASS | Commits will include Co-authored-by and Signed-off-by trailers |
+| VI: User Experience Consistency | ✅ PASS | Buffer fields follow existing config flow patterns; conditional on lock entry like trim_names |
+| VII: Performance Requirements | ✅ PASS | Buffer is O(1) timedelta addition; no impact on refresh cycle or event loop |
+
+**Gate result: PASS** — No violations. Proceeding to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-lock-code-buffer/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (internal API contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+custom_components/rental_control/
+├── __init__.py          # Migration logic (v9→v10)
+├── config_flow.py       # Options flow — buffer fields
+├── const.py             # CONF_CODE_BUFFER_BEFORE, CONF_CODE_BUFFER_AFTER, defaults
+├── coordinator.py       # Buffer properties, update_config
+├── sensors/
+│   └── calsensor.py     # (unchanged — passes event attrs to util functions)
+├── util.py              # async_fire_set_code / async_fire_update_times — apply buffer offset
+├── event_overrides.py   # (unchanged — uses unbuffered times for internal matching)
+└── strings.json         # UI labels for buffer fields
+
+tests/
+├── unit/
+│   ├── test_config_flow.py   # Buffer field validation
+│   ├── test_coordinator.py   # Buffer property tests
+│   ├── test_init.py          # Migration v9→v10 tests
+│   └── test_util.py          # Buffer offset application tests
+└── integration/
+    └── test_refresh_cycle.py  # Buffer changes propagate on refresh
+```
+
+**Structure Decision**: Single-project Home Assistant custom integration. All source under `custom_components/rental_control/`, all tests under `tests/`.
+
+## Complexity Tracking
+
+> No violations to justify — all gates pass.

--- a/specs/009-lock-code-buffer/plan.md
+++ b/specs/009-lock-code-buffer/plan.md
@@ -9,7 +9,7 @@ Add configurable pre-check-in and post-checkout buffer times (in minutes) for lo
 
 ## Technical Context
 
-**Language/Version**: Python 3.11+
+**Language/Version**: Python ≥3.14.2
 **Primary Dependencies**: Home Assistant core, Keymaster integration, icalendar, voluptuous
 **Storage**: HA config entries (persisted via `config_entry.data`)
 **Testing**: pytest via `uv run pytest tests/`

--- a/specs/009-lock-code-buffer/quickstart.md
+++ b/specs/009-lock-code-buffer/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart: Lock Code Buffer Times
+
+**Feature Branch**: `009-lock-code-buffer`
+**Date**: 2025-07-17
+
+## Overview
+
+This feature adds two new configuration options — "code buffer before" and "code buffer after" — that offset the lock code validity window sent to Keymaster. A before-buffer of 30 minutes means a 3:00 PM check-in produces a lock code valid from 2:30 PM. An after-buffer of 15 minutes means an 11:00 AM checkout keeps the code active until 11:15 AM.
+
+## Implementation Scope
+
+### Files to Modify (~6 files)
+
+| File | Change |
+|------|--------|
+| `const.py` | Add `CONF_CODE_BUFFER_BEFORE`, `CONF_CODE_BUFFER_AFTER`, `DEFAULT_CODE_BUFFER_BEFORE`, `DEFAULT_CODE_BUFFER_AFTER` |
+| `__init__.py` | Add v9→v10 migration |
+| `coordinator.py` | Add `code_buffer_before`/`code_buffer_after` properties to `__init__` and `update_config` |
+| `config_flow.py` | Add buffer fields to `_get_schema` (conditional on lock entry); bump VERSION to 10 |
+| `util.py` | Apply buffer offsets in `async_fire_set_code` and `async_fire_update_times` |
+| `strings.json` | Add labels and descriptions for both buffer fields |
+
+### Files NOT Modified
+
+| File | Why |
+|------|-----|
+| `event_overrides.py` | FR-005: overrides use unbuffered times |
+| `sensors/calsensor.py` | Event attributes remain unbuffered |
+| `sensors/checkinsensor.py` | Check-in timing uses raw event times |
+
+## Key Design Decisions
+
+1. **Buffer applied at Keymaster call site only**: The offset is computed in `async_fire_set_code`/`async_fire_update_times` right before the service call. This prevents contamination of all other consumers.
+
+2. **Conditional visibility in config flow**: Buffer fields only appear when a lock entry is selected (FR-008). Implemented by conditionally extending the schema based on `CONF_LOCK_ENTRY` value.
+
+3. **No upper bound validation**: Per spec edge cases, large buffers are legitimate (e.g., 24-hour buffers for cleaning crews).
+
+4. **Lazy update on refresh**: When buffer values change, active slots are updated on the next coordinator refresh cycle — consistent with `trim_names` pattern.
+
+## Development Workflow
+
+### Prerequisites
+
+```bash
+# From repo root
+uv sync  # install dependencies
+```
+
+### Run Tests
+
+```bash
+uv run pytest tests/ -v
+```
+
+### Commit Pattern (Atomic Commits)
+
+Suggested commit sequence:
+
+1. `Feat: add CONF_CODE_BUFFER constants to const.py`
+2. `Feat: add v9-to-v10 config migration for buffer fields`
+3. `Feat: add buffer properties to coordinator`
+4. `Feat: add buffer fields to config flow schema`
+5. `Feat: apply buffer offsets in Keymaster service calls`
+6. `Feat: add strings.json labels for buffer fields`
+7. `Test: add unit tests for buffer functionality`
+
+Each commit must pass all pre-commit hooks (`ruff`, `mypy`, `interrogate`, `reuse-tool`, `gitlint`).
+
+## Testing Strategy
+
+| Test Area | File | What to Test |
+|-----------|------|-------------|
+| Constants | `test_util.py` or new | Constants exist with correct defaults |
+| Migration | `test_init.py` | v9→v10 adds both fields with default 0 |
+| Coordinator | `test_coordinator.py` | Properties initialized from config; update_config picks up changes |
+| Config flow | `test_config_flow.py` | Buffer fields present when lock configured; absent when not; validation rejects negative values |
+| Buffer logic | `test_util.py` | `async_fire_set_code` sends buffered start/end to Keymaster; 0 buffer sends unbuffered times |
+| Integration | `test_refresh_cycle.py` | Buffer change propagates to active slots on refresh |

--- a/specs/009-lock-code-buffer/research.md
+++ b/specs/009-lock-code-buffer/research.md
@@ -1,0 +1,181 @@
+# Research: Lock Code Buffer Times
+
+**Feature Branch**: `009-lock-code-buffer`
+**Date**: 2025-07-17
+
+## Research Task 1: Where to Apply Buffer Offsets
+
+**Question**: Where in the code path should buffer offsets be applied to lock code validity windows?
+
+**Findings**:
+
+The lock code validity window (`date_range_start` / `date_range_end`) is sent to Keymaster in two functions in `util.py`:
+
+1. **`async_fire_set_code`** (line ~286): Called when a new slot is reserved. Sets `date_range_start` and `date_range_end` from `event.extra_state_attributes["start"]` and `event.extra_state_attributes["end"]` (lines 359–366).
+
+2. **`async_fire_update_times`** (line ~425): Called when times change on an existing slot. Also reads from `event.extra_state_attributes["start"]` and `event.extra_state_attributes["end"]` (lines 448–458).
+
+Both functions already receive the `coordinator` as their first argument, making it trivial to read `coordinator.code_buffer_before` and `coordinator.code_buffer_after`.
+
+**Decision**: Apply buffer offsets in `async_fire_set_code` and `async_fire_update_times` at the point where `date_range_start` and `date_range_end` values are prepared for the Keymaster service calls.
+
+**Rationale**: This is the narrowest insertion point that affects only the Keymaster-bound datetime values. The `event.extra_state_attributes["start"]` and `["end"]` values remain unbuffered, preserving correct behavior for all other consumers (check-in sensor, calendar display, event overrides, auto timers).
+
+**Alternatives considered**:
+- Applying offset in `calsensor.py` when setting `_event_attributes["start"]`/`["end"]`: Rejected because it would contaminate all downstream consumers (check-in sensor timing, display, ETA calculations) violating FR-005.
+- Adding separate `buffered_start`/`buffered_end` attributes to event state: Rejected as unnecessary complexity — only the Keymaster service calls need buffered values, and the buffer can be applied inline.
+
+---
+
+## Research Task 2: Config Flow Pattern for Lock-Conditional Fields
+
+**Question**: How should buffer fields be conditionally shown only when a lock entry is configured?
+
+**Findings**:
+
+The config flow schema in `config_flow.py` (`_get_schema`, line 224) builds a single `vol.Schema`. Fields like `CONF_TRIM_NAMES` and `CONF_MAX_NAME_LENGTH` are included unconditionally in the schema but are functionally relevant only when a lock is configured. The schema does not currently have conditional visibility logic — all fields are always shown.
+
+However, per FR-008, buffer fields should "only be visible in the options flow when a lock entry is configured." The current pattern shows all lock-related fields unconditionally. To maintain pattern consistency while honoring FR-008, the buffer fields should be added alongside `CONF_TRIM_NAMES` and `CONF_MAX_NAME_LENGTH` in the same schema section. The visibility constraint can be implemented by adding the buffer fields conditionally when the current `default_dict` has a non-None `CONF_LOCK_ENTRY`.
+
+**Decision**: Add buffer fields to `_get_schema` as `vol.Optional` entries alongside `CONF_TRIM_NAMES`. Make them conditionally included in the schema when `CONF_LOCK_ENTRY` is present and not None/`"(none)"` in the defaults.
+
+**Rationale**: Follows existing patterns for lock-related config fields while honoring FR-008's visibility requirement.
+
+**Alternatives considered**:
+- Always showing buffer fields (matching trim_names pattern): Simpler but violates FR-008 which explicitly requires conditional visibility.
+- Multi-step config flow: Overkill for 2 additional fields; would break existing UX patterns.
+
+---
+
+## Research Task 3: Migration Pattern (v9→v10)
+
+**Question**: What is the established migration pattern, and how should v9→v10 be implemented?
+
+**Findings**:
+
+Migration in `__init__.py` (`async_migrate_entry`, line 164) follows a sequential version-by-version upgrade pattern. Each version bump:
+1. Copies `config_entry.data`
+2. Adds new fields with default values
+3. Calls `hass.config_entries.async_update_entry()` with the new data and incremented version
+4. The config flow handler's `VERSION` class attribute must also be bumped
+
+The most recent migration (v8→v9, line 261) adds `CONF_TRIM_NAMES = False` and `CONF_MAX_NAME_LENGTH = DEFAULT_MAX_NAME_LENGTH`.
+
+**Decision**: Add v9→v10 migration block that adds `CONF_CODE_BUFFER_BEFORE = 0` and `CONF_CODE_BUFFER_AFTER = 0`. Bump `RentalControlFlowHandler.VERSION` from 9 to 10.
+
+**Rationale**: Exact match to established pattern. Default of 0 preserves existing behavior per FR-003.
+
+**Alternatives considered**: None — the pattern is well-established and mandatory.
+
+---
+
+## Research Task 4: Coordinator Property Pattern
+
+**Question**: How should buffer values be stored and updated in the coordinator?
+
+**Findings**:
+
+The `RentalControlCoordinator.__init__` (line 92) reads all config values from `config_entry.data` into instance attributes. The `update_config` method (line 527) re-reads them when options change. Both follow the same pattern:
+
+```python
+# In __init__:
+self.trim_names: bool = bool(config.get(CONF_TRIM_NAMES, DEFAULT_TRIM_NAMES))
+
+# In update_config:
+self.trim_names = bool(config.get(CONF_TRIM_NAMES, DEFAULT_TRIM_NAMES))
+```
+
+**Decision**: Add `self.code_buffer_before: int` and `self.code_buffer_after: int` to both `__init__` and `update_config` following the same pattern.
+
+**Rationale**: Consistent with all existing config property patterns. The coordinator already passes `self` to `async_fire_set_code` and `async_fire_update_times`, so no additional plumbing is needed.
+
+**Alternatives considered**: None — pattern is mandatory for consistency.
+
+---
+
+## Research Task 5: Buffer Application in `async_fire_set_code` / `async_fire_update_times`
+
+**Question**: What is the exact mechanism to apply the buffer offset?
+
+**Findings**:
+
+The `event.extra_state_attributes["start"]` and `["end"]` values are `datetime` objects (set in `calsensor.py` line 390–391 from `CalendarEvent.start`/`.end`). These are timezone-aware datetimes.
+
+Buffer application is straightforward datetime arithmetic:
+```python
+from datetime import timedelta
+
+buffered_start = event.extra_state_attributes["start"] - timedelta(minutes=coordinator.code_buffer_before)
+buffered_end = event.extra_state_attributes["end"] + timedelta(minutes=coordinator.code_buffer_after)
+```
+
+The buffered values replace the raw values only in the Keymaster service call payloads.
+
+**Decision**: Compute buffered datetimes inline in both `async_fire_set_code` and `async_fire_update_times`, using them only in the `date_range_start`/`date_range_end` service call data dicts.
+
+**Rationale**: Minimal change, no side effects, preserves unbuffered values in event attributes.
+
+**Alternatives considered**:
+- Creating a helper function `apply_buffer(start, end, coordinator) -> (start, end)`: Viable but adds indirection for a two-line calculation. Could be added if more call sites emerge.
+
+---
+
+## Research Task 6: Event Overrides Interaction
+
+**Question**: Should event overrides store buffered or unbuffered times?
+
+**Findings**:
+
+`event_overrides.py` stores override start/end times for slot ownership verification and reconciliation. The `EventOverrides.async_update` method receives `start_time` and `end_time` from `calsensor.py` (line 547–553). These are the raw calendar event times.
+
+FR-005 explicitly states: "Buffer values MUST NOT affect ... event override matching."
+
+The override times are used for:
+- Slot ownership verification (`verify_slot_ownership`)
+- Duplicate detection / reconciliation
+- Time-change detection (triggering `async_fire_update_times`)
+
+All of these comparisons must use unbuffered times to maintain correct matching.
+
+**Decision**: Event overrides continue to store and compare unbuffered times. No changes to `event_overrides.py`.
+
+**Rationale**: FR-005 compliance. Buffered times would break slot ownership verification since the override would no longer match the calendar event times.
+
+**Alternatives considered**: None — FR-005 is explicit.
+
+---
+
+## Research Task 7: Validation Rules for Buffer Values
+
+**Question**: What validation should buffer values have?
+
+**Findings**:
+
+FR-004 states: "Both buffer options MUST accept only non-negative integer values (minimum 0)."
+
+The edge cases section confirms: "No upper-bound validation is enforced since legitimate use cases for large buffers exist."
+
+Voluptuous provides `vol.All(vol.Coerce(int), vol.Range(min=0))` for this pattern. The config flow already uses similar patterns (e.g., `vol.Range(min=0.5, max=48.0)` for cleaning_window).
+
+**Decision**: Use `vol.All(vol.Coerce(int), vol.Range(min=0))` for both buffer fields in the schema.
+
+**Rationale**: Matches FR-004 exactly and follows existing voluptuous patterns in the codebase.
+
+**Alternatives considered**:
+- Adding an upper bound: Rejected per spec edge cases — "legitimate use cases for large buffers exist."
+- Using `cv.positive_int`: This requires ≥1, not ≥0, so it's incorrect for this use case.
+
+---
+
+## Summary
+
+All unknowns resolved. No NEEDS CLARIFICATION items remain. Key decisions:
+
+| Area | Decision |
+|------|----------|
+| Buffer insertion point | `async_fire_set_code` and `async_fire_update_times` in `util.py` |
+| Config flow | Conditional buffer fields alongside existing lock-related options |
+| Migration | v9→v10, both buffers default to 0 |
+| Coordinator | New `code_buffer_before`/`code_buffer_after` int properties |
+| Event overrides | Unchanged — unbuffered times per FR-005 |
+| Validation | Non-negative integer, no upper bound |

--- a/specs/009-lock-code-buffer/spec.md
+++ b/specs/009-lock-code-buffer/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Lock Code Buffer Times
+
+**Feature Branch**: `009-lock-code-buffer`
+**Created**: 2025-07-17
+**Status**: Draft
+**Input**: User description: "Add configurable pre/post buffer times for lock codes. Some property managers need lock codes to activate before the scheduled check-in time and/or remain active after the scheduled checkout time."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Pre-Buffer for Early Guest Arrival (Priority: P1)
+
+As a property manager, I want to set a buffer period before check-in so that lock codes activate early, giving guests who arrive ahead of schedule immediate access without needing to contact me.
+
+**Why this priority**: This is the primary use case driving the feature. Early arrivals are the most common timing friction point for property managers, and providing seamless early access reduces guest frustration and support burden.
+
+**Independent Test**: Can be fully tested by configuring a before-buffer value and verifying that the lock code validity start time is shifted earlier by the configured number of minutes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the integration is configured with a 30-minute before-buffer, **When** a lock code is programmed for a reservation starting at 3:00 PM, **Then** the lock code becomes valid at 2:30 PM.
+2. **Given** the integration is configured with a 0-minute before-buffer (default), **When** a lock code is programmed, **Then** the lock code validity start matches the event start time exactly.
+3. **Given** a guest arrives 20 minutes early and the before-buffer is 30 minutes, **When** the guest enters their lock code, **Then** the code works and the check-in sensor transitions from "awaiting check-in" to "checked in."
+
+---
+
+### User Story 2 - Configure Post-Buffer for Late Checkout Grace (Priority: P2)
+
+As a property manager, I want to set a buffer period after checkout so that lock codes remain active slightly past the scheduled checkout time, accommodating guests who are running a few minutes behind.
+
+**Why this priority**: Late checkouts are common and a deactivated code at the exact checkout minute creates a poor guest experience. This complements the pre-buffer and completes the full buffer feature.
+
+**Independent Test**: Can be fully tested by configuring an after-buffer value and verifying that the lock code validity end time is extended by the configured number of minutes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the integration is configured with a 15-minute after-buffer, **When** a lock code is programmed for a reservation ending at 11:00 AM, **Then** the lock code remains valid until 11:15 AM.
+2. **Given** the integration is configured with a 0-minute after-buffer (default), **When** a lock code is programmed, **Then** the lock code validity end matches the event end time exactly.
+
+---
+
+### User Story 3 - Adjust Buffer Settings for Active Reservations (Priority: P3)
+
+As a property manager, I want to change buffer settings and have them apply to currently active reservation lock codes on the next refresh cycle, so I can adjust timing without manually reprogramming locks.
+
+**Why this priority**: Allows managers to fine-tune buffer settings after initial setup without disrupting active reservations. This is a natural follow-on once buffers are configured.
+
+**Independent Test**: Can be fully tested by changing buffer values in the options flow while an active reservation exists and verifying the lock code date range updates on the next coordinator refresh.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active reservation has a lock code programmed with a 30-minute before-buffer, **When** the manager changes the before-buffer to 60 minutes, **Then** the lock code validity start is updated to reflect the new buffer on the next refresh cycle.
+2. **Given** buffer values are changed, **When** the next coordinator refresh occurs, **Then** all active lock code slots are reprogrammed with the updated buffer-adjusted date ranges.
+
+---
+
+### User Story 4 - Seamless Upgrade for Existing Users (Priority: P1)
+
+As an existing user upgrading the integration, I want my current behavior to remain unchanged until I explicitly configure buffer times, so the upgrade does not alter my lock code timing.
+
+**Why this priority**: Equal to P1 because breaking existing users on upgrade is unacceptable. Default buffer values of 0 ensure backward compatibility.
+
+**Independent Test**: Can be fully tested by upgrading from config version 9 to 10 and verifying that both buffer values default to 0 and all lock code timing remains identical to pre-upgrade behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is running config version 9, **When** the integration upgrades to config version 10, **Then** both buffer options are added with a default value of 0.
+2. **Given** a freshly upgraded installation with default buffer values, **When** lock codes are programmed, **Then** the lock code date ranges are identical to what they were before the upgrade.
+
+---
+
+### Edge Cases
+
+- What happens when the before-buffer is larger than the time between consecutive reservations? The buffered start of the next reservation may overlap with the (potentially buffered) end of the previous one. Each reservation's lock code operates independently; the lock itself handles overlapping valid windows for different codes.
+- What happens when a user enters a very large buffer value (e.g., 1440 minutes / 24 hours)? The system accepts any non-negative integer. The resulting lock code window extends accordingly. No upper-bound validation is enforced since legitimate use cases for large buffers exist (e.g., multi-day early access for cleaning crews).
+- What happens when buffer values are changed while no lock entry is configured? The buffer options are only visible and editable when a lock entry is configured. The values are stored but have no effect until a lock is associated.
+- How does the system handle a buffer that extends the code validity across a date boundary? The buffered datetime is calculated as a simple time offset; crossing midnight or date boundaries is handled naturally by datetime arithmetic.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a "code buffer before" configuration option that specifies the number of minutes before a reservation's start time that the lock code should activate.
+- **FR-002**: System MUST provide a "code buffer after" configuration option that specifies the number of minutes after a reservation's end time that the lock code should deactivate.
+- **FR-003**: Both buffer options MUST default to 0 minutes, preserving existing behavior for new and upgraded installations.
+- **FR-004**: Both buffer options MUST accept only non-negative integer values (minimum 0).
+- **FR-005**: Buffer values MUST only affect the lock code validity window sent to the lock management system (Keymaster date range start/end). They MUST NOT affect calendar event display times, check-in/checkout sensor transition timing, event override matching, or auto check-in/checkout timer scheduling.
+- **FR-006**: System MUST subtract the "code buffer before" minutes from the reservation start time when setting the lock code validity start.
+- **FR-007**: System MUST add the "code buffer after" minutes to the reservation end time when setting the lock code validity end.
+- **FR-008**: Buffer configuration options MUST only be visible in the options flow when a lock entry is configured (consistent with existing lock-related option visibility).
+- **FR-009**: System MUST migrate existing configurations from version 9 to version 10, adding both buffer options with default value 0.
+- **FR-010**: When buffer values are changed, existing active lock code slots MUST be updated with the new buffer-adjusted date ranges on the next coordinator refresh cycle (lazy update).
+- **FR-011**: When a guest arrives within the before-buffer window and uses their lock code, the check-in sensor MUST correctly transition from "awaiting check-in" to "checked in" upon receiving the lock state change event. This behavior requires Keymaster monitoring to be enabled; in automatic check-in mode, the transition occurs at the unbuffered event start time per FR-005.
+
+### Key Entities
+
+- **Code Buffer Before**: An integration-level configuration value (non-negative integer, minutes) representing how far in advance of a reservation's start time the associated lock code should become valid.
+- **Code Buffer After**: An integration-level configuration value (non-negative integer, minutes) representing how long after a reservation's end time the associated lock code should remain valid.
+- **Lock Code Validity Window**: The effective start and end datetimes sent to Keymaster, calculated as the reservation's start/end times adjusted by the respective buffer values.
+
+## Assumptions
+
+- Keymaster correctly enforces the date range start/end values it receives; no additional validation of buffered times is needed on the Rental Control side.
+- The lock hardware supports time precision to the minute, which aligns with the minute-granularity buffer configuration.
+- Overlapping lock code validity windows for consecutive reservations are handled gracefully by Keymaster and the lock hardware (different codes for different slots).
+- The lazy update approach (applying buffer changes on the next refresh cycle) is acceptable and consistent with existing patterns like trim_names behavior.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Property managers can configure before and after buffer times in under 1 minute through the existing options flow.
+- **SC-002**: Lock codes activate exactly at the configured number of minutes before the reservation start time, accurate to the minute.
+- **SC-003**: Lock codes deactivate exactly at the configured number of minutes after the reservation end time, accurate to the minute.
+- **SC-004**: Existing users upgrading to the new version experience zero change in lock code timing behavior without any manual action.
+- **SC-005**: All internal integration logic (calendar display, check-in sensors, event overrides, auto check-in/checkout timers) continues to use unbuffered reservation times, with no observable side effects from buffer configuration.
+- **SC-006**: Changes to buffer values are reflected in active lock code slots within one coordinator refresh cycle.
+- **SC-007**: Guests arriving within the before-buffer window can use their lock code and are correctly recorded as checked in.

--- a/specs/009-lock-code-buffer/tasks.md
+++ b/specs/009-lock-code-buffer/tasks.md
@@ -1,0 +1,227 @@
+# Tasks: Lock Code Buffer Times
+
+**Input**: Design documents from `/specs/009-lock-code-buffer/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: Included — plan.md specifies ~8 test files added/modified; existing test files confirmed in `tests/unit/` and `tests/integration/`.
+
+**Organization**: Tasks grouped by user story. US1 (pre-buffer) and US2 (post-buffer) share implementation files since both buffers are applied in the same code paths; US2 phase focuses on additional test coverage for the after-buffer specifically.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Source**: `custom_components/rental_control/` at repository root
+- **Tests**: `tests/unit/`, `tests/integration/` at repository root
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add constants and UI strings that all subsequent phases depend on
+
+- [ ] T001 Add CONF_CODE_BUFFER_BEFORE, CONF_CODE_BUFFER_AFTER, DEFAULT_CODE_BUFFER_BEFORE, DEFAULT_CODE_BUFFER_AFTER constants to custom_components/rental_control/const.py
+- [ ] T002 [P] Add UI labels and descriptions for code_buffer_before and code_buffer_after fields to custom_components/rental_control/strings.json
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Migration, VERSION bump, and coordinator properties that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Add v9→v10 migration block that adds CONF_CODE_BUFFER_BEFORE=0 and CONF_CODE_BUFFER_AFTER=0 to custom_components/rental_control/__init__.py
+- [ ] T004 [P] Bump RentalControlFlowHandler.VERSION from 9 to 10 in custom_components/rental_control/config_flow.py
+- [ ] T005 Add code_buffer_before and code_buffer_after int properties to __init__ and update_config methods in custom_components/rental_control/coordinator.py
+
+**Checkpoint**: Foundation ready — constants defined, migration handles upgrade, coordinator exposes buffer values
+
+---
+
+## Phase 3: User Story 4 — Seamless Upgrade for Existing Users (Priority: P1)
+
+**Goal**: Existing users upgrading from config v9 experience zero change in lock code timing; both buffer values default to 0
+
+**Independent Test**: Upgrade from config version 9 to 10 and verify both buffer values default to 0 and all lock code timing remains identical to pre-upgrade behavior
+
+### Tests for User Story 4
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation tasks in later phases confirm behavior**
+
+- [ ] T006 [US4] Add v9→v10 migration test verifying both buffer fields are added with default 0 in tests/unit/test_init.py
+- [ ] T007 [P] [US4] Add coordinator initialization test verifying code_buffer_before=0 and code_buffer_after=0 from migrated config in tests/unit/test_coordinator.py
+
+**Checkpoint**: Migration correctness verified — upgrading users get default 0 buffers with no behavior change
+
+---
+
+## Phase 4: User Story 1 — Configure Pre-Buffer for Early Guest Arrival (Priority: P1) 🎯 MVP
+
+**Goal**: Property managers can set a before-buffer so lock codes activate N minutes before check-in time
+
+**Independent Test**: Configure a before-buffer value and verify lock code validity start is shifted earlier by the configured minutes
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T008 [P] [US1] Add config flow test verifying buffer fields appear when lock entry is configured and are hidden when no lock entry in tests/unit/test_config_flow.py
+- [ ] T009 [P] [US1] Add config flow validation test verifying negative buffer values are rejected in tests/unit/test_config_flow.py
+- [ ] T010 [P] [US1] Add unit test verifying async_fire_set_code sends buffered date_range_start (start - before_buffer) to Keymaster in tests/unit/test_util.py
+- [ ] T011 [P] [US1] Add unit test verifying async_fire_update_times sends buffered date_range_start (start - before_buffer) to Keymaster in tests/unit/test_util.py
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Add before-buffer and after-buffer fields to _get_schema conditional on CONF_LOCK_ENTRY being configured in custom_components/rental_control/config_flow.py
+- [ ] T013 [US1] Apply buffer offsets to date_range_start and date_range_end in async_fire_set_code in custom_components/rental_control/util.py
+- [ ] T014 [US1] Apply buffer offsets to date_range_start and date_range_end in async_fire_update_times in custom_components/rental_control/util.py
+
+**Checkpoint**: Pre-buffer fully functional — lock codes activate early by configured minutes; config flow shows buffer fields when lock is configured
+
+---
+
+## Phase 5: User Story 2 — Configure Post-Buffer for Late Checkout Grace (Priority: P2)
+
+**Goal**: Property managers can set an after-buffer so lock codes remain active N minutes after checkout time
+
+**Independent Test**: Configure an after-buffer value and verify lock code validity end is extended by the configured minutes
+
+> **Note**: Implementation was delivered in Phase 4 (T012–T014) since both buffers share the same code paths. This phase adds after-buffer-specific test coverage.
+
+### Tests for User Story 2
+
+- [ ] T015 [US2] Add unit test verifying async_fire_set_code sends buffered date_range_end (end + after_buffer) to Keymaster in tests/unit/test_util.py
+- [ ] T016 [P] [US2] Add unit test verifying async_fire_update_times sends buffered date_range_end (end + after_buffer) to Keymaster in tests/unit/test_util.py
+- [ ] T017 [P] [US2] Add unit test verifying zero-buffer defaults produce unbuffered date ranges identical to pre-feature behavior in tests/unit/test_util.py
+
+**Checkpoint**: Post-buffer verified — lock codes stay active past checkout by configured minutes; zero-buffer preserves existing behavior
+
+---
+
+## Phase 6: User Story 3 — Adjust Buffer Settings for Active Reservations (Priority: P3)
+
+**Goal**: Changing buffer values in options flow updates active lock code slots on the next coordinator refresh cycle (lazy update)
+
+**Independent Test**: Change buffer values while an active reservation exists and verify lock code date ranges update on next coordinator refresh
+
+### Tests for User Story 3
+
+- [ ] T018 [US3] Add coordinator test verifying update_config picks up changed buffer values from config entry in tests/unit/test_coordinator.py
+- [ ] T019 [US3] Add integration test verifying buffer change propagates to active lock code slots on refresh cycle in tests/integration/test_refresh_cycle.py
+
+**Checkpoint**: All user stories independently functional — buffers configurable, applicable to new and active reservations, upgrade-safe
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation across all stories
+
+- [ ] T020 [P] Add combined before+after buffer test verifying both offsets applied simultaneously in tests/unit/test_util.py
+- [ ] T021 Run full test suite via `uv run pytest tests/ -v`
+- [ ] T022 Run pre-commit hooks validation (ruff, mypy, interrogate, reuse-tool, gitlint)
+- [ ] T023 Validate against quickstart.md acceptance scenarios
+- [ ] T024 [P] Add negative test verifying calsensor event attributes, checkinsensor tracked_event_start/end, and event_overrides use unbuffered times when buffers are configured in tests/unit/test_util.py (FR-005)
+- [ ] T025 Add integration test verifying check-in sensor transitions to checked_in when lock code is used during before-buffer window (before unbuffered event start) with keymaster monitoring enabled in tests/integration/test_refresh_cycle.py (FR-011, SC-007)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US4 (Phase 3)**: Depends on Phase 2 — tests migration correctness
+- **US1 (Phase 4)**: Depends on Phase 2 — core buffer implementation
+- **US2 (Phase 5)**: Depends on Phase 4 — leverages shared implementation, adds after-buffer tests
+- **US3 (Phase 6)**: Depends on Phase 4 — tests lazy update of active reservations
+- **Polish (Phase 7)**: Depends on all user story phases
+
+### User Story Dependencies
+
+- **US4 (P1)**: Can start after Foundational (Phase 2) — no dependencies on other stories
+- **US1 (P1)**: Can start after Foundational (Phase 2) — no dependencies on other stories; can run in parallel with US4
+- **US2 (P2)**: Depends on US1 implementation (Phase 4) since both buffers share code paths
+- **US3 (P3)**: Depends on US1 implementation (Phase 4) for buffer application code to exist
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Implementation follows atomic commit discipline (one logical change per commit)
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel (different files)
+- T003, T004, and T005 — T004 can run in parallel with T003 (different files)
+- T006 and T007 can run in parallel (different test files)
+- T008, T009, T010, T011 can all run in parallel (all are test-writing tasks in different test areas)
+- T015, T016, T017 — T016 and T017 can run in parallel with T015
+- US4 (Phase 3) and US1 tests (Phase 4 tests) can start in parallel after Foundational phase
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all US1 tests in parallel (write tests first):
+Task: "Config flow buffer field visibility test in tests/unit/test_config_flow.py"  # T008
+Task: "Config flow negative value rejection test in tests/unit/test_config_flow.py" # T009
+Task: "Before-buffer async_fire_set_code test in tests/unit/test_util.py"           # T010
+Task: "Before-buffer async_fire_update_times test in tests/unit/test_util.py"       # T011
+
+# Then implement sequentially (same files have dependencies):
+Task: "Add buffer fields to config flow schema"     # T012
+Task: "Apply buffer offsets in async_fire_set_code"  # T013
+Task: "Apply buffer offsets in async_fire_update_times" # T014
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US4 + US1)
+
+1. Complete Phase 1: Setup (constants + strings)
+2. Complete Phase 2: Foundational (migration + VERSION + coordinator)
+3. Complete Phase 3: US4 tests (verify upgrade safety)
+4. Complete Phase 4: US1 tests → implementation (core buffer feature)
+5. **STOP and VALIDATE**: Run `uv run pytest tests/ -v` — both buffers work, upgrade is safe
+6. This delivers full buffer functionality as MVP
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. US4 (migration tests) → Upgrade safety verified
+3. US1 (pre-buffer + implementation) → Core feature working (MVP!)
+4. US2 (after-buffer tests) → Post-buffer coverage complete
+5. US3 (lazy update tests) → Runtime adjustment verified
+6. Polish → Full validation pass
+
+### Atomic Commit Sequence (from quickstart.md)
+
+1. `Feat: add CONF_CODE_BUFFER constants to const.py` (T001)
+2. `Feat: add strings.json labels for buffer fields` (T002)
+3. `Feat: add v9-to-v10 config migration for buffer fields` (T003, T004)
+4. `Feat: add buffer properties to coordinator` (T005)
+5. `Feat: add buffer fields to config flow schema` (T012)
+6. `Feat: apply buffer offsets in Keymaster service calls` (T013, T014)
+7. `Test: add unit tests for buffer functionality` (T006–T011, T015–T020)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps task to specific user story for traceability
+- US1 and US2 share implementation (same code paths for before/after buffer); US2 phase is test-focused
+- Both buffer fields are always added together (same schema block, same function calls) per contracts/internal-api.md
+- All source changes are modifications to existing files (~6 files); no new source files created
+- Test files are modifications to existing test files + potentially new integration test file
+- Commit after each task or logical group following atomic commit discipline


### PR DESCRIPTION
Add specification and implementation plan for configurable
pre/post buffer times on lock codes (spec 009).

## Artifacts

- spec.md — Feature specification (4 user stories, 11 FRs)
- plan.md — Implementation plan with constitution check
- research.md — Technical research findings
- data-model.md — Entity definitions and state transitions
- contracts/internal-api.md — Internal API contracts
- quickstart.md — Development workflow and commit sequence
- tasks.md — 25 tasks across 7 phases
- checklists/requirements.md — Requirements checklist

## Summary

Adds configurable pre-check-in and post-checkout buffer
times (in minutes) for lock codes. Buffer offsets are
applied only to Keymaster date_range_start/date_range_end
values. All internal RC logic uses unbuffered event times.