### PR TITLE
Docs(plan): Add implementation plan for spec 010

### DIFF
--- a/specs/010-explicit-entry-guards/plan.md
+++ b/specs/010-explicit-entry-guards/plan.md
@@ -1,0 +1,150 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Implementation Plan: Explicit Entry Data Guards
+
+**Feature**: `010-explicit-entry-guards` | **Planning Branch**: `010-explicit-entry-guards-plan` | **Date**: 2026-06-18 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/010-explicit-entry-guards/spec.md`
+
+## Summary
+
+Replace the six issue-reported `hass.data.get(DOMAIN, {}).get(...)` entry-data
+access paths with an explicit domain-and-entry guard. Research selects a shared
+`get_entry_data(hass, entry_id) -> dict[str, Any] | None` helper in
+`custom_components/rental_control/util.py` so all six sites distinguish missing
+integration domain data from missing entry data without creating throwaway empty
+state. Loaded-entry behavior remains unchanged; missing entry data short-circuits
+or follows the existing component-absence fallback for that operation.
+
+## Technical Context
+
+**Language/Version**: Python >=3.14.2
+**Primary Dependencies**: Home Assistant core, pytest-homeassistant-custom-component
+**Storage**: HA runtime storage in `hass.data[DOMAIN][entry_id]`; no persisted data changes
+**Testing**: pytest via `uv run pytest tests/`; ruff via `uv run ruff check ...`
+**Target Platform**: Home Assistant custom integration on Linux/Docker/HA OS
+**Project Type**: Single project — Home Assistant custom integration (HACS)
+**Performance Goals**: O(1) dictionary lookups only; no measurable refresh-cycle impact
+**Constraints**: Must not block the HA event loop; must not create phantom entry state
+**Scale/Scope**: Six issue-reported access paths across three source files, plus tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I: Code Quality & Testing | PASS | Helper and changed paths will be type hinted, documented, and covered by targeted tests for loaded and missing data |
+| II: Atomic Commit Discipline | PASS | Future implementation commits must remain atomic and include their required targeted tests with the code they validate |
+| III: Licensing & Attribution | PASS | Modified files already have SPDX headers; new spec artifacts include SPDX headers |
+| IV: Pre-Commit Integrity | PASS | Plan requires pytest and ruff before implementation merge; hooks must not be bypassed |
+| V: Agent Co-Authorship & DCO | PASS | Commits use `git commit -s` with agent co-authorship trailers |
+| VI: User Experience Consistency | PASS | No new options, entities, services, migrations, or normal-path behavior changes |
+| VII: Performance Requirements | PASS | Helper centralizes the same O(1) lookups and adds no I/O or async work |
+
+**Gate result: PASS** — No violations. Proceeding to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-explicit-entry-guards/
+├── plan.md                    # This file
+├── research.md                # Phase 0 decision: helper vs inline guards
+├── quickstart.md              # Phase 1 maintainer verification guide
+├── checklists/
+│   └── requirements.md        # Existing SPEC-stage checklist
+└── tasks.md                   # Phase 2 output only; not created in PLAN stage
+```
+
+`data-model.md` is intentionally omitted because this internal refactor adds no
+entities, fields, relationships, validation rules, or state transitions.
+`contracts/` is intentionally omitted because no external API, service,
+configuration, entity, or integration contract changes are introduced.
+
+### Source Code (repository root)
+
+```text
+custom_components/rental_control/
+├── util.py                    # Add get_entry_data helper with docstring/type hints
+├── __init__.py                # Use helper in update listener and event listener paths
+├── sensors/
+│   └── checkinsensor.py       # Use helper for monitoring and early-expiry checks
+└── switch.py                  # Use helper before registering monitoring switch
+
+tests/
+├── unit/
+│   ├── test_init.py           # Update listener missing-entry/domain regression coverage
+│   ├── test_keymaster_event_diagnostics.py  # Event forwarding missing-data coverage
+│   ├── test_checkin_sensor.py # Monitoring fallback and early-expiry missing-data coverage
+│   └── test_switch.py         # Switch registration missing-data coverage
+└── integration/
+    └── test_full_setup.py     # Loaded-entry smoke/regression coverage if needed
+```
+
+**Structure Decision**: Single-project Home Assistant custom integration. The
+implementation stage should only touch the helper, the six reported call sites,
+and targeted tests required to prove both loaded-entry and missing-data behavior.
+
+## Phase 0 Research
+
+Research is complete in [research.md](research.md). It resolves the only central
+design decision: use a shared helper rather than six inline guard blocks.
+
+### Live Call-Site Findings
+
+| Site | Current expression | Present-data behavior | Missing-data behavior to preserve or make explicit |
+|------|--------------------|-----------------------|----------------------------------------------------|
+| `__init__.py:update_listener` first lookup, line ~309 | `hass.data.get(DOMAIN, {}).get(config_entry.entry_id)` | Copy options, update entry data, call `coordinator.update_config()` | Return before config mutation/update work when domain or entry is absent |
+| `__init__.py:update_listener` second lookup, line ~331 | `hass.data.get(DOMAIN, {}).get(config_entry.entry_id)` | Unsubscribe old listeners, clear list, re-register keymaster listeners when configured | Return before listener refresh if data vanished after the config update |
+| `__init__.py:_handle_keymaster_event`, line ~484 | `hass.data.get(DOMAIN, {}).get(config_entry.entry_id, {})` | Fetch check-in sensor and monitoring switch, then forward accepted unlock events | Reject and return when domain or entry data is absent; do not report accepted forwarding |
+| `sensors/checkinsensor.py:_is_keymaster_monitoring_enabled`, line ~464 | `self._hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id, {})` | Use switch state when the monitoring switch exists | Missing domain/entry follows the existing safe fallback: `self.coordinator.lockname is not None` |
+| `sensors/checkinsensor.py:async_checkout`, line ~1200 | `self._hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id, {})` | If early-expiry switch is on, shorten lock-code expiry before checkout transition | Missing domain/entry skips early expiry and continues checkout as existing switch-absence behavior does |
+| `switch.py:KeymasterMonitoringSwitch.async_added_to_hass`, line ~132 | `self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id, {})` | Store the switch reference in entry data for event forwarding and monitoring checks | Return after state restore/logging when domain or entry is absent; do not mutate a throwaway dict |
+
+The event listener also contains a nearby diagnostic sensor lookup using chained
+`get` calls inside `_record()`. That lookup is not one of the six issue-reported
+entry-data assignments, so the implementation stage should only change it if the
+same helper is needed to keep the line ~484 event-path diagnostics internally
+consistent without broadening scope.
+
+## Phase 1 Design Artifacts
+
+- [research.md](research.md): required and complete.
+- [quickstart.md](quickstart.md): required and complete.
+- `data-model.md`: N/A for this internal refactor; intentionally omitted.
+- `contracts/`: N/A because no API or user-facing contracts change;
+  intentionally omitted.
+- `update-agent-context.sh`: intentionally not run. The design adds no new
+  technology, dependency, platform, or agent-relevant context.
+
+## Post-Design Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I: Code Quality & Testing | PASS | Quickstart defines targeted pytest and ruff validation; helper must include docstring/type hints |
+| II: Atomic Commit Discipline | PASS | PLAN artifacts are one docs-only commit; implementation work remains future-stage scope |
+| III: Licensing & Attribution | PASS | `plan.md`, `research.md`, and `quickstart.md` include SPDX headers |
+| IV: Pre-Commit Integrity | PASS | No bypasses planned; docs PR still runs repository hooks and CI |
+| V: Agent Co-Authorship & DCO | PASS | PLAN commit will be signed off and co-authored |
+| VI: User Experience Consistency | PASS | Design preserves loaded-entry behavior and introduces no UI/API/entity changes |
+| VII: Performance Requirements | PASS | Shared helper adds no blocking work and preserves O(1) access |
+
+**Gate result: PASS** — No complexity violations.
+
+## Complexity Tracking
+
+> No violations to justify — all gates pass.
+
+## Phase Notes
+
+- PLAN stage owns only `plan.md`, `research.md`, and `quickstart.md`.
+- TASKS and IMPLEMENT stages must not be performed in this PR.
+- Future tasks should include tests for both missing `hass.data[DOMAIN]` and
+  missing `hass.data[DOMAIN][entry_id]` for each affected operation.
+- Future implementation should keep supporting component absence separate from
+  missing entry data: component lookups inside present `entry_data` may continue
+  to use `.get(...)` with the existing fallback behavior.

