### PR TITLE
Feat: Add lock code buffer times

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -35,6 +35,8 @@ from homeassistant.util import dt as dt_util
 from homeassistant.util import slugify
 
 from .const import CHECKIN_SENSOR
+from .const import CONF_CODE_BUFFER_AFTER
+from .const import CONF_CODE_BUFFER_BEFORE
 from .const import CONF_CODE_LENGTH
 from .const import CONF_CREATION_DATETIME
 from .const import CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
@@ -45,6 +47,8 @@ from .const import CONF_PATH
 from .const import CONF_SHOULD_UPDATE_CODE
 from .const import CONF_TRIM_NAMES
 from .const import COORDINATOR
+from .const import DEFAULT_CODE_BUFFER_AFTER
+from .const import DEFAULT_CODE_BUFFER_BEFORE
 from .const import DEFAULT_CODE_LENGTH
 from .const import DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
 from .const import DEFAULT_GENERATE
@@ -273,6 +277,23 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         )
 
         version = 9
+        _LOGGER.debug("Migration to version %s complete", config_entry.version)
+
+    # 9 -> 10: Add code buffer before/after to configuration
+    if version == 9:
+        _LOGGER.debug("Migrating from version %s", version)
+
+        data = config_entry.data.copy()
+        data[CONF_CODE_BUFFER_BEFORE] = DEFAULT_CODE_BUFFER_BEFORE
+        data[CONF_CODE_BUFFER_AFTER] = DEFAULT_CODE_BUFFER_AFTER
+        hass.config_entries.async_update_entry(
+            entry=config_entry,
+            unique_id=config_entry.unique_id,
+            data=data,
+            version=10,
+        )
+
+        version = 10
         _LOGGER.debug("Migration to version %s complete", config_entry.version)
 
     return True

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -284,8 +284,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         _LOGGER.debug("Migrating from version %s", version)
 
         data = config_entry.data.copy()
