### PR TITLE
Fix(core): Guard update_listener after unload

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -305,6 +305,10 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
     if not config_entry.options:
         return
 
+    # Guard against listener firing after entry has been unloaded
+    if config_entry.entry_id not in hass.data.get(DOMAIN, {}):
+        return
+
     new_data = config_entry.options.copy()
     new_data.pop(CONF_GENERATE, None)
 

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -306,13 +306,14 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
         return
 
     # Guard against listener firing after entry has been unloaded
-    if config_entry.entry_id not in hass.data.get(DOMAIN, {}):
+    entry_data = hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
+    if entry_data is None:
         return
 
     new_data = config_entry.options.copy()
     new_data.pop(CONF_GENERATE, None)
 
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
+    coordinator = entry_data[COORDINATOR]
 
     # do not update the creation datetime if it already exists (which it should)
     new_data[CONF_CREATION_DATETIME] = coordinator.created
@@ -328,12 +329,15 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
     # Update the calendar config
     await coordinator.update_config(new_data)
 
+    entry_data = hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
+    if entry_data is None:
+        return
+    coordinator = entry_data[COORDINATOR]
+
     # Unsubscribe to any listeners so we can create new ones
-    for unsub_listener in hass.data[DOMAIN][config_entry.entry_id].get(
-        UNSUB_LISTENERS, []
-    ):
+    for unsub_listener in entry_data.get(UNSUB_LISTENERS, []):
         unsub_listener()
-    hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []).clear()
+    entry_data.get(UNSUB_LISTENERS, []).clear()
 
     if coordinator.lockname:
         await async_start_listener(hass, config_entry)


### PR DESCRIPTION
When eager tasks fire the update_listener callback after async_unload_entry has already removed the config entry from hass.data, a KeyError is raised during test teardown.

This adds an early-return guard to silently skip the update when the entry is no longer registered in hass.data[DOMAIN].

Failing test: tests/unit/test_config_flow.py::test_config_flow_lock_entry_none_normalized
CI run: https://github.com/tykeal/homeassistant-rental-control/actions/runs/26416667125/job/77762683574