### PR TITLE
CI(pre-commit): Add aislop staged-mode gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ htmlcov/
 *.pyc
 *.pyo
 .aislop/history.jsonl
+.aislop/install_id
 .tox/
 *.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,17 @@ repos:
       - id: ruff-format
         files: ^(scripts|tests|custom_components)/.+\.py$
 
+  - repo: local
+    hooks:
+      - id: aislop
+        name: aislop ci (staged)
+        entry: aislop ci --staged
+        language: node
+        additional_dependencies:
+          - aislop@0.12.0
+        pass_filenames: false
+        require_serial: true
+
   - repo: https://github.com/adrienverge/yamllint.git
     rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
     hooks:


### PR DESCRIPTION
Adds a staged-mode aislop pre-commit gate using the same local-hook structure as pylocal-akuvox, but runs `aislop ci --staged` so only newly staged files are checked. This relates to ai-slop enforcement without bricking commits over pre-existing untouched slop.

Also ignores aislop's generated local install ID so reuse/pre-commit.ci remains green.