### PR TITLE
Fix(checkin): Widen self-heal to all sources

### DIFF
--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -64,6 +64,7 @@ _CHECKIN_STATE_ICONS: dict[str, str] = {
     CHECKIN_STATE_CHECKED_OUT: "mdi:airplane",
     CHECKIN_STATE_NO_RESERVATION: "mdi:bed-empty",
 }
+_SELF_HEAL_FUTURE_THRESHOLD = timedelta(hours=24)
 
 
 class CheckinExtraStoredData(ExtraStoredData):
@@ -563,15 +564,16 @@ class CheckinTrackingSensor(
             if tracked is not None:
                 self._event_missing_warned = False
                 now = dt_util.now()
-                # Self-healing: if an automatically checked-in sensor
-                # is tracking an event that has not started yet, it is
-                # tracking the wrong event. Force checkout so
-                # re-evaluation picks up the correct event.
-                if tracked.start > now and self._checkin_source == "automatic":
+                # Self-healing: if the tracked event starts more than
+                # 24 hours from now, the sensor is tracking the wrong
+                # event regardless of how check-in was triggered.
+                # Events starting within 24 hours may be legitimate
+                # early arrivals via keymaster.
+                if tracked.start > now + _SELF_HEAL_FUTURE_THRESHOLD:
                     _LOGGER.warning(
                         "Self-healing: sensor is checked_in but "
                         "tracked event '%s' starts at %s which is "
-                        "in the future; forcing checkout for %s",
+                        "more than 24h in the future; forcing checkout for %s",
                         tracked.summary,
                         tracked.start,
                         self.coordinator.name,
@@ -1339,7 +1341,7 @@ class CheckinTrackingSensor(
 
         Auto-corrects stale state and reschedules timers:
 
-        * ``checked_in`` with ended event → ``checked_out``
+        * ``checked_in`` with far-future or ended event → ``checked_out``
         * ``awaiting_checkin`` with passed start (time-based) → ``checked_in``
         * ``checked_out`` with expired linger / new event → reprocess
         * Valid state with pending transition → reschedule timer
@@ -1348,6 +1350,32 @@ class CheckinTrackingSensor(
         current_state = self._state
 
         if current_state == CHECKIN_STATE_CHECKED_IN:
+            if (
+                self._tracked_event_start is not None
+                and self._tracked_event_start > now + _SELF_HEAL_FUTURE_THRESHOLD
+            ):
+                # Tracked event is far in the future — sensor was
+                # tracking the wrong event. Silent checkout so the
+                # coordinator update can pick up the correct event.
+                _LOGGER.debug(
+                    "Stale restore: checked_in but tracked event starts %s "
+                    "(>24h away), forcing checkout (silent)",
+                    self._tracked_event_start,
+                )
+                self._state = CHECKIN_STATE_CHECKED_OUT
+                self._checkout_source = "automatic"
+                self._checkout_time = now
+                if (
+                    self._tracked_event_summary is not None
+                    and self._tracked_event_start is not None
+                ):
+                    self._checked_out_event_key = self._event_key(
+                        self._tracked_event_summary,
+                        self._tracked_event_start,
+                    )
+                self._compute_linger_timing()
+                self.async_write_ha_state()
+                return
             if self._tracked_event_end is not None and self._tracked_event_end <= now:
                 # Event has ended while we were down → silent checkout
                 # (no HA bus event to avoid triggering automations on

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -1340,6 +1340,49 @@ class TestStaleStateValidation:
         # Checkout time should be anchored to event end, not restore time
         assert sensor._checkout_time == end
 
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_checked_in_transitions_to_checked_out_when_event_far_future(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test restored checked_in → checked_out for far-future event."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        start = now + timedelta(hours=25)
+        end = start + timedelta(hours=48)
+
+        data_dict = _make_extra_data_dict(
+            state=CHECKIN_STATE_CHECKED_IN,
+            summary="Reserved - John Smith",
+            start=start,
+            end=end,
+            slot_name="John Smith",
+            checkin_source="keymaster",
+        )
+
+        mock_checkin_coordinator.data = []
+        mock_checkin_coordinator.last_update_success = True
+
+        with patch.object(
+            sensor,
+            "async_get_last_extra_data",
+            new=AsyncMock(return_value=_mock_extra_data(data_dict)),
+        ):
+            await sensor.async_added_to_hass()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._checkout_source == "automatic"
+        assert sensor._checkout_time == now
+        assert (
+            sensor._checked_out_event_key
+            == f"Reserved - John Smith|{start.isoformat()}"
+        )
+
     async def test_awaiting_transitions_to_checked_in_when_start_passed(
         self,
         hass: HomeAssistant,
@@ -5488,26 +5531,24 @@ class TestCheckedInSelfHealing:
     """Tests for checked_in self-healing when tracking a future event."""
 
     @freeze_time("2025-07-01T12:00:00+00:00")
-    async def test_forces_checkout_when_tracked_event_in_future(
+    async def test_forces_checkout_when_tracked_event_far_future(
         self,
         hass: HomeAssistant,
         mock_checkin_coordinator: MagicMock,
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
-        """Sensor forces checkout when checked_in but tracked event hasn't started."""
+        """Sensor forces checkout when tracked event starts more than 24h away."""
         sensor = _create_sensor(
             hass, mock_checkin_coordinator, mock_checkin_config_entry
         )
 
         now = dt_util.now()
-        # Event starts tomorrow — should NOT be checked_in yet
         future_event = _make_event(
             summary="Reserved - FutureGuest",
-            start=now + timedelta(days=1),
+            start=now + timedelta(hours=25),
             end=now + timedelta(days=4),
         )
 
-        # Manually put sensor in a bad automatic state (simulating the bug)
         sensor._state = CHECKIN_STATE_CHECKED_IN
         sensor._checkin_source = "automatic"
         sensor._tracked_event_summary = future_event.summary
@@ -5518,7 +5559,6 @@ class TestCheckedInSelfHealing:
         mock_checkin_coordinator.data = [future_event]
         sensor._handle_coordinator_update()
 
-        # Should have self-healed to checked_out
         assert sensor._state == CHECKIN_STATE_CHECKED_OUT
         assert sensor._checkout_source == "automatic"
 
@@ -5542,7 +5582,7 @@ class TestCheckedInSelfHealing:
         )
         future_event = _make_event(
             summary="Reserved - FutureGuest",
-            start=now + timedelta(days=1),
+            start=now + timedelta(hours=25),
             end=now + timedelta(days=4),
         )
 
@@ -5559,6 +5599,38 @@ class TestCheckedInSelfHealing:
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
         assert sensor._tracked_event_summary == active_event.summary
         assert sensor._checkin_source == "automatic"
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_self_heals_for_keymaster_far_future_event(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Keymaster check-in heals when tracked event starts more than 24h away."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+
+        now = dt_util.now()
+        future_event = _make_event(
+            summary="Reserved - WrongGuest",
+            start=now + timedelta(hours=25),
+            end=now + timedelta(days=3),
+        )
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._checkin_source = "keymaster"
+        sensor._tracked_event_summary = future_event.summary
+        sensor._tracked_event_start = future_event.start
+        sensor._tracked_event_end = future_event.end
+        sensor._tracked_event_slot_name = "WrongGuest"
+
+        mock_checkin_coordinator.data = [future_event]
+        sensor._handle_coordinator_update()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._checkout_source == "automatic"
 
     @freeze_time("2025-07-01T12:00:00+00:00")
     async def test_no_self_healing_for_keymaster_early_arrival(


### PR DESCRIPTION
Fixes sensors stuck in `checked_in` state when keymaster triggered check-in on the wrong event.

## Problem
PR #549 added self-healing for sensors tracking a future event, but restricted it to `_checkin_source == "automatic"`. Sensors checked in via keymaster (door code) remained stuck because their source is `"keymaster"`.

## Fix
- Replace source-based restriction with a 24-hour time threshold: if tracked event starts >24h from now, force checkout regardless of source
- Add the same check to `_validate_restored_state()` so stuck sensors self-correct immediately on HA restart
- Events starting within 24h are preserved (legitimate early arrival via keymaster)

## Testing
- Updated existing self-healing tests
- Added keymaster-source self-heal test (>24h → heals)
- Added early-arrival preservation test (<24h → no heal)
- Added restore-time self-heal test