--- a/specs/010-explicit-entry-guards/plan.md
+++ b/specs/010-explicit-entry-guards/plan.md
@@ -20,7 +20,7 @@ or follows the existing component-absence fallback for that operation.
 
 ## Technical Context
 
-**Language/Version**: Python >=3.14.2
+**Language/Version**: Python ≥3.14.2
 **Primary Dependencies**: Home Assistant core, pytest-homeassistant-custom-component
 **Storage**: HA runtime storage in `hass.data[DOMAIN][entry_id]`; no persisted data changes
 **Testing**: pytest via `uv run pytest tests/`; ruff via `uv run ruff check ...`

--- a/specs/010-explicit-entry-guards/quickstart.md
+++ b/specs/010-explicit-entry-guards/quickstart.md
@@ -1,0 +1,115 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart: Explicit Entry Data Guards
+
+**Feature Branch**: `010-explicit-entry-guards`
+**Date**: 2026-06-18
+
+## Overview
+
+This refactor makes missing Rental Control domain data or entry data explicit at
+six issue-reported access paths. Loaded entries should behave exactly as before.
+Missing domain or entry data should short-circuit safely without raising and
+without creating or mutating throwaway `{}` state.
+
+## Implementation Scope
+
+### Files Expected to Change
+
+| File | Change |
+|------|--------|
+| `custom_components/rental_control/util.py` | Add `get_entry_data(hass, entry_id) -> dict[str, Any] | None` with a docstring and type hints |
+| `custom_components/rental_control/__init__.py` | Use helper in the two `update_listener` lookups and the keymaster event forwarding lookup |
+| `custom_components/rental_control/sensors/checkinsensor.py` | Use helper for monitoring-switch and early-expiry-switch entry-data lookups |
+| `custom_components/rental_control/switch.py` | Use helper before storing the monitoring switch reference |
+| `tests/unit/test_init.py` | Cover update-listener missing domain/entry behavior |
+| `tests/unit/test_keymaster_event_diagnostics.py` | Cover keymaster event rejection when entry data is unavailable |
+| `tests/unit/test_checkin_sensor.py` | Cover monitoring fallback and early-expiry skip behavior |
+| `tests/unit/test_switch.py` | Cover no throwaway mutation when switch registration lacks entry data |
+
+### Files Not Expected to Change
+
+| Path | Why |
+|------|-----|
+| `specs/010-explicit-entry-guards/data-model.md` | No new data model is introduced |
+| `specs/010-explicit-entry-guards/contracts/` | No API, service, entity, or configuration contract changes are introduced |
+| Agent context files | No new technology, dependency, or platform context is introduced |
+
+## Maintainer Verification
+
+### 1. Inspect the Access Paths
+
+Confirm the six issue-reported paths no longer use chained domain defaults,
+including the multi-line lookups in `checkinsensor.py`:
+
+```bash
+rg --multiline 'data\.get\(DOMAIN, \{\}\)\s*\.get|data\.get\(DOMAIN, \{\}\)\.get' \
+  custom_components/rental_control/__init__.py \
+  custom_components/rental_control/sensors/checkinsensor.py \
+  custom_components/rental_control/switch.py
+```
+
+Expected result: no matches for the six issue-reported paths. If this command
+still reports a nearby non-reported diagnostic lookup, confirm whether it is
+directly coupled to the event-path implementation before broadening scope.
+
+Confirm the shared helper exists and is imported by each changed module:
+
+```bash
+rg 'get_entry_data' custom_components/rental_control tests
+```
+
+### 2. Verify Loaded-Entry Behavior
+
+Run targeted tests that exercise normal setup, listener refresh, event
+diagnostics, check-in monitoring, checkout, and switch registration:
+
+```bash
+uv run pytest \
+  tests/unit/test_init.py \
+  tests/unit/test_keymaster_event_diagnostics.py \
+  tests/unit/test_checkin_sensor.py \
+  tests/unit/test_switch.py \
+  tests/integration/test_full_setup.py
+```
+
+Expected result: all selected tests pass, with no behavior regression for a
+normally loaded entry where `hass.data[DOMAIN][entry_id]` exists.
+
+### 3. Verify Missing-Data Safety
+
+Add or review tests that remove `hass.data[DOMAIN]` and, separately, remove
+`hass.data[DOMAIN][entry_id]` before invoking each affected operation. Confirm:
+
+- `update_listener()` returns without mutating config-entry data when entry data
+  is unavailable before the update.
+- Listener refresh returns safely if entry data disappears after
+  `coordinator.update_config()`.
+- Keymaster unlock handling returns without forwarding or recording an accepted
+  event when entry data is unavailable.
+- `_is_keymaster_monitoring_enabled()` uses the existing configured-lock
+  fallback when entry data or the monitoring switch is unavailable.
+- Manual checkout skips early expiry when entry data or the early-expiry switch
+  is unavailable, then continues the checkout transition.
+- `KeymasterMonitoringSwitch.async_added_to_hass()` does not create or mutate a
+  throwaway dict when entry data is unavailable.
+
+### 4. Run Linting
+
+```bash
+uv run ruff check \
+  custom_components/rental_control/util.py \
+  custom_components/rental_control/__init__.py \
+  custom_components/rental_control/sensors/checkinsensor.py \
+  custom_components/rental_control/switch.py \
+  tests/unit/test_init.py \
+  tests/unit/test_keymaster_event_diagnostics.py \
+  tests/unit/test_checkin_sensor.py \
+  tests/unit/test_switch.py
+```
+
+Expected result: ruff passes. Pre-commit hooks and CI must also pass before the
+implementation PR is merged.