-        data[CONF_CODE_BUFFER_BEFORE] = DEFAULT_CODE_BUFFER_BEFORE
-        data[CONF_CODE_BUFFER_AFTER] = DEFAULT_CODE_BUFFER_AFTER
+        data.setdefault(CONF_CODE_BUFFER_BEFORE, DEFAULT_CODE_BUFFER_BEFORE)
+        data.setdefault(CONF_CODE_BUFFER_AFTER, DEFAULT_CODE_BUFFER_AFTER)
         hass.config_entries.async_update_entry(
             entry=config_entry,
             unique_id=config_entry.unique_id,

--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -28,6 +28,8 @@ from .const import CODE_GENERATORS
 from .const import CONF_CHECKIN
 from .const import CONF_CHECKOUT
 from .const import CONF_CLEANING_WINDOW
+from .const import CONF_CODE_BUFFER_AFTER
+from .const import CONF_CODE_BUFFER_BEFORE
 from .const import CONF_CODE_GENERATION
 from .const import CONF_CODE_LENGTH
 from .const import CONF_CREATION_DATETIME
@@ -48,6 +50,8 @@ from .const import CONF_TRIM_NAMES
 from .const import DEFAULT_CHECKIN
 from .const import DEFAULT_CHECKOUT
 from .const import DEFAULT_CLEANING_WINDOW
+from .const import DEFAULT_CODE_BUFFER_AFTER
+from .const import DEFAULT_CODE_BUFFER_BEFORE
 from .const import DEFAULT_CODE_GENERATION
 from .const import DEFAULT_CODE_LENGTH
 from .const import DEFAULT_DAYS
@@ -77,7 +81,7 @@ class RentalControlFlowHandler(  # type: ignore[call-arg]
 ):
     """Handle the config flow for Rental Control."""
 
-    VERSION = 9
+    VERSION = 10
 
     DEFAULTS = {
         CONF_CHECKIN: DEFAULT_CHECKIN,
@@ -91,6 +95,8 @@ class RentalControlFlowHandler(  # type: ignore[call-arg]
         CONF_HONOR_EVENT_TIMES: DEFAULT_HONOR_EVENT_TIMES,
         CONF_TRIM_NAMES: DEFAULT_TRIM_NAMES,
         CONF_MAX_NAME_LENGTH: DEFAULT_MAX_NAME_LENGTH,
+        CONF_CODE_BUFFER_BEFORE: DEFAULT_CODE_BUFFER_BEFORE,
+        CONF_CODE_BUFFER_AFTER: DEFAULT_CODE_BUFFER_AFTER,
         CONF_TIMEZONE: str(dt.DEFAULT_TIME_ZONE),
         CONF_VERIFY_SSL: True,
     }
@@ -355,6 +361,20 @@ def _get_schema(
                         DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS,
                     ),
                 ): cv.boolean,
+                vol.Optional(
+                    CONF_CODE_BUFFER_BEFORE,
+                    default=_get_default(
+                        CONF_CODE_BUFFER_BEFORE,
+                        DEFAULT_CODE_BUFFER_BEFORE,
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+                vol.Optional(
+                    CONF_CODE_BUFFER_AFTER,
+                    default=_get_default(
+                        CONF_CODE_BUFFER_AFTER,
+                        DEFAULT_CODE_BUFFER_AFTER,
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0)),
             }
         )
     return schema

--- a/custom_components/rental_control/const.py
+++ b/custom_components/rental_control/const.py
@@ -106,6 +106,11 @@ MIN_NAME_LENGTH = 4
 CONF_TRIM_NAMES = "trim_names"
 CONF_MAX_NAME_LENGTH = "max_name_length"
 
+CONF_CODE_BUFFER_BEFORE = "code_buffer_before"
+CONF_CODE_BUFFER_AFTER = "code_buffer_after"
+DEFAULT_CODE_BUFFER_BEFORE = 0
+DEFAULT_CODE_BUFFER_AFTER = 0
+
 CODE_GENERATORS = [
     {"type": "date_based", "description": "Start/End Date"},
     {"type": "static_random", "description": "Static Random"},

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -50,6 +50,8 @@ import x_wr_timezone
 
 from .const import CONF_CHECKIN
 from .const import CONF_CHECKOUT
+from .const import CONF_CODE_BUFFER_AFTER
+from .const import CONF_CODE_BUFFER_BEFORE
 from .const import CONF_CODE_GENERATION
 from .const import CONF_CODE_LENGTH
 from .const import CONF_CREATION_DATETIME
@@ -65,6 +67,8 @@ from .const import CONF_SHOULD_UPDATE_CODE
 from .const import CONF_START_SLOT
 from .const import CONF_TIMEZONE
 from .const import CONF_TRIM_NAMES
+from .const import DEFAULT_CODE_BUFFER_AFTER
+from .const import DEFAULT_CODE_BUFFER_BEFORE
 from .const import DEFAULT_CODE_GENERATION
 from .const import DEFAULT_CODE_LENGTH
 from .const import DEFAULT_MAX_MISSES
@@ -127,6 +131,12 @@ class RentalControlCoordinator(DataUpdateCoordinator[list[CalendarEvent]]):
         self.trim_names: bool = bool(config.get(CONF_TRIM_NAMES, DEFAULT_TRIM_NAMES))
         self.max_name_length: int = int(
             str(config.get(CONF_MAX_NAME_LENGTH, DEFAULT_MAX_NAME_LENGTH))
+        )
+        self.code_buffer_before: int = int(
+            str(config.get(CONF_CODE_BUFFER_BEFORE, DEFAULT_CODE_BUFFER_BEFORE))
+        )
+        self.code_buffer_after: int = int(
+            str(config.get(CONF_CODE_BUFFER_AFTER, DEFAULT_CODE_BUFFER_AFTER))
         )
         if self.event_overrides is not None:
             self.event_overrides.trim_names = self.trim_names
@@ -579,6 +589,12 @@ Please update Keymaster to at least v0.1.0-b0
         self.trim_names = bool(config.get(CONF_TRIM_NAMES, DEFAULT_TRIM_NAMES))
         self.max_name_length = int(
             str(config.get(CONF_MAX_NAME_LENGTH, DEFAULT_MAX_NAME_LENGTH))
+        )
+        self.code_buffer_before = int(
+            str(config.get(CONF_CODE_BUFFER_BEFORE, DEFAULT_CODE_BUFFER_BEFORE))
+        )
+        self.code_buffer_after = int(
+            str(config.get(CONF_CODE_BUFFER_AFTER, DEFAULT_CODE_BUFFER_AFTER))
         )
         if self.event_overrides is not None:
             self.event_overrides.trim_names = self.trim_names

--- a/custom_components/rental_control/strings.json
+++ b/custom_components/rental_control/strings.json
@@ -34,6 +34,8 @@
           "honor_event_times": "Honor calendar event times from PMS instead of stored override times",
           "trim_names": "Trim slot names to maximum length",
           "max_name_length": "Maximum slot name length",
+          "code_buffer_before": "Lock code activation buffer (minutes before check-in)",
+          "code_buffer_after": "Lock code deactivation buffer (minutes after checkout)",
           "timezone": "Calendar Timezone",
           "url": "Calendar URL",
           "verify_ssl": "Verify SSL certificates"
@@ -79,13 +81,17 @@
           "honor_event_times": "Honor calendar event times from PMS instead of stored override times",
           "trim_names": "Trim slot names to maximum length",
           "max_name_length": "Maximum slot name length",
+          "code_buffer_before": "Lock code activation buffer (minutes before check-in)",
+          "code_buffer_after": "Lock code deactivation buffer (minutes after checkout)",
           "timezone": "Calendar Timezone",
           "url": "Calendar URL",
           "verify_ssl": "Verify SSL certificates",
           "enable_keymaster_event_diagnostics": "Enable keymaster event diagnostics (records last 10 keymaster_lock_state_changed events on the check-in sensor)"
         },
         "data_description": {
-          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)"
+          "cleaning_window": "Hours to keep checkout status before returning to no reservation (0.5–48)",
+          "code_buffer_before": "Minutes before check-in time to activate the lock code (0 = no buffer)",
+          "code_buffer_after": "Minutes after checkout time to deactivate the lock code (0 = no buffer)"
         }
       }
     }

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -283,6 +283,20 @@ def trim_name(name: str, max_length: int) -> str:
     return " ".join(result)
 
 
