### PR TITLE
Chore(ci): Align workflows with reference

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -280,11 +280,7 @@ jobs:
           egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
-<<<<<<< HEAD
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-=======
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
->>>>>>> 7c2e1ee (Fix(ci): Checkout before Grype scan)
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -280,7 +280,11 @@ jobs:
           egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
+<<<<<<< HEAD
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+=======
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+>>>>>>> 7c2e1ee (Fix(ci): Checkout before Grype scan)
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -23,8 +23,7 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
-permissions:
-  actions: write  # Required for cache deletion when clear_cache is true
+permissions: {}
 
 jobs:
   repository-metadata:
@@ -56,8 +55,84 @@ jobs:
           artifact_upload: 'true'
           artifact_formats: 'json'
 
+  clear-cache:
+    name: 'Clear Python Caches'
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      && github.event.inputs.clear_cache == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Clear Python dependency caches'
+        env:
+          REPO: "${{ github.repository }}"
+        run: |
+          # Clear Python dependency caches
+          echo "Clearing Python dependency caches 🗑️"
+          deleted=0
+          failed=0
+          for prefix in python- setup-python- setup-uv-; do
+            while true; do
+              if ! keys=$(gh cache list --repo "$REPO" \
+                --key "$prefix" --limit 100 \
+                --json key --jq '.[].key' 2>&1); then
+                echo "::warning::Failed to list caches" \
+                  "for prefix '$prefix': $keys"
+                echo "Warning: failed to list caches for" \
+                  "prefix \`$prefix\`: $keys" \
+                  >> "$GITHUB_STEP_SUMMARY"
+                failed=1
+                break
+              fi
+              [ -n "$keys" ] || break
+
+              batch_deleted=0
+              while IFS= read -r key; do
+                [ -n "$key" ] || continue
+                if delete_out=$(gh cache delete "$key" \
+                  --repo "$REPO" 2>&1); then
+                  echo "Deleted cache: $key"
+                  deleted=$((deleted + 1))
+                  batch_deleted=$((batch_deleted + 1))
+                else
+                  echo "::warning::Failed to delete" \
+                    "cache '$key': $delete_out"
+                  echo "Warning: failed to delete cache" \
+                    "\`$key\`: $delete_out" \
+                    >> "$GITHUB_STEP_SUMMARY"
+                  failed=1
+                fi
+              done <<< "$keys"
+
+              [ "$batch_deleted" -gt 0 ] || break
+            done
+          done
+          if [ "$deleted" -gt 0 ]; then
+            echo "Cleared $deleted Python cache(s) ✅" \
+              >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$failed" -eq 0 ]; then
+            echo "No Python caches found to clear 💬" \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "$failed" -ne 0 ]; then
+            echo "Cache clearing completed with errors ❌" \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
   python-build:
     name: 'Python Build'
+    needs: 'clear-cache'
+    if: ${{ always() && !cancelled() }}
     runs-on: 'ubuntu-latest'
     outputs:
       matrix_json: "${{ steps.python-build.outputs.matrix_json }}"
@@ -65,10 +140,7 @@ jobs:
       artefact_path: "${{ steps.python-build.outputs.artefact_path }}"
     permissions:
       contents: read
-      actions: write  # Required for cache deletion when clear_cache is true
     timeout-minutes: 12
-    env:
-      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
@@ -83,13 +155,12 @@ jobs:
         id: python-build
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/python-build-action@5f570d5d17a7315074a824a91c6a705b6fc5c7dd  # v1.1.2
-        with:
-          clear_cache: ${{ github.event.inputs.clear_cache || 'false' }}
 
   python-tests:
     name: 'Python Tests'
     runs-on: 'ubuntu-latest'
     needs: 'python-build'
+    if: ${{ !cancelled() && needs.python-build.result == 'success' }}
     # Matrix job
     strategy:
       fail-fast: false
@@ -122,6 +193,7 @@ jobs:
     name: 'Python Audit'
     runs-on: 'ubuntu-latest'
     needs: 'python-build'
+    if: ${{ !cancelled() && needs.python-build.result == 'success' }}
     # Matrix job
     strategy:
       fail-fast: false
