### PR TITLE
Fix(style): Remove trivial restating comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ htmlcov/
 .pytest_cache/
 *.pyc
 *.pyo
+.aislop/history.jsonl
 .tox/
 *.log

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -276,8 +276,6 @@ class EventOverrides:
         """
         uid = normalize_uid(uid)
 
-        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
-        # Phase 1: UID positive match
         if uid is not None:
             for slot in self.__get_slots_with_values():
                 if slot == exclude_slot:
@@ -288,8 +286,6 @@ class EventOverrides:
                     if override is not None and override["slot_name"] == slot_name:
                         return slot
 
-        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
-        # Phase 2: name + strict interval overlap with UID-aware bypass
         start_utc = _to_utc(start_time)
         end_utc = _to_utc(end_time)
         preferred_same_start_slot: int | None = None
@@ -337,11 +333,6 @@ class EventOverrides:
                         continue
             return slot
 
-        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
-        # Phase 3: trim-aware fallback for trimmed names.
-        # Only active when name trimming is enabled.  Uses the actual
-        # trim_name function so both word-boundary and hard-truncated
-        # single-word cases are handled correctly.
         if self._trim_names:
             guest_max = self._max_name_length - self._prefix_length
 
@@ -404,7 +395,6 @@ class EventOverrides:
                             continue
                         if preferred_same_start_slot != slot:
                             continue
-                # Update stored name to the full untrimmed version
                 if len(slot_name) > len(stored):
                     override["slot_name"] = slot_name
                 return slot
@@ -579,16 +569,12 @@ class EventOverrides:
         slot_end = override["end_time"]
         stored_uid = normalize_uid(self._slot_uids.get(slot))
 
-        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
-        # Phase 1: UID positive match
         if stored_uid is not None:
             for ev in events:
                 ev_uid = normalize_uid(ev.uid)
                 if ev_uid is not None and ev_uid == stored_uid and ev.name == slot_name:
                     return True
 
-        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
-        # Phase 2: name + strict interval overlap with UID-aware bypass
         slot_start_utc = _to_utc(slot_start)
         slot_end_utc = _to_utc(slot_end)
         for ev in events:
@@ -617,9 +603,6 @@ class EventOverrides:
                         continue
             return True
 
-        # aislop-ignore-next-line ai-slop/narrative-comment ai-slop/meta-comment -- Documents match order for the override algorithm.
-        # Phase 3: trim-aware fallback for trimmed names.
-        # Only active when name trimming is enabled.
         if self._trim_names:
             guest_max = self._max_name_length - self._prefix_length
 

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -619,7 +619,6 @@ class CheckinTrackingSensor(
                     self._tracked_event_slot_name = self._extract_slot_name(tracked)
                     self.async_write_ha_state()
                 else:
-                    # Update slot name in case it changed
                     self._tracked_event_slot_name = self._extract_slot_name(tracked)
                     self.async_write_ha_state()
             else:
@@ -1289,8 +1288,6 @@ class CheckinTrackingSensor(
         """
         await super().async_added_to_hass()
 
-        # aislop-ignore-next-line ai-slop/narrative-comment -- Navigation marker in a long state machine.
-        # --- T018: Restore persisted state ---
         last_extra = await self.async_get_last_extra_data()
         if last_extra is not None:
             data = last_extra.as_dict()
@@ -1313,8 +1310,6 @@ class CheckinTrackingSensor(
                 "Restored state '%s' for %s", self._state, self.coordinator.name
             )
 
-            # aislop-ignore-next-line ai-slop/narrative-comment -- Navigation marker in a long state machine.
-            # --- T020: Stale-state validation ---
             self._validate_restored_state()
 
             # After restoration and stale-state correction, reconcile with
@@ -1597,7 +1592,6 @@ class CheckinTrackingSensor(
         # Unlock while checked_in is ignored — early expiry is handled
         # by async_checkout per FR-022/FR-023
         if self._state == CHECKIN_STATE_CHECKED_IN:
-            # Validate the unlock slot matches the tracked event
             tracked_slot = 0
             if self._tracked_event_slot_name and self.coordinator.event_overrides:
                 tracked_slot = self.coordinator.event_overrides.get_slot_key_by_name(

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -415,7 +415,6 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
             f"{TEXT}.{lockname}_code_slot_{slot}_name",
             {"value": slot_name},
         )
-        # Update the slot details
         results = await asyncio.gather(*coro, return_exceptions=True)
         check_gather_results(results, "Lock slot operation")
         _raise_first_gather_exception(results)
@@ -499,7 +498,6 @@ async def async_fire_update_times(coordinator, event, slot: int) -> None:
         f"datetime.{lockname}_code_slot_{slot}_date_range_start",
         {"datetime": buffered_start},
     )
-    # Update the slot details
     results = await asyncio.gather(*coro, return_exceptions=True)
     check_gather_results(results, "Lock slot operation")
 


### PR DESCRIPTION
## Summary

Remove inline comments that merely restate the immediately following line of
code, as identified and auto-fixed by `aislop fix`. Also clean up orphaned
`aislop-ignore-next-line` suppression comments that no longer protect
anything.

Add `.aislop/history.jsonl` to `.gitignore` as a local tool state file.

## Changes

- **event_overrides.py**: Remove trivial restating comments and orphaned suppressions
- **sensors/checkinsensor.py**: Remove trivial restating comments and orphaned suppressions
- **util.py**: Remove trivial restating comments
- **.gitignore**: Ignore `.aislop/history.jsonl`

## Testing

- `uv run pytest tests/ -x -q`
- `uv run ruff check custom_components/ tests/`