+def _apply_buffer(
+    start: datetime,
+    end: datetime,
+    before_minutes: int,
+    after_minutes: int,
+) -> tuple[datetime, datetime]:
+    """Return buffered start/end times for Keymaster date ranges."""
+    if before_minutes:
+        start = start - timedelta(minutes=before_minutes)
+    if after_minutes:
+        end = end + timedelta(minutes=after_minutes)
+    return start, end
+
+
 async def async_fire_set_code(coordinator, event, slot: int) -> None:
     """Set codes into a slot."""
     _LOGGER.debug("In async_fire_set_code - slot: %s", slot)
@@ -348,16 +362,12 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         )
 
         # Compute buffered validity window for Keymaster
-        buffered_start = event.extra_state_attributes["start"]
-        buffered_end = event.extra_state_attributes["end"]
-        if coordinator.code_buffer_before:
-            buffered_start = buffered_start - timedelta(
-                minutes=coordinator.code_buffer_before
-            )
-        if coordinator.code_buffer_after:
-            buffered_end = buffered_end + timedelta(
-                minutes=coordinator.code_buffer_after
-            )
+        buffered_start, buffered_end = _apply_buffer(
+            event.extra_state_attributes["start"],
+            event.extra_state_attributes["end"],
+            coordinator.code_buffer_before,
+            coordinator.code_buffer_after,
+        )
 
         coro = add_call(
             coordinator.hass,
@@ -453,14 +463,12 @@ async def async_fire_update_times(coordinator, event, slot: int) -> None:
         return
 
     # Compute buffered validity window for Keymaster
-    buffered_start = event.extra_state_attributes["start"]
-    buffered_end = event.extra_state_attributes["end"]
-    if coordinator.code_buffer_before:
-        buffered_start = buffered_start - timedelta(
-            minutes=coordinator.code_buffer_before
-        )
-    if coordinator.code_buffer_after:
-        buffered_end = buffered_end + timedelta(minutes=coordinator.code_buffer_after)
+    buffered_start, buffered_end = _apply_buffer(
+        event.extra_state_attributes["start"],
+        event.extra_state_attributes["end"],
+        coordinator.code_buffer_before,
+        coordinator.code_buffer_after,
+    )
 
     coro = add_call(
         coordinator.hass,

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -284,17 +284,27 @@ def trim_name(name: str, max_length: int) -> str:
 
 
 def _apply_buffer(
-    start: datetime,
-    end: datetime,
+    start: date | datetime,
+    end: date | datetime,
     before_minutes: int,
     after_minutes: int,
-) -> tuple[datetime, datetime]:
-    """Return buffered start/end times for Keymaster date ranges."""
+    coordinator: object,
+) -> tuple[date | datetime, date | datetime]:
+    """Return buffered start/end times for Keymaster date ranges.
+
+    Normalises bare ``date`` values via ``_ensure_datetime`` before
+    applying offsets.  When both buffer values are zero the inputs
+    are returned unchanged.
+    """
+    if not before_minutes and not after_minutes:
+        return start, end
+    dt_start = _ensure_datetime(start, coordinator)
+    dt_end = _ensure_datetime(end, coordinator)
     if before_minutes:
-        start = start - timedelta(minutes=before_minutes)
+        dt_start = dt_start - timedelta(minutes=before_minutes)
     if after_minutes:
-        end = end + timedelta(minutes=after_minutes)
-    return start, end
+        dt_end = dt_end + timedelta(minutes=after_minutes)
+    return dt_start, dt_end
 
 
 async def async_fire_set_code(coordinator, event, slot: int) -> None:
@@ -367,6 +377,7 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
             event.extra_state_attributes["end"],
             coordinator.code_buffer_before,
             coordinator.code_buffer_after,
+            coordinator,
         )
 
         coro = add_call(
@@ -468,6 +479,7 @@ async def async_fire_update_times(coordinator, event, slot: int) -> None:
         event.extra_state_attributes["end"],
         coordinator.code_buffer_before,
         coordinator.code_buffer_after,
+        coordinator,
     )
 
     coro = add_call(

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -292,9 +292,9 @@ def _apply_buffer(
 ) -> tuple[date | datetime, date | datetime]:
     """Return buffered start/end times for Keymaster date ranges.
 
-    Normalises bare ``date`` values via ``_ensure_datetime`` before
-    applying offsets.  When both buffer values are zero the inputs
-    are returned unchanged.
+    When a non-zero buffer is applied, bare ``date`` values are
+    normalised via ``_ensure_datetime`` before arithmetic.  When
+    both buffer values are zero the inputs are returned unchanged.
     """
     if not before_minutes and not after_minutes:
         return start, end

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -347,13 +347,25 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
             blocking=True,
         )
 