@@ -144,6 +216,7 @@ jobs:
         uses: lfreleng-actions/python-audit-action@78b00a589ced3e8f70d0cd03fd592b8c92298dfd  # v0.3.0
         with:
           python_version: "${{ matrix.python-version }}"
+          permit_fail: "${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}"
           # pip CVE-2026-3219: concatenated tar/ZIP handling in pip
           # itself (runner tooling, not project dependency)
           ignore_vulns: 'GHSA-58qw-9mgm-455v'
@@ -152,6 +225,7 @@ jobs:
     name: 'Generate SBOM'
     runs-on: ubuntu-latest
     needs: 'python-build'
+    if: ${{ !cancelled() && needs.python-build.result == 'success' }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -182,28 +256,92 @@ jobs:
             sbom-cyclonedx.xml
           retention-days: 45
 
-      - name: "Security scan with Grype (SARIF)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-sarif
-        with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "sarif"
-          output-file: "grype-results.sarif"
-          fail-build: "true"
-          config: ".grype.yaml"
+      - name: "SBOM summary"
+        run: |
+            # SBOM summary
+            {
+              echo "## SBOM Summary"
+              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
+              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+            } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "Security scan with Grype (Text/Table)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-table
-        if: always()
+  grype:
+    name: 'Grype Audit SBOM'
+    runs-on: ubuntu-latest
+    needs: 'sbom'
+    if: ${{ !cancelled() && needs.sbom.result == 'success' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "table"
-          output-file: "grype-results.txt"
-          fail-build: "false"
-          config: ".grype.yaml"
+          egress-policy: 'audit'
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: "Download SBOM artefact"
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sbom-files
+
+      - name: "Install Grype"
+        id: grype
+        # yamllint disable-line rule:line-length
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        with:
+          cache-db: "true"
+
+      - name: "Grype audit SBOM"
+        id: grype-audit
+        env:
+          GRYPE_CMD: "${{ steps.grype.outputs.cmd }}"
+          NO_BLOCK_AUDIT_FAIL: >-
+            ${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}
+        run: |
+            # Run grype once, emitting all three output formats
+            # Render the human-readable table in this step's log
+            set +e
+            "${GRYPE_CMD}" \
+              -o "sarif=grype-results.sarif" \
+              -o "json=grype-results.json" \
+              -o "table=grype-results.txt" \
+              --fail-on medium \
+              -c .grype.yaml \
+              "sbom:sbom-cyclonedx.json"
+            grype_exit=$?
+            set -e
+
+            echo "--- Grype scan results ---"
+            if [ -f grype-results.txt ]; then
+              cat grype-results.txt
+            else
+              echo "No table output produced"
+            fi
+
+            if [ "${grype_exit}" = "0" ]; then
+              echo "No vulnerabilities at or above 'medium'"
+              exit 0
+            fi
+            if [ "${grype_exit}" != "2" ]; then
+              echo "::error::Grype exited with code ${grype_exit}"
+              exit "${grype_exit}"
+            fi
+
+            if [ "${NO_BLOCK_AUDIT_FAIL}" = "true" ]; then
+              echo "::warning::Grype found vulnerabilities at or" \
+                "above the 'medium' threshold, but" \
+                "NO_BLOCK_AUDIT_FAIL is set so the job will not" \
+                "fail."
+              exit 0
+            fi
+            echo "::error::Grype found vulnerabilities at or above" \
+              "the 'medium' severity threshold. See the table" \
+              "above for the offending packages and CVEs."
+            exit 1
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length
@@ -213,14 +351,62 @@ jobs:
           name: grype-scan-results
           path: |
             grype-results.sarif
+            grype-results.json
             grype-results.txt
           retention-days: 90
+          if-no-files-found: warn
 
       - name: "Grype summary"
         if: always()
         run: |
-          # Grype summary
-          echo "## Grype Summary" >> "$GITHUB_STEP_SUMMARY"
-          [ -f grype-results.txt ] && cat grype-results.txt \
-            >> "$GITHUB_STEP_SUMMARY" || echo "No scan results available" \
-            >> "$GITHUB_STEP_SUMMARY"
+            # Render a Markdown table of output in step summary.
+            {
+              echo "## Grype Vulnerability Scan"
+              echo ""
+              if [ ! -f grype-results.json ]; then
+                echo "No scan results available"
+                exit 0
+              fi
+              match_count=$(jq '.matches | length' grype-results.json)
+              if [ "${match_count}" = "0" ]; then
+                echo "No vulnerabilities found at or above the" \
+                  "configured severity threshold."
+                exit 0
+              fi
+              echo "Found ${match_count} matching Grype record(s)."
+              echo ""
+              echo "| Package | Installed | Fixed In | Type |" \
+                "Vulnerability | Severity | EPSS | Risk |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+              jq -r '
+                def esc: tostring | gsub("\\|"; "\\|");
+                def round2: (. * 100 | round) / 100;
+                def epss_pct:
+                  ( .vulnerability.epss // [] ) as $e
+                  | if ($e | length) == 0 then "-"
+                    else ( $e[0].epss // 0 ) as $p
+                      | if $p == 0 then "0%"
+                        elif ($p * 100) < 0.01 then "<0.01%"
+                        else ( ($p * 100) | round2 | tostring
+                               + "%" ) end
+                    end;
+                def risk_fmt:
+                  .vulnerability.risk
+                  | if . == null then "-"
+                    elif type == "number" then
+                      (round2 | tostring)
+                    else (. | tostring) end;
+                .matches[] |
+                [ (.artifact.name // "-" | esc),
+                  (.artifact.version // "-" | esc),
+                  ( ( .vulnerability.fix.versions // [] )
+                    | if length == 0 then "-"
+                      else join(", ") end | esc ),
+                  (.artifact.type // "-" | esc),
+                  (.vulnerability.id // "-" | esc),
+                  (.vulnerability.severity // "-" | esc),
+                  epss_pct,
+                  risk_fmt
+                ] | "| " + join(" | ") + " |"
+              ' grype-results.json
+            } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -249,7 +249,11 @@ jobs:
           egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
+<<<<<<< HEAD
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+=======
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+>>>>>>> 7c2e1ee (Fix(ci): Checkout before Grype scan)
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -249,11 +249,7 @@ jobs:
           egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
-<<<<<<< HEAD
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-=======
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
->>>>>>> 7c2e1ee (Fix(ci): Checkout before Grype scan)
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -188,6 +188,7 @@ jobs:
         uses: lfreleng-actions/python-audit-action@78b00a589ced3e8f70d0cd03fd592b8c92298dfd  # v0.3.0
         with:
           python_version: "${{ matrix.python-version }}"
+          permit_fail: "${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}"
           ignore_vulns: 'GHSA-58qw-9mgm-455v'
 
   sbom:
@@ -224,30 +225,92 @@ jobs:
             sbom-cyclonedx.xml
           retention-days: 45
 
-      - name: "Security scan with Grype (SARIF)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-sarif
-        # Do not block releases on Grype findings
-        continue-on-error: true
-        with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "sarif"
-          output-file: "grype-results.sarif"
-          fail-build: "true"
-          config: ".grype.yaml"
+      - name: "SBOM summary"
+        run: |
+            # SBOM summary
+            {
+              echo "## SBOM Summary"
+              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
+              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+            } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "Security scan with Grype (Text/Table)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-table
-        if: always()
+  grype:
+    name: 'Grype Audit SBOM'
+    runs-on: ubuntu-latest
+    needs: 'sbom'
+    if: ${{ !cancelled() && needs.sbom.result == 'success' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "table"
-          output-file: "grype-results.txt"
-          fail-build: "false"
-          config: ".grype.yaml"
+          egress-policy: 'audit'
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: "Download SBOM artefact"
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sbom-files
+
+      - name: "Install Grype"
+        id: grype
+        # yamllint disable-line rule:line-length
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        with:
+          cache-db: "true"
+
+      - name: "Grype audit SBOM"
+        id: grype-audit
+        env:
+          GRYPE_CMD: "${{ steps.grype.outputs.cmd }}"
+          NO_BLOCK_AUDIT_FAIL: >-
+            ${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}
+        run: |
+            # Run grype once, emitting all three output formats
+            # Render the human-readable table in this step's log
+            set +e
+            "${GRYPE_CMD}" \
+              -o "sarif=grype-results.sarif" \
+              -o "json=grype-results.json" \
+              -o "table=grype-results.txt" \
+              --fail-on medium \
+              -c .grype.yaml \
+              "sbom:sbom-cyclonedx.json"
+            grype_exit=$?
+            set -e
+
+            echo "--- Grype scan results ---"
+            if [ -f grype-results.txt ]; then
+              cat grype-results.txt
+            else
+              echo "No table output produced"
+            fi
+
+            if [ "${grype_exit}" = "0" ]; then
+              echo "No vulnerabilities at or above 'medium'"
+              exit 0
+            fi
+            if [ "${grype_exit}" != "2" ]; then
+              echo "::error::Grype exited with code ${grype_exit}"
+              exit "${grype_exit}"
+            fi
+
+            if [ "${NO_BLOCK_AUDIT_FAIL}" = "true" ]; then
+              echo "::warning::Grype found vulnerabilities at or" \
+                "above the 'medium' threshold, but" \
+                "NO_BLOCK_AUDIT_FAIL is set so the job will not" \
+                "fail."
+              exit 0
+            fi
+            echo "::error::Grype found vulnerabilities at or above" \
+              "the 'medium' severity threshold. See the table" \
+              "above for the offending packages and CVEs."
+            exit 1
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length
@@ -257,17 +320,65 @@ jobs:
           name: grype-scan-results
           path: |
             grype-results.sarif
+            grype-results.json
             grype-results.txt
           retention-days: 90
+          if-no-files-found: warn
 
       - name: "Grype summary"
         if: always()
         run: |
-          # Grype summary
-          echo "## Grype Summary" >> "$GITHUB_STEP_SUMMARY"
-          [ -f grype-results.txt ] && cat grype-results.txt \
-            >> "$GITHUB_STEP_SUMMARY" || echo "No scan results available" \
-            >> "$GITHUB_STEP_SUMMARY"
+            # Render a Markdown table of output in step summary.
+            {
+              echo "## Grype Vulnerability Scan"
+              echo ""
+              if [ ! -f grype-results.json ]; then
+                echo "No scan results available"
+                exit 0
+              fi
+              match_count=$(jq '.matches | length' grype-results.json)
+              if [ "${match_count}" = "0" ]; then
+                echo "No vulnerabilities found at or above the" \
+                  "configured severity threshold."
+                exit 0
+              fi
+              echo "Found ${match_count} matching Grype record(s)."
+              echo ""
+              echo "| Package | Installed | Fixed In | Type |" \
+                "Vulnerability | Severity | EPSS | Risk |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+              jq -r '
+                def esc: tostring | gsub("\\|"; "\\|");
+                def round2: (. * 100 | round) / 100;
+                def epss_pct:
+                  ( .vulnerability.epss // [] ) as $e
+                  | if ($e | length) == 0 then "-"
+                    else ( $e[0].epss // 0 ) as $p
+                      | if $p == 0 then "0%"
+                        elif ($p * 100) < 0.01 then "<0.01%"
+                        else ( ($p * 100) | round2 | tostring
+                               + "%" ) end
+                    end;
+                def risk_fmt:
+                  .vulnerability.risk
+                  | if . == null then "-"
+                    elif type == "number" then
+                      (round2 | tostring)
+                    else (. | tostring) end;
+                .matches[] |
+                [ (.artifact.name // "-" | esc),
+                  (.artifact.version // "-" | esc),
+                  ( ( .vulnerability.fix.versions // [] )
+                    | if length == 0 then "-"
+                      else join(", ") end | esc ),
+                  (.artifact.type // "-" | esc),
+                  (.vulnerability.id // "-" | esc),
+                  (.vulnerability.severity // "-" | esc),
+                  epss_pct,
+                  risk_fmt
+                ] | "| " + join(" | ") + " |"
+              ' grype-results.json
+            } >> "$GITHUB_STEP_SUMMARY"
 
   build-zip:
     name: 'Build Integration ZIP'


### PR DESCRIPTION
## Summary
- align build-test and release workflows with the current dependamerge patterns
- split Grype into standalone jobs, add clear-cache handling, and tighten permissions
- add NO_BLOCK_AUDIT_FAIL support while intentionally keeping egress policy in audit mode

## Notes
- egress-policy remains 'audit' by design
- pull_request path filters remain absent by design
- the CPython 3.14 PYTEST_ADDOPTS workaround and build-zip release job were preserved