--- a/specs/010-explicit-entry-guards/research.md
+++ b/specs/010-explicit-entry-guards/research.md
@@ -1,0 +1,131 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Research: Explicit Entry Data Guards
+
+**Feature Branch**: `010-explicit-entry-guards`
+**Date**: 2026-06-18
+
+## Research Task 1: Shared Helper vs Inline Guards
+
+**Question**: Should the six issue-reported access paths use inline missing-data
+guards at each call site, or a shared helper such as
+`get_entry_data(hass, entry_id) -> dict[str, Any] | None`?
+
+### Findings
+
+The live source confirms that all six reported sites read the same runtime entry
+storage shape: `hass.data[DOMAIN][entry_id]`. They differ only in the local
+`HomeAssistant` reference (`hass`, `self._hass`, or `self.hass`) and the source
+of the entry id (`config_entry.entry_id` or `self._config_entry.entry_id`).
+
+1. `custom_components/rental_control/__init__.py:update_listener`, line ~309:
+   the first lookup currently uses
+   `hass.data.get(DOMAIN, {}).get(config_entry.entry_id)`. When entry data is
+   present, it reads the coordinator, writes merged config-entry data, and calls
+   `coordinator.update_config(new_data)`. When entry data is absent, the current
+   code already returns early, but the missing integration domain is hidden by
+   an anonymous `{}` default.
+
+2. `custom_components/rental_control/__init__.py:update_listener`, line ~331:
+   the second lookup repeats the same expression after `update_config()`. When
+   entry data is present, it unsubscribes and clears listeners, then restarts
+   listeners if a lock is configured. When data disappeared during the update,
+   the current code returns early. The missing-domain path should be equally
+   explicit.
+
+3. `custom_components/rental_control/__init__.py:_handle_keymaster_event`, line
+   ~484: the event listener uses
+   `hass.data.get(DOMAIN, {}).get(config_entry.entry_id, {})`, then reads the
+   check-in sensor and monitoring switch. Present data preserves event
+   evaluation and forwarding. Missing domain or entry data should reject the
+   event and return without reporting it as accepted or forwarded.
+
+4. `custom_components/rental_control/sensors/checkinsensor.py:_is_keymaster_monitoring_enabled`,
+   line ~464: the sensor uses
+   `self._hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id, {})`, then
+   reads the monitoring switch. If the switch exists, its `is_on` state wins.
+   If the switch is absent, the method intentionally falls back to
+   `self.coordinator.lockname is not None` to avoid premature auto check-in
+   during setup races. Missing domain or entry data should use that same
+   fallback rather than returning false.
+
+5. `custom_components/rental_control/sensors/checkinsensor.py:async_checkout`,
+   line ~1200: checkout reads entry data to find the early-checkout-expiry
+   switch. If the switch exists and is on, checkout shortens the lock-code end
+   time before transitioning. If the switch is absent, checkout continues
+   without early expiry. Missing domain or entry data should follow that same
+   skip-and-continue behavior.
+
+6. `custom_components/rental_control/switch.py:KeymasterMonitoringSwitch.async_added_to_hass`,
+   line ~132: after restoring the switch state, the entity stores itself in
+   entry data for later event forwarding and monitoring checks. With missing
+   domain or entry data, the current code mutates a throwaway `{}` and silently
+   loses the registration. The new behavior should return without mutating
+   phantom state.
+
+All six sites therefore share the same missing-domain and missing-entry lookup
+semantics. Supporting component absence remains call-site-specific and should
+stay local: a present entry may still lack `CHECKIN_SENSOR`,
+`KEYMASTER_MONITORING_SWITCH`, or `EARLY_CHECKOUT_EXPIRY_SWITCH` during setup or
+unload ordering.
+
+### Decision
+
+Introduce a shared helper in `custom_components/rental_control/util.py`:
+
+```python
+def get_entry_data(hass: HomeAssistant, entry_id: str) -> dict[str, Any] | None:
+    """Return Rental Control entry data when domain and entry data exist."""
+```
+
+The helper should:
+
+1. read `domain_data = hass.data.get(DOMAIN)`;
+2. return `None` when the integration domain is absent;
+3. read `entry_data = domain_data.get(entry_id)`;
+4. return `None` when the entry is absent; and
+5. return the existing entry dictionary without creating or mutating defaults.
+
+### Rationale
+
+A helper is the best fit because every reported path reads the same entry-scoped
+runtime store and needs identical absent-domain and absent-entry semantics. It
+keeps the implementation DRY, makes the intended contract searchable, and
+prevents future reintroduction of `hass.data.get(DOMAIN, {})` defaults in these
+paths. `util.py` is already imported by `__init__.py`, `switch.py`, and
+`checkinsensor.py`, imports `HomeAssistant`, `Any`, and `DOMAIN`, and does not
+need new dependencies or an import cycle for this helper.
+
+The helper should only guard entry-data retrieval. It should not fetch specific
+supporting components, because each call site has a different existing fallback:
+return early for event forwarding, configured-lock fallback for monitoring,
+skip early expiry for checkout, and skip registration for the switch if entry
+state is absent.
+
+### Alternatives considered
+
+- **Inline domain and entry guards at all six sites**: This is straightforward
+  and mirrors the issue's suggested after-code. It was rejected because it
+  duplicates identical guard semantics in three modules, making future drift
+  likely and obscuring the common contract.
+- **A helper that accepts `ConfigEntry` instead of `entry_id`**: This would save
+  a single attribute access in some sites but is less flexible for entity
+  methods that already store the entry id and would unnecessarily couple the
+  helper to config-entry objects.
+- **Component-specific helpers such as `get_monitoring_switch(...)`**: Rejected
+  as too broad for this quality refactor. Supporting component absence has
+  distinct behavior at each call site and should remain explicit locally.
+- **Leaving the existing chained defaults**: Rejected because it violates issue
+  #571 and the spec requirements by hiding missing domain/entry data and, in
+  the switch registration path, mutating throwaway state.
+
+## Summary
+
+The implementation stage should add the shared `get_entry_data()` helper and use
+it at the six issue-reported access paths. Missing domain or missing entry data
+returns `None`; each caller then preserves its established safe outcome for that
+operation while loaded entries continue to use the same entry dictionary as
+before.


### PR DESCRIPTION
## Summary
- Add the PLAN-stage implementation plan for issue #571 / feature 010-explicit-entry-guards.
- Document the shared get_entry_data helper decision versus inline guards.
- Add maintainer quickstart verification for loaded-entry and missing-data behavior.

## Stage
This is stage 2 (PLAN) for #571. It intentionally does not create tasks or implement source changes.

## Artifacts
- specs/010-explicit-entry-guards/plan.md
- specs/010-explicit-entry-guards/research.md
- specs/010-explicit-entry-guards/quickstart.md

Data model and contracts are N/A for this internal refactor and were intentionally omitted.