+        # Compute buffered validity window for Keymaster
+        buffered_start = event.extra_state_attributes["start"]
+        buffered_end = event.extra_state_attributes["end"]
+        if coordinator.code_buffer_before:
+            buffered_start = buffered_start - timedelta(
+                minutes=coordinator.code_buffer_before
+            )
+        if coordinator.code_buffer_after:
+            buffered_end = buffered_end + timedelta(
+                minutes=coordinator.code_buffer_after
+            )
+
         coro = add_call(
             coordinator.hass,
             coro,
             DATETIME,
             "set_value",
             f"{DATETIME}.{lockname}_code_slot_{slot}_date_range_end",
-            {"datetime": event.extra_state_attributes["end"]},
+            {"datetime": buffered_end},
         )
 
         coro = add_call(
@@ -362,7 +374,7 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
             DATETIME,
             "set_value",
             f"{DATETIME}.{lockname}_code_slot_{slot}_date_range_start",
-            {"datetime": event.extra_state_attributes["start"]},
+            {"datetime": buffered_start},
         )
 
         coro = add_call(
@@ -440,13 +452,23 @@ async def async_fire_update_times(coordinator, event, slot: int) -> None:
         )
         return
 
+    # Compute buffered validity window for Keymaster
+    buffered_start = event.extra_state_attributes["start"]
+    buffered_end = event.extra_state_attributes["end"]
+    if coordinator.code_buffer_before:
+        buffered_start = buffered_start - timedelta(
+            minutes=coordinator.code_buffer_before
+        )
+    if coordinator.code_buffer_after:
+        buffered_end = buffered_end + timedelta(minutes=coordinator.code_buffer_after)
+
     coro = add_call(
         coordinator.hass,
         coro,
         DATETIME,
         "set_value",
         f"datetime.{lockname}_code_slot_{slot}_date_range_end",
-        {"datetime": event.extra_state_attributes["end"]},
+        {"datetime": buffered_end},
     )
 
     coro = add_call(
@@ -455,7 +477,7 @@ async def async_fire_update_times(coordinator, event, slot: int) -> None:
         DATETIME,
         "set_value",
         f"datetime.{lockname}_code_slot_{slot}_date_range_start",
-        {"datetime": event.extra_state_attributes["start"]},
+        {"datetime": buffered_start},
     )
     # Update the slot details
     results = await asyncio.gather(*coro, return_exceptions=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,7 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="Test Rental",
-        version=9,
+        version=10,
         unique_id="test-unique-id",
         data={
             "name": "Test Rental",
@@ -135,6 +135,8 @@ def mock_config_entry() -> MockConfigEntry:
             "verify_ssl": True,
             "ignore_non_reserved": False,
             "honor_event_times": False,
+            "code_buffer_before": 0,
+            "code_buffer_after": 0,
         },
         options={
             "refresh_frequency": 5,
@@ -153,7 +155,7 @@ def mock_config_entry_full() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="Complete Rental",
-        version=9,
+        version=10,
         unique_id="test-full-unique-id",
         data={
             "name": "Complete Rental",
@@ -284,7 +286,7 @@ def mock_checkin_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="Test Rental",
-        version=9,
+        version=10,
         unique_id="test-checkin-unique-id",
         data={
             "name": "Test Rental",
@@ -298,6 +300,8 @@ def mock_checkin_config_entry() -> MockConfigEntry:
             "verify_ssl": True,
             "ignore_non_reserved": False,
             "honor_event_times": False,
+            "code_buffer_before": 0,
+            "code_buffer_after": 0,
         },
         options={
             "refresh_frequency": 5,

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -1002,14 +1002,14 @@ async def test_config_flow_url_bad_content_type(hass: HomeAssistant) -> None:
 
 
 async def test_honor_event_times_version_is_8(hass: HomeAssistant) -> None:
-    """Test that RentalControlFlowHandler VERSION is 9.
+    """Test that RentalControlFlowHandler VERSION is 10.
 
     Verifies that the config flow handler version has been bumped
-    to 9 to account for the new trim_names configuration keys.
+    to 10 to account for the new lock code buffer keys.
     """
     from custom_components.rental_control.config_flow import RentalControlFlowHandler
 
-    assert RentalControlFlowHandler.VERSION == 9
+    assert RentalControlFlowHandler.VERSION == 10
 
 
 async def test_honor_event_times_in_options_schema(hass: HomeAssistant) -> None:

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -1001,7 +1001,7 @@ async def test_config_flow_url_bad_content_type(hass: HomeAssistant) -> None:
     assert result["errors"] == {CONF_URL: "bad_ics"}
 
 
-async def test_honor_event_times_version_is_8(hass: HomeAssistant) -> None:
+async def test_config_flow_version_is_10(hass: HomeAssistant) -> None:
     """Test that RentalControlFlowHandler VERSION is 10.
 
     Verifies that the config flow handler version has been bumped

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -255,7 +255,7 @@ async def test_migrate_entry_rejects_version_below_3(
     assert result is False
 
 
-async def test_migrate_entry_v3_to_v8(
+async def test_migrate_entry_v3_to_v10(
     hass: HomeAssistant,
 ) -> None:
     """Verify a version-3 entry migrates through all steps to version 10.
@@ -300,7 +300,7 @@ async def test_migrate_entry_v3_to_v8(
     assert entry.data[CONF_HONOR_EVENT_TIMES] is False
 
 
-async def test_migrate_entry_v6_to_v8(
+async def test_migrate_entry_v6_to_v10(
     hass: HomeAssistant,
 ) -> None:
     """Verify a version-6 entry runs v6→7→8→9→10 steps."""
@@ -337,7 +337,7 @@ async def test_migrate_entry_v6_to_v8(
     assert entry.data[CONF_HONOR_EVENT_TIMES] is False
 
 
-async def test_migrate_entry_v7_to_v8_honor_event_times(
+async def test_migrate_entry_v7_to_v10_honor_event_times(
     hass: HomeAssistant,
 ) -> None:
     """Verify v7→v8→v9→v10 migration sets honor_event_times.
@@ -379,7 +379,7 @@ async def test_migrate_entry_v7_to_v8_honor_event_times(
     assert entry.data[CONF_HONOR_EVENT_TIMES] is False
 
 
-async def test_migrate_entry_v8_to_v9_trim_names(
+async def test_migrate_entry_v8_to_v10_trim_names(
     hass: HomeAssistant,
 ) -> None:
     """Verify v8→v9→v10 migration adds trim_names and max_name_length.

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -258,11 +258,12 @@ async def test_migrate_entry_rejects_version_below_3(
 async def test_migrate_entry_v3_to_v8(
     hass: HomeAssistant,
 ) -> None:
-    """Verify a version-3 entry migrates through all steps to version 9.
+    """Verify a version-3 entry migrates through all steps to version 10.
 
-    The migration chain 3→4→5→6→7→8→9 adds code_length,
+    The migration chain 3→4→5→6→7→8→9→10 adds code_length,
     generate_package, removes packages_path, adds
-    should_update_code, honor_event_times, and trim fields.
+    should_update_code, honor_event_times, trim fields, and
+    code buffer fields.
     """
     from custom_components.rental_control import async_migrate_entry
 
@@ -291,7 +292,7 @@ async def test_migrate_entry_v3_to_v8(
     result = await async_migrate_entry(hass, entry)
 
     assert result is True
-    assert entry.version == 9
+    assert entry.version == 10
     assert entry.data[CONF_CODE_LENGTH] == DEFAULT_CODE_LENGTH
     assert entry.data[CONF_GENERATE] == DEFAULT_GENERATE
     assert CONF_PATH not in entry.data
@@ -302,7 +303,7 @@ async def test_migrate_entry_v3_to_v8(
 async def test_migrate_entry_v6_to_v8(
     hass: HomeAssistant,
 ) -> None:
-    """Verify a version-6 entry runs v6→7→8→9 steps."""
+    """Verify a version-6 entry runs v6→7→8→9→10 steps."""
     from custom_components.rental_control import async_migrate_entry
 
     entry = MockConfigEntry(
@@ -331,7 +332,7 @@ async def test_migrate_entry_v6_to_v8(
     result = await async_migrate_entry(hass, entry)
 
     assert result is True
-    assert entry.version == 9
+    assert entry.version == 10
     assert entry.data[CONF_SHOULD_UPDATE_CODE] is False
     assert entry.data[CONF_HONOR_EVENT_TIMES] is False
 
@@ -339,11 +340,11 @@ async def test_migrate_entry_v6_to_v8(
 async def test_migrate_entry_v7_to_v8_honor_event_times(
     hass: HomeAssistant,
 ) -> None:
-    """Verify v7→v8→v9 migration sets honor_event_times to False.
+    """Verify v7→v8→v9→v10 migration sets honor_event_times.
 
     Verifies that an existing v7 config entry that lacks the
-    honor_event_times key gets migrated through v8 to v9 with the
-    key set to False, preserving existing behavior.
+    honor_event_times key gets migrated through v8 to v10 with
+    the key set to False, preserving existing behavior.
     """
     from custom_components.rental_control import async_migrate_entry
 
@@ -374,19 +375,22 @@ async def test_migrate_entry_v7_to_v8_honor_event_times(
     result = await async_migrate_entry(hass, entry)
 
     assert result is True
-    assert entry.version == 9
+    assert entry.version == 10
     assert entry.data[CONF_HONOR_EVENT_TIMES] is False
 
 
 async def test_migrate_entry_v8_to_v9_trim_names(
     hass: HomeAssistant,
 ) -> None:
-    """Verify v8→v9 migration adds trim_names and max_name_length.
+    """Verify v8→v9→v10 migration adds trim_names and max_name_length.
 
     Verifies that an existing v8 config entry without trim fields
-    gets migrated to v9 with trim_names=False and max_name_length=16.
+    gets migrated to v10 with trim_names=False, max_name_length=16,
+    and both buffer fields defaulting to 0.
     """
     from custom_components.rental_control import async_migrate_entry
+    from custom_components.rental_control.const import CONF_CODE_BUFFER_AFTER
+    from custom_components.rental_control.const import CONF_CODE_BUFFER_BEFORE
     from custom_components.rental_control.const import CONF_MAX_NAME_LENGTH
     from custom_components.rental_control.const import CONF_TRIM_NAMES
 
@@ -417,6 +421,54 @@ async def test_migrate_entry_v8_to_v9_trim_names(
     result = await async_migrate_entry(hass, entry)
 
     assert result is True
-    assert entry.version == 9
+    assert entry.version == 10
     assert entry.data[CONF_TRIM_NAMES] is False
     assert entry.data[CONF_MAX_NAME_LENGTH] == 16
+    assert entry.data[CONF_CODE_BUFFER_BEFORE] == 0
+    assert entry.data[CONF_CODE_BUFFER_AFTER] == 0
+
+
+async def test_migrate_entry_v9_to_v10_code_buffer(
+    hass: HomeAssistant,
+) -> None:
+    """Verify v9→v10 migration adds buffer fields with default 0.
+
+    Verifies that an existing v9 config entry gets migrated to v10
+    with code_buffer_before=0 and code_buffer_after=0.
+    """
+    from custom_components.rental_control import async_migrate_entry
+    from custom_components.rental_control.const import CONF_CODE_BUFFER_AFTER
+    from custom_components.rental_control.const import CONF_CODE_BUFFER_BEFORE
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="V9 Entry",
+        version=9,
+        unique_id="v9-migration-test",
+        data={
+            "name": "V9 Entry",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "America/New_York",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            "start_slot": 10,
+            "max_events": 3,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "code_length": 4,
+            "should_update_code": False,
+            "honor_event_times": False,
+            "trim_names": False,
+            "max_name_length": 16,
+        },
+        entry_id="v9_entry",
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 10
+    assert entry.data[CONF_CODE_BUFFER_BEFORE] == 0
+    assert entry.data[CONF_CODE_BUFFER_AFTER] == 0

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -340,7 +340,7 @@ async def test_migrate_entry_v6_to_v10(
 async def test_migrate_entry_v7_to_v10_honor_event_times(
     hass: HomeAssistant,
 ) -> None:
-    """Verify v7→v8→v9→v10 migration sets honor_event_times.
+    """Verify v7→v8→v9→v10 migration sets honor_event_times to False.
 
     Verifies that an existing v7 config entry that lacks the
     honor_event_times key gets migrated through v8 to v10 with

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from datetime import date
+from datetime import datetime
 from datetime import timedelta
 import logging
 from unittest.mock import AsyncMock
@@ -1376,6 +1377,8 @@ class TestAsyncFireSetCode:
         coordinator.lockname = "front_door"
         coordinator.event_prefix = ""
         coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
 
         event = self._make_event()
@@ -1409,6 +1412,8 @@ class TestAsyncFireSetCode:
         coordinator.lockname = "front_door"
         coordinator.event_prefix = "Rental"
         coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
 
         event = self._make_event(slot_name="Guest")
@@ -1429,6 +1434,8 @@ class TestAsyncFireSetCode:
         coordinator.lockname = "front_door"
         coordinator.event_prefix = ""
         coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
 
         event = self._make_event(slot_name="Guest")
@@ -1447,6 +1454,8 @@ class TestAsyncFireSetCode:
         coordinator.event_prefix = "Rental"
         coordinator.trim_names = True
         coordinator.max_name_length = 12
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
 
         event = self._make_event(slot_name="Very Long Guest Name")
@@ -1467,6 +1476,8 @@ class TestAsyncFireSetCode:
         coordinator.lockname = "front_door"
         coordinator.event_prefix = "Rental"
         coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
 
         event = self._make_event(slot_name="Very Long Guest Name")
@@ -1535,6 +1546,8 @@ class TestAsyncFireUpdateTimes:
         """Verify both datetime entities are updated."""
         coordinator = MagicMock()
         coordinator.lockname = "front_door"
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
 
         event = self._make_event()
@@ -1573,6 +1586,8 @@ class TestAsyncFireUpdateTimes:
         """Verify a failing service call is logged but does not crash."""
         coordinator = MagicMock()
         coordinator.lockname = "front_door"
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock(
             side_effect=ServiceNotFound("datetime", "set_value")
         )
@@ -1668,6 +1683,8 @@ class TestPreExecutionVerification:
         coordinator.lockname = "front_door"
         coordinator.event_prefix = ""
         coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
         coordinator.event_overrides.verify_slot_ownership.return_value = True
 
@@ -1700,6 +1717,8 @@ class TestRetryEscalation:
         coordinator.lockname = "front_door"
         coordinator.event_prefix = ""
         coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
         coordinator.event_overrides.verify_slot_ownership.return_value = True
         coordinator.event_overrides._escalated = {10: True}
@@ -1729,6 +1748,8 @@ class TestRetryEscalation:
         coordinator.lockname = "front_door"
         coordinator.event_prefix = ""
         coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
         coordinator.event_overrides.verify_slot_ownership.return_value = True
         coordinator.event_overrides._escalated = {}
@@ -1898,6 +1919,8 @@ class TestSlugifiedLocknameEntityIds:
         coordinator.lockname = "front_door"
         coordinator.event_prefix = ""
         coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
 
         event = MagicMock()
@@ -2190,3 +2213,247 @@ class TestTrimName:
     def test_skips_long_middle_word(self) -> None:
         """Verify accumulation stops at first non-fitting word."""
         assert trim_name("Hello LongWord A", 8) == "Hello"
+
+
+# ---------------------------------------------------------------------------
+# Lock code buffer tests (spec 009)
+# ---------------------------------------------------------------------------
+
+
+class TestBufferInSetCode:
+    """Tests for buffer offsets in async_fire_set_code."""
+
+    @staticmethod
+    def _make_event(
+        slot_name: str = "Guest",
+        slot_code: str = "1234",
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> MagicMock:
+        """Build a mock event with slot attributes."""
+        if start is None:
+            start = datetime(2025, 1, 15, 16, 0, 0)
+        if end is None:
+            end = datetime(2025, 1, 17, 11, 0, 0)
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": slot_name,
+            "slot_code": slot_code,
+            "start": start,
+            "end": end,
+        }
+        return event
+
+    async def test_before_buffer_shifts_start(self) -> None:
+        """Verify date_range_start is 30 minutes earlier."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 30
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+
+        event = self._make_event()
+        await async_fire_set_code(coordinator, event, 10)
+
+        calls = coordinator.hass.services.async_call.await_args_list
+        start_calls = [
+            c
+            for c in calls
+            if "date_range_start" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        assert len(start_calls) == 1
+        sent = start_calls[0].kwargs["service_data"]["datetime"]
+        assert sent == datetime(2025, 1, 15, 15, 30, 0)
+
+    async def test_after_buffer_extends_end(self) -> None:
+        """Verify date_range_end is 15 minutes later."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 15
+        coordinator.hass.services.async_call = AsyncMock()
+
+        event = self._make_event()
+        await async_fire_set_code(coordinator, event, 10)
+
+        calls = coordinator.hass.services.async_call.await_args_list
+        end_calls = [
+            c
+            for c in calls
+            if "date_range_end" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        assert len(end_calls) == 1
+        sent = end_calls[0].kwargs["service_data"]["datetime"]
+        assert sent == datetime(2025, 1, 17, 11, 15, 0)
+
+    async def test_both_buffers_applied(self) -> None:
+        """Verify both offsets applied simultaneously."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 60
+        coordinator.code_buffer_after = 30
+        coordinator.hass.services.async_call = AsyncMock()
+
+        event = self._make_event()
+        await async_fire_set_code(coordinator, event, 10)
+
+        calls = coordinator.hass.services.async_call.await_args_list
+        start_calls = [
+            c
+            for c in calls
+            if "date_range_start" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        end_calls = [
+            c
+            for c in calls
+            if "date_range_end" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        assert start_calls[0].kwargs["service_data"]["datetime"] == (
+            datetime(2025, 1, 15, 15, 0, 0)
+        )
+        assert end_calls[0].kwargs["service_data"]["datetime"] == (
+            datetime(2025, 1, 17, 11, 30, 0)
+        )
+
+    async def test_zero_buffer_unchanged(self) -> None:
+        """Verify zero buffers send unbuffered times."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+
+        start = datetime(2025, 1, 15, 16, 0, 0)
+        end = datetime(2025, 1, 17, 11, 0, 0)
+        event = self._make_event(start=start, end=end)
+        await async_fire_set_code(coordinator, event, 10)
+
+        calls = coordinator.hass.services.async_call.await_args_list
+        start_calls = [
+            c
+            for c in calls
+            if "date_range_start" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        end_calls = [
+            c
+            for c in calls
+            if "date_range_end" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        assert start_calls[0].kwargs["service_data"]["datetime"] == start
+        assert end_calls[0].kwargs["service_data"]["datetime"] == end
+
+
+class TestBufferInUpdateTimes:
+    """Tests for buffer offsets in async_fire_update_times."""
+
+    @staticmethod
+    def _make_event(
+        slot_name: str = "Guest",
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> MagicMock:
+        """Build a mock event with slot attributes."""
+        if start is None:
+            start = datetime(2025, 1, 15, 16, 0, 0)
+        if end is None:
+            end = datetime(2025, 1, 17, 11, 0, 0)
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": slot_name,
+            "start": start,
+            "end": end,
+        }
+        return event
+
+    async def test_before_buffer_shifts_start(self) -> None:
+        """Verify date_range_start is 30 minutes earlier."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.code_buffer_before = 30
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+
+        event = self._make_event()
+        await async_fire_update_times(coordinator, event, 10)
+
+        calls = coordinator.hass.services.async_call.await_args_list
+        start_calls = [
+            c
+            for c in calls
+            if "date_range_start" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        assert start_calls[0].kwargs["service_data"]["datetime"] == (
+            datetime(2025, 1, 15, 15, 30, 0)
+        )
+
+    async def test_after_buffer_extends_end(self) -> None:
+        """Verify date_range_end is 15 minutes later."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 15
+        coordinator.hass.services.async_call = AsyncMock()
+
+        event = self._make_event()
+        await async_fire_update_times(coordinator, event, 10)
+
+        calls = coordinator.hass.services.async_call.await_args_list
+        end_calls = [
+            c
+            for c in calls
+            if "date_range_end" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        assert end_calls[0].kwargs["service_data"]["datetime"] == (
+            datetime(2025, 1, 17, 11, 15, 0)
+        )
+
+    async def test_zero_buffer_unchanged(self) -> None:
+        """Verify zero buffers produce unbuffered date ranges."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+
+        start = datetime(2025, 1, 15, 16, 0, 0)
+        end = datetime(2025, 1, 17, 11, 0, 0)
+        event = self._make_event(start=start, end=end)
+        await async_fire_update_times(coordinator, event, 10)
+
+        calls = coordinator.hass.services.async_call.await_args_list
+        start_calls = [
+            c
+            for c in calls
+            if "date_range_start" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        end_calls = [
+            c
+            for c in calls
+            if "date_range_end" in c.kwargs.get("target", {}).get("entity_id", "")
+        ]
+        assert start_calls[0].kwargs["service_data"]["datetime"] == start
+        assert end_calls[0].kwargs["service_data"]["datetime"] == end
+
+    async def test_event_attributes_unmodified(self) -> None:
+        """Verify event attributes remain unbuffered after call."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.code_buffer_before = 30
+        coordinator.code_buffer_after = 15
+        coordinator.hass.services.async_call = AsyncMock()
+
+        original_start = datetime(2025, 1, 15, 16, 0, 0)
+        original_end = datetime(2025, 1, 17, 11, 0, 0)
+        event = self._make_event(start=original_start, end=original_end)
+        await async_fire_update_times(coordinator, event, 10)
+
+        assert event.extra_state_attributes["start"] == original_start
+        assert event.extra_state_attributes["end"] == original_end

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -2253,6 +2253,7 @@ class TestBufferInSetCode:
         coordinator.code_buffer_before = 30
         coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
 
         event = self._make_event()
         await async_fire_set_code(coordinator, event, 10)
@@ -2276,6 +2277,7 @@ class TestBufferInSetCode:
         coordinator.code_buffer_before = 0
         coordinator.code_buffer_after = 15
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
 
         event = self._make_event()
         await async_fire_set_code(coordinator, event, 10)
@@ -2299,6 +2301,7 @@ class TestBufferInSetCode:
         coordinator.code_buffer_before = 60
         coordinator.code_buffer_after = 30
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
 
         event = self._make_event()
         await async_fire_set_code(coordinator, event, 10)
@@ -2330,6 +2333,7 @@ class TestBufferInSetCode:
         coordinator.code_buffer_before = 0
         coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
 
         start = datetime(2025, 1, 15, 16, 0, 0)
         end = datetime(2025, 1, 17, 11, 0, 0)
@@ -2380,6 +2384,7 @@ class TestBufferInUpdateTimes:
         coordinator.code_buffer_before = 30
         coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
 
         event = self._make_event()
         await async_fire_update_times(coordinator, event, 10)
@@ -2401,6 +2406,7 @@ class TestBufferInUpdateTimes:
         coordinator.code_buffer_before = 0
         coordinator.code_buffer_after = 15
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
 
         event = self._make_event()
         await async_fire_update_times(coordinator, event, 10)
@@ -2422,6 +2428,7 @@ class TestBufferInUpdateTimes:
         coordinator.code_buffer_before = 0
         coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
 
         start = datetime(2025, 1, 15, 16, 0, 0)
         end = datetime(2025, 1, 17, 11, 0, 0)
@@ -2449,6 +2456,7 @@ class TestBufferInUpdateTimes:
         coordinator.code_buffer_before = 30
         coordinator.code_buffer_after = 15
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
 
         original_start = datetime(2025, 1, 15, 16, 0, 0)
         original_end = datetime(2025, 1, 17, 11, 0, 0)


### PR DESCRIPTION
## Summary

Add configurable pre/post buffer times (in minutes) for lock
codes. Buffer times extend when physical lock codes are valid
on locks without affecting internal RC timing (calendar display,
check-in sensors, event overrides).

## Changes

### Constants & Strings
- Add `CONF_CODE_BUFFER_BEFORE`, `CONF_CODE_BUFFER_AFTER` constants
  with defaults of 0 minutes
- Add UI labels in `strings.json` for config/options flows

### Migration
- Add v9→v10 migration in `__init__.py` to populate buffer defaults

### Config Flow
- Bump `VERSION` to 10
- Add buffer fields to options flow schema (visible only in options,
  not initial setup)

### Coordinator
- Add `code_buffer_before`/`code_buffer_after` int properties

### Util
- Apply buffer offsets to Keymaster `date_range_start`/`date_range_end`
  in `async_fire_set_code` and `async_fire_update_times`
- Zero buffers skip arithmetic (no behavior change for existing users)

### Tests
- Update all fixtures from v9 to v10 with buffer defaults
- Add v9→v10 migration test
- Add buffer offset tests for `set_code` and `update_times`
- Fix existing mock coordinators to include buffer attributes

## Testing

All 795 tests pass. Linting clean.