### PR TITLE
Chore(ci): Update grype ignore rules

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -37,10 +37,37 @@ ignore:
       version: "12.1.1"
       type: python
 
-  # uv build dependency — low severity, not shipped
-  # to users. Fixed in 0.11.6.
-  - vulnerability: GHSA-pjjw-68hj-v9mw
+  # uv transitive dependency via homeassistant —
+  # we cannot pin it directly. Fixed in 0.11.15.
+  - vulnerability: GHSA-4gg8-gxpx-9rph
     package:
       name: uv
-      version: "0.11.1"
+      version: "0.11.8"
+      type: python
+
+  # zeroconf transitive dependency via
+  # homeassistant — we cannot pin it directly.
+  # Fixed in 0.149.5.
+  - vulnerability: GHSA-9pgc-3ccv-5297
+    package:
+      name: zeroconf
+      version: "0.148.0"
+      type: python
+
+  # zeroconf transitive dependency via
+  # homeassistant — we cannot pin it directly.
+  # Fixed in 0.149.6.
+  - vulnerability: GHSA-phvx-9mgw-67r5
+    package:
+      name: zeroconf
+      version: "0.148.0"
+      type: python
+
+  # zeroconf transitive dependency via
+  # homeassistant — we cannot pin it directly.
+  # Fixed in 0.149.7.
+  - vulnerability: GHSA-rfg2-pjw2-56x2
+    package:
+      name: zeroconf
+      version: "0.148.0"
       type: python

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -71,3 +71,21 @@ ignore:
       name: zeroconf
       version: "0.148.0"
       type: python
+
+  # aiohttp transitive dependency via
+  # homeassistant — we cannot pin it directly.
+  # Fixed in 3.14.0.
+  - vulnerability: GHSA-jg22-mg44-37j8
+    package:
+      name: aiohttp
+      version: "3.13.5"
+      type: python
+
+  # aiohttp transitive dependency via
+  # homeassistant — we cannot pin it directly.
+  # Fixed in 3.14.0.
+  - vulnerability: GHSA-hg6j-4rv6-33pg
+    package:
+      name: aiohttp
+      version: "3.13.5"
+      type: python


### PR DESCRIPTION
## Summary
- add grype ignores for transitive CVEs inherited from homeassistant
- remove the stale uv 0.11.1 ignore rule that is no longer in the lockfile
- unblock the Generate SBOM check on PRs #553, #554, #559, #560, #561, #562, and #563

## Context
These vulnerabilities are reported in transitive dependencies that come from homeassistant, so they cannot be pinned directly in this repository.

Ignored advisories:
- GHSA-4gg8-gxpx-9rph for uv 0.11.8
- GHSA-9pgc-3ccv-5297 for zeroconf 0.148.0
- GHSA-phvx-9mgw-67r5 for zeroconf 0.148.0
- GHSA-rfg2-pjw2-56x2 for zeroconf 0.148.0
- GHSA-jg22-mg44-37j8 for aiohttp 3.13.5
- GHSA-hg6j-4rv6-33pg for aiohttp 3.13.5