### PR TITLE
Fix(checkin): self-heal wrong-event checked_in

### DIFF
--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -563,6 +563,32 @@ class CheckinTrackingSensor(
             if tracked is not None:
                 self._event_missing_warned = False
                 now = dt_util.now()
+                # Self-healing: if the tracked event hasn't started
+                # yet but the sensor is in checked_in, the sensor is
+                # tracking the wrong event (likely from the bug fixed
+                # in PR #547).  Force checkout so re-evaluation picks
+                # up the correct event.
+                if tracked.start > now:
+                    _LOGGER.warning(
+                        "Self-healing: sensor is checked_in but "
+                        "tracked event '%s' starts at %s which is "
+                        "in the future; forcing checkout for %s",
+                        tracked.summary,
+                        tracked.start,
+                        self.coordinator.name,
+                    )
+                    self._cancel_timer()
+                    self._transition_to_checked_out(
+                        source="automatic",
+                        linger_baseline=now,
+                    )
+                    event = self._get_relevant_event()
+                    if event is not None and (
+                        self._event_key(event.summary, event.start)
+                        != self._checked_out_event_key
+                    ):
+                        self._transition_to_awaiting(event)
+                    return
                 if tracked.end <= now:
                     # Event has ended — force checkout as safety net
                     # in case the auto-checkout timer failed to fire.

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -568,7 +568,7 @@ class CheckinTrackingSensor(
                 # tracking the wrong event (likely from the bug fixed
                 # in PR #547).  Force checkout so re-evaluation picks
                 # up the correct event.
-                if tracked.start > now:
+                if tracked.start > now and self._checkin_source == "automatic":
                     _LOGGER.warning(
                         "Self-healing: sensor is checked_in but "
                         "tracked event '%s' starts at %s which is "
@@ -577,7 +577,6 @@ class CheckinTrackingSensor(
                         tracked.start,
                         self.coordinator.name,
                     )
-                    self._cancel_timer()
                     self._transition_to_checked_out(
                         source="automatic",
                         linger_baseline=now,

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -563,11 +563,10 @@ class CheckinTrackingSensor(
             if tracked is not None:
                 self._event_missing_warned = False
                 now = dt_util.now()
-                # Self-healing: if the tracked event hasn't started
-                # yet but the sensor is in checked_in, the sensor is
-                # tracking the wrong event (likely from the bug fixed
-                # in PR #547).  Force checkout so re-evaluation picks
-                # up the correct event.
+                # Self-healing: if an automatically checked-in sensor
+                # is tracking an event that has not started yet, it is
+                # tracking the wrong event. Force checkout so
+                # re-evaluation picks up the correct event.
                 if tracked.start > now and self._checkin_source == "automatic":
                     _LOGGER.warning(
                         "Self-healing: sensor is checked_in but "

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -5482,3 +5482,110 @@ class TestKeymasterSlotValidation:
 
         # Should proceed — can't validate without ready overrides
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
+
+
+class TestCheckedInSelfHealing:
+    """Tests for checked_in self-healing when tracking a future event."""
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_forces_checkout_when_tracked_event_in_future(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Sensor forces checkout when checked_in but tracked event hasn't started."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        # Event starts tomorrow — should NOT be checked_in yet
+        future_event = _make_event(
+            summary="Reserved - FutureGuest",
+            start=now + timedelta(days=1),
+            end=now + timedelta(days=4),
+        )
+
+        # Manually put sensor in a bad state (simulating the bug)
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = future_event.summary
+        sensor._tracked_event_start = future_event.start
+        sensor._tracked_event_end = future_event.end
+        sensor._tracked_event_slot_name = "FutureGuest"
+
+        mock_checkin_coordinator.data = [future_event]
+        sensor._handle_coordinator_update()
+
+        # Should have self-healed to checked_out
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._checkout_source == "automatic"
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_self_heals_to_active_event_when_present(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Sensor re-evaluates to an active event after self-healing checkout."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        active_event = _make_event(
+            summary="Reserved - ActiveGuest",
+            start=now - timedelta(hours=2),
+            end=now + timedelta(days=3),
+        )
+        future_event = _make_event(
+            summary="Reserved - FutureGuest",
+            start=now + timedelta(days=1),
+            end=now + timedelta(days=4),
+        )
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = future_event.summary
+        sensor._tracked_event_start = future_event.start
+        sensor._tracked_event_end = future_event.end
+        sensor._tracked_event_slot_name = "FutureGuest"
+
+        mock_checkin_coordinator.data = [active_event, future_event]
+        sensor._handle_coordinator_update()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+        assert sensor._tracked_event_summary == active_event.summary
+        assert sensor._checkin_source == "automatic"
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_no_self_healing_when_event_already_started(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Sensor stays checked_in when tracked event has already started (normal)."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        # Event started 2 hours ago — normal checked_in state
+        active_event = _make_event(
+            summary="Reserved - ActiveGuest",
+            start=now - timedelta(hours=2),
+            end=now + timedelta(days=3),
+        )
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = active_event.summary
+        sensor._tracked_event_start = active_event.start
+        sensor._tracked_event_end = active_event.end
+        sensor._tracked_event_slot_name = "ActiveGuest"
+
+        mock_checkin_coordinator.data = [active_event]
+        sensor._handle_coordinator_update()
+
+        # Should remain checked_in
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -5507,8 +5507,9 @@ class TestCheckedInSelfHealing:
             end=now + timedelta(days=4),
         )
 
-        # Manually put sensor in a bad state (simulating the bug)
+        # Manually put sensor in a bad automatic state (simulating the bug)
         sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._checkin_source = "automatic"
         sensor._tracked_event_summary = future_event.summary
         sensor._tracked_event_start = future_event.start
         sensor._tracked_event_end = future_event.end
@@ -5546,6 +5547,7 @@ class TestCheckedInSelfHealing:
         )
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._checkin_source = "automatic"
         sensor._tracked_event_summary = future_event.summary
         sensor._tracked_event_start = future_event.start
         sensor._tracked_event_end = future_event.end
@@ -5557,6 +5559,38 @@ class TestCheckedInSelfHealing:
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
         assert sensor._tracked_event_summary == active_event.summary
         assert sensor._checkin_source == "automatic"
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_no_self_healing_for_keymaster_early_arrival(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Keymaster early arrivals remain checked_in before event start."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        future_event = _make_event(
+            summary="Reserved - EarlyGuest",
+            start=now + timedelta(hours=4),
+            end=now + timedelta(days=3),
+        )
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._checkin_source = "keymaster"
+        sensor._tracked_event_summary = future_event.summary
+        sensor._tracked_event_start = future_event.start
+        sensor._tracked_event_end = future_event.end
+        sensor._tracked_event_slot_name = "EarlyGuest"
+
+        mock_checkin_coordinator.data = [future_event]
+        sensor._handle_coordinator_update()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+        assert sensor._checkout_source is None
 
     @freeze_time("2025-07-01T12:00:00+00:00")
     async def test_no_self_healing_when_event_already_started(
@@ -5579,6 +5613,7 @@ class TestCheckedInSelfHealing:
         )
 
         sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._checkin_source = "automatic"
         sensor._tracked_event_summary = active_event.summary
         sensor._tracked_event_start = active_event.start
         sensor._tracked_event_end = active_event.end


### PR DESCRIPTION
## Summary

Adds a self-healing safety net in the `checked_in` state handler.

When the sensor is in `checked_in` state but the tracked event's start time is still in the future, the sensor is clearly tracking the wrong event (a consequence of the awaiting re-evaluation bug fixed in PR #547). On the next coordinator update, the sensor now forces an automatic checkout so the normal state machine re-evaluation can pick up the correct event.

## Behavior

- If `tracked.start > now` while in `checked_in`: force checkout with `linger_baseline=now`
- Immediately re-evaluate to a different relevant event when one is already present
- The post-checkout linger/follow-on logic continues to handle same-event future reservations naturally
- Existing sensors stuck in the wrong state will self-correct on the first coordinator refresh after upgrading

## Testing

- 3 unit tests: verifies self-healing fires for future events, re-evaluates to an active event when present, and does NOT fire for active tracked events
- All existing tests pass
