### PR TITLE
Fix(checkin): re-evaluate event in awaiting state

### DIFF
--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -1511,7 +1511,11 @@ class CheckinTrackingSensor(
 
         - ``code_slot_num != 0`` (FR-017: ignore manual/RF unlocks)
         - ``code_slot_num`` is within the managed slot range
-        - Sensor is in ``awaiting_checkin`` state → transition to checked_in
+        - Sensor is in ``awaiting_checkin`` state and overrides are
+          ready: reject if the slot's guest name does not match the
+          tracked event (defense-in-depth against wrong-event check-in)
+        - Sensor is in ``awaiting_checkin`` state → transition to
+          checked_in
         - Sensor is in ``checked_in`` state → ignored (early checkout
           expiry is handled by ``async_checkout`` per FR-022/FR-023)
 

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -358,12 +358,18 @@ class CheckinTrackingSensor(
     def _get_relevant_event(self) -> CalendarEvent | None:
         """Get the most relevant event from coordinator data.
 
+        Returns the first event whose end time is still in the future,
+        skipping events that have already ended.  This prevents the
+        sensor from tracking stale events that remain in coordinator
+        data until the next midnight filter removes them.
+
         Returns:
-            The first event from coordinator data (event 0), or None
-            if no events are available.
+            The first non-ended event, or None if no active events.
         """
-        if self.coordinator.data and len(self.coordinator.data) > 0:
-            return self.coordinator.data[0]
+        now = dt_util.now()
+        for event in self.coordinator.data or []:
+            if event.end > now:
+                return event
         return None
 
     def _get_next_event(self) -> CalendarEvent | None:
@@ -493,6 +499,38 @@ class CheckinTrackingSensor(
         elif current_state == CHECKIN_STATE_AWAITING:
             tracked = self._find_tracked_event()
             if tracked is not None:
+                # Check if a more relevant (earlier) event has appeared
+                # that the sensor should track instead. This handles the
+                # case where a nearer reservation is added to the calendar
+                # after the sensor already started tracking a future event.
+                relevant = self._get_relevant_event()
+                if (
+                    relevant is not None
+                    and self._tracked_event_start is not None
+                    and self._tracked_event_summary is not None
+                ):
+                    relevant_key = self._event_key(relevant.summary, relevant.start)
+                    tracked_key = self._event_key(
+                        self._tracked_event_summary,
+                        self._tracked_event_start,
+                    )
+                    if (
+                        relevant_key != tracked_key
+                        and relevant_key != self._checked_out_event_key
+                        and relevant.start < self._tracked_event_start
+                    ):
+                        _LOGGER.debug(
+                            "More relevant event found (%s starting "
+                            "%s) while awaiting %s starting %s; "
+                            "switching tracked event",
+                            relevant.summary,
+                            relevant.start,
+                            self._tracked_event_summary,
+                            self._tracked_event_start,
+                        )
+                        self._transition_to_awaiting(relevant)
+                        return
+
                 # Same event still in coordinator — update mutable fields
                 self._tracked_event_end = tracked.end
                 self._tracked_event_slot_name = self._extract_slot_name(tracked)
@@ -660,7 +698,9 @@ class CheckinTrackingSensor(
         self._checkin_source = None
         self._checkout_source = None
         self._checkout_time = None
-        self._checked_out_event_key = None
+        # Preserve _checked_out_event_key so that the awaiting
+        # re-evaluation logic can exclude the just-checked-out event
+        # and avoid same-day turnover regressions.
         self._next_event_start_day = None
         self._checkin_lock_name = None
         self._linger_followon_key = None
@@ -1523,6 +1563,28 @@ class CheckinTrackingSensor(
                 self._state,
             )
             return
+
+        # Validate unlock slot matches tracked event when overrides
+        # are ready.  If the slot belongs to a different guest, reject
+        # to prevent checking in the wrong event (defense-in-depth for
+        # the awaiting re-evaluation logic).
+        if self.coordinator.event_overrides and self.coordinator.event_overrides.ready:
+            incoming_slot_name = self.coordinator.event_overrides.get_slot_name(
+                code_slot_num
+            )
+            if (
+                incoming_slot_name
+                and self._tracked_event_slot_name
+                and incoming_slot_name != self._tracked_event_slot_name
+            ):
+                _LOGGER.debug(
+                    "Ignoring keymaster unlock: slot %d belongs to "
+                    "'%s' but tracked event is for '%s'",
+                    code_slot_num,
+                    incoming_slot_name,
+                    self._tracked_event_slot_name,
+                )
+                return
 
         # All conditions met — transition to checked_in
         _LOGGER.info(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,9 +266,7 @@ def mock_checkin_coordinator(
     coordinator.checkin = time(16, 0)
     coordinator.checkout = time(11, 0)
     coordinator.event_prefix = ""
-    coordinator.event_overrides = MagicMock()
-    coordinator.event_overrides.ready = False
-    coordinator.event_overrides.get_slot_name.return_value = ""
+    coordinator.event_overrides = None
     coordinator.unique_id = "test-checkin-unique-id"
     coordinator.name = "Test Rental"
     coordinator.device_info = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,6 +266,9 @@ def mock_checkin_coordinator(
     coordinator.checkin = time(16, 0)
     coordinator.checkout = time(11, 0)
     coordinator.event_prefix = ""
+    coordinator.event_overrides = MagicMock()
+    coordinator.event_overrides.ready = False
+    coordinator.event_overrides.get_slot_name.return_value = ""
     coordinator.unique_id = "test-checkin-unique-id"
     coordinator.name = "Test Rental"
     coordinator.device_info = {

--- a/tests/integration/test_checkin_tracking.py
+++ b/tests/integration/test_checkin_tracking.py
@@ -82,6 +82,9 @@ def _make_coordinator(hass: HomeAssistant) -> MagicMock:
     coordinator.start_slot = 10
     coordinator.max_events = 3
     coordinator.event_prefix = ""
+    coordinator.event_overrides = MagicMock()
+    coordinator.event_overrides.ready = False
+    coordinator.event_overrides.get_slot_name.return_value = ""
     coordinator.unique_id = "test-integration-checkin-id"
     coordinator.name = "Test Rental"
     coordinator.device_info = {

--- a/tests/integration/test_checkin_tracking.py
+++ b/tests/integration/test_checkin_tracking.py
@@ -82,9 +82,7 @@ def _make_coordinator(hass: HomeAssistant) -> MagicMock:
     coordinator.start_slot = 10
     coordinator.max_events = 3
     coordinator.event_prefix = ""
-    coordinator.event_overrides = MagicMock()
-    coordinator.event_overrides.ready = False
-    coordinator.event_overrides.get_slot_name.return_value = ""
+    coordinator.event_overrides = None
     coordinator.unique_id = "test-integration-checkin-id"
     coordinator.name = "Test Rental"
     coordinator.device_info = {
@@ -1108,6 +1106,9 @@ class TestFullLifecycleT043:
         """
         coordinator = _make_coordinator(hass)
         coordinator.lockname = "front_door"
+        coordinator.event_overrides = MagicMock()
+        coordinator.event_overrides.ready = True
+        coordinator.event_overrides.get_slot_name.return_value = "Guest2"
         config_entry = _make_config_entry()
         sensor = _create_sensor(hass, coordinator, config_entry)
 

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -5336,7 +5336,7 @@ class TestGetRelevantEvent:
 # ===========================================================================
 
 
-class TestKeyasterSlotValidation:
+class TestKeymasterSlotValidation:
     """Tests for keymaster slot validation in AWAITING state."""
 
     @freeze_time("2025-07-01T12:00:00+00:00")

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -4038,6 +4038,7 @@ class TestEarlyCheckoutExpiry:
         sensor._tracked_event_slot_name = "John Smith"
         sensor._checkin_source = "keymaster"
 
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.get_slot_key_by_name.return_value = 10
 
         # Switch ON — unlock should still be ignored
@@ -4071,6 +4072,7 @@ class TestEarlyCheckoutExpiry:
         sensor._tracked_event_slot_name = "John Smith"
         sensor._checkin_source = "keymaster"
 
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.get_slot_key_by_name.return_value = 10
 
         _setup_early_expiry_switch(hass, mock_checkin_config_entry, is_on=False)
@@ -4181,6 +4183,7 @@ class TestEarlyCheckoutExpiry:
         sensor._checkin_source = "keymaster"
 
         mock_checkin_coordinator.data = []
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.get_slot_key_by_name.return_value = 10
 
         # Set an existing timer that would fire at original_end
@@ -4287,6 +4290,7 @@ class TestEarlyCheckoutExpiry:
         sensor._checkin_source = "keymaster"
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.get_slot_key_by_name.return_value = 10
         mock_checkin_coordinator.data = []
 
@@ -4330,6 +4334,7 @@ class TestEarlyCheckoutExpiry:
         sensor._checkin_source = "keymaster"
 
         mock_checkin_coordinator.lockname = None
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.get_slot_key_by_name.return_value = 10
         mock_checkin_coordinator.data = []
 
@@ -4364,6 +4369,7 @@ class TestEarlyCheckoutExpiry:
         sensor._checkin_source = "keymaster"
 
         mock_checkin_coordinator.lockname = "front_door"
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.get_slot_key_by_name.return_value = 0
         mock_checkin_coordinator.data = []
 
@@ -4401,6 +4407,7 @@ class TestEarlyCheckoutExpiry:
         sensor._tracked_event_slot_name = "John Smith"
         sensor._checkin_source = "keymaster"
 
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.get_slot_key_by_name.return_value = 10
 
         _setup_early_expiry_switch(hass, mock_checkin_config_entry, is_on=True)
@@ -5363,6 +5370,7 @@ class TestKeymasterSlotValidation:
         assert sensor._tracked_event_slot_name == "Alice"
 
         # Set up event_overrides to return a different guest for slot 10
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.ready = True
         mock_checkin_coordinator.event_overrides.get_slot_name.return_value = "Bob"
         mock_checkin_coordinator.lockname = "front_door"
@@ -5397,6 +5405,7 @@ class TestKeymasterSlotValidation:
         assert sensor._tracked_event_slot_name == "Alice"
 
         # event_overrides.ready is True but slot has no name
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.ready = True
         mock_checkin_coordinator.event_overrides.get_slot_name.return_value = ""
         mock_checkin_coordinator.lockname = "front_door"
@@ -5431,6 +5440,7 @@ class TestKeymasterSlotValidation:
         assert sensor._tracked_event_slot_name == "Alice"
 
         # event_overrides returns matching name
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.ready = True
         mock_checkin_coordinator.event_overrides.get_slot_name.return_value = "Alice"
         mock_checkin_coordinator.lockname = "front_door"
@@ -5463,6 +5473,7 @@ class TestKeymasterSlotValidation:
         assert sensor._state == CHECKIN_STATE_AWAITING
 
         # event_overrides exists but not ready
+        mock_checkin_coordinator.event_overrides = MagicMock()
         mock_checkin_coordinator.event_overrides.ready = False
         mock_checkin_coordinator.lockname = "front_door"
 

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -5141,3 +5141,333 @@ class TestSetState:
         await hass.async_block_till_done()
 
         assert len(fired) == 0
+
+
+# ===========================================================================
+# Awaiting state re-evaluation (event tracking switch)
+# ===========================================================================
+
+
+class TestAwaitingReEvaluation:
+    """Tests for awaiting state re-evaluation when a more relevant event appears."""
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_switches_to_earlier_event(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Sensor switches to an earlier event appearing in coordinator data."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        # Initially tracking a future event (starts in 2 days)
+        far_event = _make_event(
+            summary="Reserved - FarGuest",
+            start=now + timedelta(days=2),
+            end=now + timedelta(days=5),
+        )
+        mock_checkin_coordinator.data = [far_event]
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+        assert sensor._tracked_event_summary == "Reserved - FarGuest"
+
+        # A nearer event appears (starts tomorrow)
+        near_event = _make_event(
+            summary="Reserved - NearGuest",
+            start=now + timedelta(days=1),
+            end=now + timedelta(days=3),
+        )
+        # Coordinator data is sorted by start
+        mock_checkin_coordinator.data = [near_event, far_event]
+        sensor._handle_coordinator_update()
+
+        assert sensor._state == CHECKIN_STATE_AWAITING
+        assert sensor._tracked_event_summary == "Reserved - NearGuest"
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_does_not_switch_to_checked_out_event(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Sensor does not switch to an event it already checked out (same-day turnover)."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        # Simulate a just-checked-out event still in coordinator data
+        old_event = _make_event(
+            summary="Reserved - OldGuest",
+            start=now - timedelta(days=3),
+            end=now + timedelta(hours=2),
+        )
+        new_event = _make_event(
+            summary="Reserved - NewGuest",
+            start=now + timedelta(hours=4),
+            end=now + timedelta(days=3),
+        )
+
+        # Set up: track new_event, mark old_event as checked-out
+        sensor._state = CHECKIN_STATE_AWAITING
+        sensor._tracked_event_summary = new_event.summary
+        sensor._tracked_event_start = new_event.start
+        sensor._tracked_event_end = new_event.end
+        sensor._tracked_event_slot_name = None
+        old_key = sensor._event_key(old_event.summary, old_event.start)
+        sensor._checked_out_event_key = old_key
+
+        # old_event is earlier and still active (end > now) but should be skipped
+        mock_checkin_coordinator.data = [old_event, new_event]
+        sensor._handle_coordinator_update()
+
+        # Must remain tracking new_event, NOT switch back to old_event
+        assert sensor._tracked_event_summary == "Reserved - NewGuest"
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_does_not_switch_to_later_event(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Sensor does not switch when relevant event starts later than tracked."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        # Tracking an event that starts tomorrow
+        early_event = _make_event(
+            summary="Reserved - EarlyGuest",
+            start=now + timedelta(days=1),
+            end=now + timedelta(days=3),
+        )
+        mock_checkin_coordinator.data = [early_event]
+        sensor._handle_coordinator_update()
+        assert sensor._tracked_event_summary == "Reserved - EarlyGuest"
+
+        # Later event appears — data[0] is still early_event because sorted
+        late_event = _make_event(
+            summary="Reserved - LateGuest",
+            start=now + timedelta(days=5),
+            end=now + timedelta(days=8),
+        )
+        mock_checkin_coordinator.data = [early_event, late_event]
+        sensor._handle_coordinator_update()
+
+        # Must remain tracking early_event
+        assert sensor._tracked_event_summary == "Reserved - EarlyGuest"
+
+
+# ===========================================================================
+# _get_relevant_event skips ended events
+# ===========================================================================
+
+
+class TestGetRelevantEvent:
+    """Tests for _get_relevant_event filtering ended events."""
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_skips_ended_events(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """_get_relevant_event skips events whose end has passed."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        ended_event = _make_event(
+            summary="Reserved - EndedGuest",
+            start=now - timedelta(days=3),
+            end=now - timedelta(hours=1),
+        )
+        active_event = _make_event(
+            summary="Reserved - ActiveGuest",
+            start=now - timedelta(hours=2),
+            end=now + timedelta(days=1),
+        )
+        mock_checkin_coordinator.data = [ended_event, active_event]
+
+        result = sensor._get_relevant_event()
+        assert result is not None
+        assert result.summary == "Reserved - ActiveGuest"
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_returns_none_when_all_ended(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """_get_relevant_event returns None when all events have ended."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        ended1 = _make_event(
+            summary="Reserved - A",
+            start=now - timedelta(days=5),
+            end=now - timedelta(hours=2),
+        )
+        ended2 = _make_event(
+            summary="Reserved - B",
+            start=now - timedelta(days=2),
+            end=now - timedelta(hours=1),
+        )
+        mock_checkin_coordinator.data = [ended1, ended2]
+
+        result = sensor._get_relevant_event()
+        assert result is None
+
+
+# ===========================================================================
+# Keymaster slot validation in awaiting state
+# ===========================================================================
+
+
+class TestKeyasterSlotValidation:
+    """Tests for keymaster slot validation in AWAITING state."""
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_rejects_mismatched_slot(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Keymaster unlock is rejected when slot belongs to different guest."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        event = _make_event(
+            summary="Reserved - Alice",
+            start=now + timedelta(hours=4),
+            end=now + timedelta(days=3),
+        )
+        mock_checkin_coordinator.data = [event]
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+        assert sensor._tracked_event_slot_name == "Alice"
+
+        # Set up event_overrides to return a different guest for slot 10
+        mock_checkin_coordinator.event_overrides.ready = True
+        mock_checkin_coordinator.event_overrides.get_slot_name.return_value = "Bob"
+        mock_checkin_coordinator.lockname = "front_door"
+
+        sensor.async_handle_keymaster_unlock(code_slot_num=10)
+        await hass.async_block_till_done()
+
+        # Should remain in awaiting — mismatch rejected
+        assert sensor._state == CHECKIN_STATE_AWAITING
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_allows_when_slot_name_empty(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Keymaster unlock proceeds when slot has no name assigned yet."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        event = _make_event(
+            summary="Reserved - Alice",
+            start=now + timedelta(hours=4),
+            end=now + timedelta(days=3),
+        )
+        mock_checkin_coordinator.data = [event]
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+        assert sensor._tracked_event_slot_name == "Alice"
+
+        # event_overrides.ready is True but slot has no name
+        mock_checkin_coordinator.event_overrides.ready = True
+        mock_checkin_coordinator.event_overrides.get_slot_name.return_value = ""
+        mock_checkin_coordinator.lockname = "front_door"
+
+        sensor.async_handle_keymaster_unlock(code_slot_num=10)
+        await hass.async_block_till_done()
+
+        # Should proceed to checked_in (empty name = no validation possible)
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_allows_matching_slot(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Keymaster unlock proceeds when slot name matches tracked event."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        event = _make_event(
+            summary="Reserved - Alice",
+            start=now + timedelta(hours=4),
+            end=now + timedelta(days=3),
+        )
+        mock_checkin_coordinator.data = [event]
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+        assert sensor._tracked_event_slot_name == "Alice"
+
+        # event_overrides returns matching name
+        mock_checkin_coordinator.event_overrides.ready = True
+        mock_checkin_coordinator.event_overrides.get_slot_name.return_value = "Alice"
+        mock_checkin_coordinator.lockname = "front_door"
+
+        sensor.async_handle_keymaster_unlock(code_slot_num=10)
+        await hass.async_block_till_done()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_allows_when_overrides_not_ready(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Keymaster unlock proceeds when overrides are not ready yet."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        event = _make_event(
+            summary="Reserved - Alice",
+            start=now + timedelta(hours=4),
+            end=now + timedelta(days=3),
+        )
+        mock_checkin_coordinator.data = [event]
+        sensor._handle_coordinator_update()
+        assert sensor._state == CHECKIN_STATE_AWAITING
+
+        # event_overrides exists but not ready
+        mock_checkin_coordinator.event_overrides.ready = False
+        mock_checkin_coordinator.lockname = "front_door"
+
+        sensor.async_handle_keymaster_unlock(code_slot_num=10)
+        await hass.async_block_till_done()
+
+        # Should proceed — can't validate without ready overrides
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN


### PR DESCRIPTION
## Summary

The check-in sensor could track the wrong event when a more relevant (earlier-starting) reservation appeared in coordinator data while in the `awaiting_checkin` state. This caused the sensor to check in with the wrong event's end time, preventing auto-checkout at the correct time.

## Root Cause

When in `awaiting_checkin`, the sensor would find its tracked event in coordinator data and stay locked onto it without checking if `data[0]` (the most relevant event) had changed. A nearer reservation added to the calendar later would be ignored.

Combined with no slot validation in the keymaster unlock path, the wrong guest's lock code could trigger check-in for the wrong event, setting the auto-checkout timer to the wrong date.

## Changes

Three defects are addressed:

1. **`_get_relevant_event()`** now skips events whose end has already passed, preventing tracking of stale events that remain in coordinator data until the next midnight filter.

2. **Awaiting state re-evaluation** — after finding the tracked event still in coordinator data, the handler now compares it against the most relevant event. If a different, earlier-starting event exists (that wasn't previously checked-out), the sensor switches to tracking it.

3. **Keymaster slot validation** — `async_handle_keymaster_unlock` now validates that the unlocking slot's guest name matches the tracked event when `event_overrides` are ready, rejecting mismatched check-ins as defense-in-depth.

## Testing

- 9 new unit tests covering all three fixes
- All 815 tests pass
- Lint (ruff), type checking (mypy), and formatting all pass