### PR TITLE
Fix(style): Remove trivial restating comments

### DIFF
--- a/.aislop/config.yml
+++ b/.aislop/config.yml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
 # SPDX-License-Identifier: Apache-2.0
 
+---
+
 version: 1
 
 # aislop 0.10.x supports precise false-positive handling via inline

--- a/.aislop/config.yml
+++ b/.aislop/config.yml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+# aislop 0.10.x supports precise false-positive handling via inline
+# `aislop-ignore-*` directives in source. Keep project-local config here.

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -326,7 +326,6 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
         options={},
     )
 
-    # Update the calendar config
     await coordinator.update_config(new_data)
 
     entry_data = hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
@@ -465,7 +464,6 @@ def async_register_keymaster_listener(
             if sensor is not None and sensor.hass is not None:
                 sensor.async_write_ha_state()
 
-        # Validate state is unlocked
         if event_data.get("state") != "unlocked":
             if diagnostics_enabled:
                 _record("rejected_state")
@@ -477,7 +475,6 @@ def async_register_keymaster_listener(
                 _record("rejected_slot_zero")
             return
 
-        # Validate code slot is in managed range
         if not (start_slot <= code_slot_num < start_slot + max_events):
             if diagnostics_enabled:
                 _record("rejected_out_of_range")
@@ -496,7 +493,6 @@ def async_register_keymaster_listener(
                 _record("rejected_no_checkin_sensor")
             return
 
-        # Check monitoring switch via stored entity reference
         monitoring_switch = entry_data.get(KEYMASTER_MONITORING_SWITCH)
         if monitoring_switch is None:
             _LOGGER.debug(

--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -71,6 +71,8 @@ from .const import MIN_NAME_LENGTH
 from .const import REQUEST_TIMEOUT
 from .util import gen_uuid
 
+# aislop-ignore-file ai-slop/hallucinated-import -- Provided by Home Assistant runtime.
+
 _LOGGER = logging.getLogger(__name__)
 
 sorted_tz = sorted(available_timezones())

--- a/custom_components/rental_control/config_flow.py
+++ b/custom_components/rental_control/config_flow.py
@@ -424,7 +424,6 @@ async def _start_config_flow(
         if hasattr(cls, "_get_unique_id"):
             errors.update(await cls._get_unique_id(user_input))
 
-        # Validate user input
         try:
             cv.url(user_input[CONF_URL])
             # cv.url() only accepts http:// and https:// schemes

--- a/custom_components/rental_control/const.py
+++ b/custom_components/rental_control/const.py
@@ -127,7 +127,6 @@ If you have any issues with this you need to open an issue here:
 -------------------------------------------------------------------
 """
 
-# Check-in tracking state constants
 CHECKIN_STATE_NO_RESERVATION = "no_reservation"
 CHECKIN_STATE_AWAITING = "awaiting_checkin"
 CHECKIN_STATE_CHECKED_IN = "checked_in"

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -91,6 +91,8 @@ from .util import check_gather_results
 from .util import get_slot_name
 from .util import normalize_uid
 
+# aislop-ignore-file ai-slop/hallucinated-import -- Provided by Home Assistant runtime.
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -177,7 +177,6 @@ class RentalControlCoordinator(DataUpdateCoordinator[list[CalendarEvent]]):
             if self._parent_entry_id is not None:
                 self._child_locknames = self._discover_child_locks()
 
-        # setup device
         device_registry = dr.async_get(hass)
         device_registry.async_get_or_create(
             config_entry_id=self._entry_id,
@@ -520,7 +519,6 @@ Please update Keymaster to at least v0.1.0-b0
                     self.event = event
                     break
 
-        # Check overrides against current calendar data
         if self.event_overrides:
             await self.event_overrides.async_check_overrides(
                 self, calendar=new_calendar

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -277,6 +277,7 @@ class EventOverrides:
         """
         uid = normalize_uid(uid)
 
+        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
         # Phase 1: UID positive match
         if uid is not None:
             for slot in self.__get_slots_with_values():
@@ -288,6 +289,7 @@ class EventOverrides:
                     if override is not None and override["slot_name"] == slot_name:
                         return slot
 
+        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
         # Phase 2: name + strict interval overlap with UID-aware bypass
         start_utc = _to_utc(start_time)
         end_utc = _to_utc(end_time)
@@ -336,6 +338,7 @@ class EventOverrides:
                         continue
             return slot
 
+        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
         # Phase 3: trim-aware fallback for trimmed names.
         # Only active when name trimming is enabled.  Uses the actual
         # trim_name function so both word-boundary and hard-truncated
@@ -577,6 +580,7 @@ class EventOverrides:
         slot_end = override["end_time"]
         stored_uid = normalize_uid(self._slot_uids.get(slot))
 
+        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
         # Phase 1: UID positive match
         if stored_uid is not None:
             for ev in events:
@@ -584,6 +588,7 @@ class EventOverrides:
                 if ev_uid is not None and ev_uid == stored_uid and ev.name == slot_name:
                     return True
 
+        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
         # Phase 2: name + strict interval overlap with UID-aware bypass
         slot_start_utc = _to_utc(slot_start)
         slot_end_utc = _to_utc(slot_end)
@@ -613,6 +618,7 @@ class EventOverrides:
                         continue
             return True
 
+        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
         # Phase 3: trim-aware fallback for trimmed names.
         # Only active when name trimming is enabled.
         if self._trim_names:

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -199,7 +199,6 @@ class EventOverrides:
         else:
             max_slot = self.start_slot - 1
 
-        # Get all the available slots greater than our current max
         avail_slots = self.__get_slots_without_values(max_slot)
         if len(avail_slots):
             _LOGGER.debug("Next slot is %s", avail_slots[0])

--- a/custom_components/rental_control/sensor.py
+++ b/custom_components/rental_control/sensor.py
@@ -23,6 +23,8 @@ from .const import DOMAIN
 from .sensors.calsensor import RentalControlCalSensor
 from .sensors.checkinsensor import CheckinTrackingSensor
 
+# aislop-ignore-file ai-slop/hallucinated-import -- Provided by Home Assistant runtime.
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -395,7 +395,6 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             if isinstance(uid, str):
                 uid = uid.strip() or None
             self._event_attributes["uid"] = uid
-            # get timedelta for eta
             td = start - datetime.now(start.tzinfo)
             eta_days = None
             eta_hours = None

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -1582,7 +1582,6 @@ class CheckinTrackingSensor(
             _LOGGER.debug("Ignoring keymaster unlock: code_slot_num == 0 (manual/RF)")
             return
 
-        # Validate code slot is in managed range
         start_slot = self.coordinator.start_slot
         max_events = self.coordinator.max_events
         if not (start_slot <= code_slot_num < start_slot + max_events):

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -1289,6 +1289,7 @@ class CheckinTrackingSensor(
         """
         await super().async_added_to_hass()
 
+        # aislop-ignore-next-line ai-slop/narrative-comment -- Navigation marker in a long state machine.
         # --- T018: Restore persisted state ---
         last_extra = await self.async_get_last_extra_data()
         if last_extra is not None:
@@ -1312,6 +1313,7 @@ class CheckinTrackingSensor(
                 "Restored state '%s' for %s", self._state, self.coordinator.name
             )
 
+            # aislop-ignore-next-line ai-slop/narrative-comment -- Navigation marker in a long state machine.
             # --- T020: Stale-state validation ---
             self._validate_restored_state()
 

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -802,7 +802,6 @@ async def handle_state_change(
         end_time,
     )
 
-    # validate overrides
     await coordinator.event_overrides.async_check_overrides(coordinator)
 
 


### PR DESCRIPTION
## Summary

Remove inline comments that merely restate the immediately following line
of code. These were flagged by aislop as ai-slop indicators and provide no
information beyond what the code itself communicates.

Comments that explain intent, rationale, or requirement cross-references
(FR-xxx) are preserved.

Also adds an `.aislop` configuration file to suppress known false positives:
- Hallucinated import findings (voluptuous/aiohttp provided by HA runtime)
- Intentional algorithm documentation comments
- Navigation section markers in long state machines

## Testing

All 831+ tests pass, no lint errors.
