### PR TITLE
Refactor: Add explicit entry-data guards

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -482,7 +482,15 @@ def async_register_keymaster_listener(
             return
 
         # Retrieve the checkin sensor and forward the unlock
-        entry_data = get_entry_data(hass, config_entry.entry_id) or {}
+        entry_data = get_entry_data(hass, config_entry.entry_id)
+        if entry_data is None:
+            _LOGGER.debug(
+                "Keymaster unlock event received but entry data "
+                "not available for entry %s",
+                config_entry.entry_id,
+            )
+            return
+
         checkin_sensor = entry_data.get(CHECKIN_SENSOR)
         if checkin_sensor is None:
             _LOGGER.debug(

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -61,6 +61,7 @@ from .const import UNSUB_LISTENERS
 from .coordinator import RentalControlCoordinator
 from .util import async_reload_package_platforms
 from .util import delete_rc_and_base_folder
+from .util import get_entry_data
 from .util import handle_state_change
 
 _LOGGER = logging.getLogger(__name__)
@@ -306,7 +307,7 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
         return
 
     # Guard against listener firing after entry has been unloaded
-    entry_data = hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
+    entry_data = get_entry_data(hass, config_entry.entry_id)
     if entry_data is None:
         return
 
@@ -328,7 +329,7 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
 
     await coordinator.update_config(new_data)
 
-    entry_data = hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
+    entry_data = get_entry_data(hass, config_entry.entry_id)
     if entry_data is None:
         return
     coordinator = entry_data[COORDINATOR]
@@ -481,7 +482,7 @@ def async_register_keymaster_listener(
             return
 
         # Retrieve the checkin sensor and forward the unlock
-        entry_data = hass.data.get(DOMAIN, {}).get(config_entry.entry_id, {})
+        entry_data = get_entry_data(hass, config_entry.entry_id) or {}
         checkin_sensor = entry_data.get(CHECKIN_SENSOR)
         if checkin_sensor is None:
             _LOGGER.debug(

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -461,7 +461,10 @@ class CheckinTrackingSensor(
         active, so ``True`` is returned to prevent premature
         auto check-in during the setup race window.
         """
-        entry_data = get_entry_data(self._hass, self._config_entry.entry_id) or {}
+        entry_data = get_entry_data(self._hass, self._config_entry.entry_id)
+        if entry_data is None:
+            return self.coordinator.lockname is not None
+
         monitoring_switch = entry_data.get(KEYMASTER_MONITORING_SWITCH)
         if monitoring_switch is not None:
             return bool(monitoring_switch.is_on)
@@ -1195,8 +1198,12 @@ class CheckinTrackingSensor(
                 )
 
         # Early expiry: shorten lock code if switch is on (FR-022)
-        entry_data = get_entry_data(self._hass, self._config_entry.entry_id) or {}
-        early_expiry_switch = entry_data.get(EARLY_CHECKOUT_EXPIRY_SWITCH)
+        entry_data = get_entry_data(self._hass, self._config_entry.entry_id)
+        early_expiry_switch = (
+            entry_data.get(EARLY_CHECKOUT_EXPIRY_SWITCH)
+            if entry_data is not None
+            else None
+        )
 
         if early_expiry_switch is not None and early_expiry_switch.is_on:
             if self._tracked_event_end is not None:

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -42,7 +42,6 @@ from ..const import CONF_CLEANING_WINDOW
 from ..const import CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
 from ..const import DEFAULT_CLEANING_WINDOW
 from ..const import DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
-from ..const import DOMAIN
 from ..const import EARLY_CHECKOUT_EXPIRY_SWITCH
 from ..const import EVENT_RENTAL_CONTROL_CHECKIN
 from ..const import EVENT_RENTAL_CONTROL_CHECKOUT
@@ -51,6 +50,7 @@ from ..util import add_call
 from ..util import check_gather_results
 from ..util import compute_early_expiry_time
 from ..util import gen_uuid
+from ..util import get_entry_data
 from ..util import get_slot_name
 
 if TYPE_CHECKING:
@@ -461,9 +461,7 @@ class CheckinTrackingSensor(
         active, so ``True`` is returned to prevent premature
         auto check-in during the setup race window.
         """
-        entry_data = self._hass.data.get(DOMAIN, {}).get(
-            self._config_entry.entry_id, {}
-        )
+        entry_data = get_entry_data(self._hass, self._config_entry.entry_id) or {}
         monitoring_switch = entry_data.get(KEYMASTER_MONITORING_SWITCH)
         if monitoring_switch is not None:
             return bool(monitoring_switch.is_on)
@@ -1197,9 +1195,7 @@ class CheckinTrackingSensor(
                 )
 
         # Early expiry: shorten lock code if switch is on (FR-022)
-        entry_data = self._hass.data.get(DOMAIN, {}).get(
-            self._config_entry.entry_id, {}
-        )
+        entry_data = get_entry_data(self._hass, self._config_entry.entry_id) or {}
         early_expiry_switch = entry_data.get(EARLY_CHECKOUT_EXPIRY_SWITCH)
 
         if early_expiry_switch is not None and early_expiry_switch.is_on:

--- a/custom_components/rental_control/switch.py
+++ b/custom_components/rental_control/switch.py
@@ -130,7 +130,16 @@ class KeymasterMonitoringSwitch(SwitchEntity, RestoreEntity):
             self._attr_is_on = last_state.state == "on"
 
         # Store entity reference in hass.data for the event bus listener
-        entry_data = get_entry_data(self.hass, self._config_entry.entry_id) or {}
+        entry_data = get_entry_data(self.hass, self._config_entry.entry_id)
+        if entry_data is None:
+            _LOGGER.debug(
+                "Keymaster monitoring switch restored without entry data: "
+                "is_on=%s, entity_id=%s",
+                self._attr_is_on,
+                self.entity_id,
+            )
+            return
+
         entry_data[KEYMASTER_MONITORING_SWITCH] = self
 
         _LOGGER.debug(

--- a/custom_components/rental_control/switch.py
+++ b/custom_components/rental_control/switch.py
@@ -25,6 +25,7 @@ from .const import DOMAIN
 from .const import EARLY_CHECKOUT_EXPIRY_SWITCH
 from .const import KEYMASTER_MONITORING_SWITCH
 from .util import gen_uuid
+from .util import get_entry_data
 
 if TYPE_CHECKING:
     from .coordinator import RentalControlCoordinator
@@ -129,7 +130,7 @@ class KeymasterMonitoringSwitch(SwitchEntity, RestoreEntity):
             self._attr_is_on = last_state.state == "on"
 
         # Store entity reference in hass.data for the event bus listener
-        entry_data = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id, {})
+        entry_data = get_entry_data(self.hass, self._config_entry.entry_id) or {}
         entry_data[KEYMASTER_MONITORING_SWITCH] = self
 
         _LOGGER.debug(

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import re
 from typing import Any
 from typing import NamedTuple
+from typing import cast
 import uuid
 
 from homeassistant.components.automation import DOMAIN as AUTO_DOMAIN
@@ -56,6 +57,19 @@ from .const import EARLY_CHECKOUT_GRACE_MINUTES
 from .const import NAME
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def get_entry_data(hass: HomeAssistant, entry_id: str) -> dict[str, Any] | None:
+    """Return Rental Control entry data when domain and entry data exist."""
+    domain_data = cast("dict[str, dict[str, Any]] | None", hass.data.get(DOMAIN))
+    if domain_data is None:
+        return None
+
+    entry_data = domain_data.get(entry_id)
+    if entry_data is None:
+        return None
+
+    return entry_data
 
 
 def normalize_uid(value: str | None) -> str | None:

--- a/specs/010-explicit-entry-guards/tasks.md
+++ b/specs/010-explicit-entry-guards/tasks.md
@@ -33,8 +33,8 @@ implementation, so the MVP is complete only after both phases pass.
 
 **Purpose**: Establish the issue #571 baseline before changing tests or code
 
-- [ ] T001 Inventory the six chained entry-data lookups with `rg` in custom_components/rental_control/__init__.py, custom_components/rental_control/sensors/checkinsensor.py, and custom_components/rental_control/switch.py
-- [ ] T002 Run the baseline targeted pytest command for tests/unit/test_util.py, tests/unit/test_init.py, tests/unit/test_keymaster_event_diagnostics.py, tests/unit/test_checkin_sensor.py, tests/unit/test_switch.py, and tests/integration/test_full_setup.py
+- [X] T001 Inventory the six chained entry-data lookups with `rg` in custom_components/rental_control/__init__.py, custom_components/rental_control/sensors/checkinsensor.py, and custom_components/rental_control/switch.py
+- [X] T002 Run the baseline targeted pytest command for tests/unit/test_util.py, tests/unit/test_init.py, tests/unit/test_keymaster_event_diagnostics.py, tests/unit/test_checkin_sensor.py, tests/unit/test_switch.py, and tests/integration/test_full_setup.py
 
 ---
 
@@ -44,8 +44,8 @@ implementation, so the MVP is complete only after both phases pass.
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T003 Add get_entry_data unit tests for present entry data, missing hass.data[DOMAIN], missing hass.data[DOMAIN][entry_id], and no throwaway mutation in tests/unit/test_util.py
-- [ ] T004 Implement get_entry_data(hass, entry_id) -> dict[str, Any] | None with a docstring and type hints in custom_components/rental_control/util.py
+- [X] T003 Add get_entry_data unit tests for present entry data, missing hass.data[DOMAIN], missing hass.data[DOMAIN][entry_id], and no throwaway mutation in tests/unit/test_util.py
+- [X] T004 Implement get_entry_data(hass, entry_id) -> dict[str, Any] | None with a docstring and type hints in custom_components/rental_control/util.py
 
 **Checkpoint**: Foundation ready — helper returns the existing entry dict when
 present and None for both missing-domain and missing-entry paths.
@@ -66,18 +66,18 @@ reported operation and verify the same externally observable behavior as before.
 > **NOTE: Write these tests FIRST, ensure they FAIL or protect current behavior
 > before implementation tasks preserve the loaded-entry path.**
 
-- [ ] T005 [P] [US1] Add update_listener present-data regression tests for config update and listener refresh behavior in tests/unit/test_init.py
-- [ ] T006 [P] [US1] Add keymaster event present-data accepted-forwarding regression coverage in tests/unit/test_keymaster_event_diagnostics.py
-- [ ] T007 [P] [US1] Add monitoring-switch present-data tests proving switch is_on and is_off states win over the lockname fallback in tests/unit/test_checkin_sensor.py
-- [ ] T008 [US1] Add async_checkout present-data early-expiry regression test proving an enabled early-expiry switch shortens expiry in tests/unit/test_checkin_sensor.py
-- [ ] T009 [P] [US1] Add KeymasterMonitoringSwitch present-data registration regression test in tests/unit/test_switch.py
+- [X] T005 [P] [US1] Add update_listener present-data regression tests for config update and listener refresh behavior in tests/unit/test_init.py
+- [X] T006 [P] [US1] Add keymaster event present-data accepted-forwarding regression coverage in tests/unit/test_keymaster_event_diagnostics.py
+- [X] T007 [P] [US1] Add monitoring-switch present-data tests proving switch is_on and is_off states win over the lockname fallback in tests/unit/test_checkin_sensor.py
+- [X] T008 [US1] Add async_checkout present-data early-expiry regression test proving an enabled early-expiry switch shortens expiry in tests/unit/test_checkin_sensor.py
+- [X] T009 [P] [US1] Add KeymasterMonitoringSwitch present-data registration regression test in tests/unit/test_switch.py
 
 ### Implementation for User Story 1
 
-- [ ] T010 [US1] Replace both update_listener entry-data lookups with get_entry_data while preserving present-data config update and listener refresh behavior in custom_components/rental_control/__init__.py
-- [ ] T011 [US1] Replace the _handle_keymaster_event entry-data lookup with get_entry_data while preserving accepted unlock forwarding when components are present in custom_components/rental_control/__init__.py
-- [ ] T012 [US1] Replace _is_keymaster_monitoring_enabled and async_checkout entry-data lookups with get_entry_data while preserving present switch and early-expiry behavior in custom_components/rental_control/sensors/checkinsensor.py
-- [ ] T013 [US1] Replace KeymasterMonitoringSwitch.async_added_to_hass entry-data lookup with get_entry_data while preserving state restore, debug logging, and successful registration in custom_components/rental_control/switch.py
+- [X] T010 [US1] Replace both update_listener entry-data lookups with get_entry_data while preserving present-data config update and listener refresh behavior in custom_components/rental_control/__init__.py
+- [X] T011 [US1] Replace the _handle_keymaster_event entry-data lookup with get_entry_data while preserving accepted unlock forwarding when components are present in custom_components/rental_control/__init__.py
+- [X] T012 [US1] Replace _is_keymaster_monitoring_enabled and async_checkout entry-data lookups with get_entry_data while preserving present switch and early-expiry behavior in custom_components/rental_control/sensors/checkinsensor.py
+- [X] T013 [US1] Replace KeymasterMonitoringSwitch.async_added_to_hass entry-data lookup with get_entry_data while preserving state restore, debug logging, and successful registration in custom_components/rental_control/switch.py
 
 **Checkpoint**: Loaded-entry behavior is covered for all six call sites. The MVP
 is not complete until US2 missing-data tests also pass.
@@ -95,18 +95,18 @@ unhandled exceptions or throwaway state mutation.
 
 ### Tests for User Story 2
 
-- [ ] T014 [US2] Add update_listener missing-domain and missing-entry tests for first-lookup early return and second-lookup listener-refresh early return in tests/unit/test_init.py
-- [ ] T015 [P] [US2] Add keymaster event missing-domain and missing-entry rejection tests verifying no forwarding and no accepted disposition in tests/unit/test_keymaster_event_diagnostics.py
-- [ ] T016 [P] [US2] Add _is_keymaster_monitoring_enabled missing-domain and missing-entry tests verifying fallback to self.coordinator.lockname is not None in tests/unit/test_checkin_sensor.py
-- [ ] T017 [US2] Add async_checkout missing-domain and missing-entry tests verifying checkout continues without early expiry in tests/unit/test_checkin_sensor.py
-- [ ] T018 [P] [US2] Add KeymasterMonitoringSwitch missing-domain and missing-entry tests verifying no throwaway dict mutation while restore/logging behavior remains safe in tests/unit/test_switch.py
+- [X] T014 [US2] Add update_listener missing-domain and missing-entry tests for first-lookup early return and second-lookup listener-refresh early return in tests/unit/test_init.py
+- [X] T015 [P] [US2] Add keymaster event missing-domain and missing-entry rejection tests verifying no forwarding and no accepted disposition in tests/unit/test_keymaster_event_diagnostics.py
+- [X] T016 [P] [US2] Add _is_keymaster_monitoring_enabled missing-domain and missing-entry tests verifying fallback to self.coordinator.lockname is not None in tests/unit/test_checkin_sensor.py
+- [X] T017 [US2] Add async_checkout missing-domain and missing-entry tests verifying checkout continues without early expiry in tests/unit/test_checkin_sensor.py
+- [X] T018 [P] [US2] Add KeymasterMonitoringSwitch missing-domain and missing-entry tests verifying no throwaway dict mutation while restore/logging behavior remains safe in tests/unit/test_switch.py
 
 ### Implementation for User Story 2
 
-- [ ] T019 [US2] Ensure update_listener returns before config mutation when entry data is absent before update and before listener refresh when data vanishes after update in custom_components/rental_control/__init__.py
-- [ ] T020 [US2] Ensure _handle_keymaster_event rejects missing entry data before CHECKIN_SENSOR or KEYMASTER_MONITORING_SWITCH lookups and never records accepted forwarding in custom_components/rental_control/__init__.py
-- [ ] T021 [US2] Ensure _is_keymaster_monitoring_enabled falls back to self.coordinator.lockname is not None and async_checkout skips early expiry then continues checkout when get_entry_data returns None in custom_components/rental_control/sensors/checkinsensor.py
-- [ ] T022 [US2] Ensure KeymasterMonitoringSwitch.async_added_to_hass returns after state restore and debug logging, but without mutating entry state, when get_entry_data returns None in custom_components/rental_control/switch.py
+- [X] T019 [US2] Ensure update_listener returns before config mutation when entry data is absent before update and before listener refresh when data vanishes after update in custom_components/rental_control/__init__.py
+- [X] T020 [US2] Ensure _handle_keymaster_event rejects missing entry data before CHECKIN_SENSOR or KEYMASTER_MONITORING_SWITCH lookups and never records accepted forwarding in custom_components/rental_control/__init__.py
+- [X] T021 [US2] Ensure _is_keymaster_monitoring_enabled falls back to self.coordinator.lockname is not None and async_checkout skips early expiry then continues checkout when get_entry_data returns None in custom_components/rental_control/sensors/checkinsensor.py
+- [X] T022 [US2] Ensure KeymasterMonitoringSwitch.async_added_to_hass returns after state restore and debug logging, but without mutating entry state, when get_entry_data returns None in custom_components/rental_control/switch.py
 
 **Checkpoint**: Missing-domain and missing-entry behavior is explicit and safe
 for all six issue-reported paths. MVP is complete with US1 + US2.
@@ -123,13 +123,13 @@ supporting component at a time and verify the documented behavior.
 
 ### Tests for User Story 3
 
-- [ ] T023 [P] [US3] Add present-entry missing-CHECKIN_SENSOR and missing-KEYMASTER_MONITORING_SWITCH event rejection tests in tests/unit/test_keymaster_event_diagnostics.py
-- [ ] T024 [US3] Add present-entry missing KEYMASTER_MONITORING_SWITCH fallback tests for both configured and unconfigured lockname values in tests/unit/test_checkin_sensor.py
-- [ ] T025 [US3] Add present-entry missing EARLY_CHECKOUT_EXPIRY_SWITCH checkout test verifying skip-and-continue behavior in tests/unit/test_checkin_sensor.py
+- [X] T023 [P] [US3] Add present-entry missing-CHECKIN_SENSOR and missing-KEYMASTER_MONITORING_SWITCH event rejection tests in tests/unit/test_keymaster_event_diagnostics.py
+- [X] T024 [US3] Add present-entry missing KEYMASTER_MONITORING_SWITCH fallback tests for both configured and unconfigured lockname values in tests/unit/test_checkin_sensor.py
+- [X] T025 [US3] Add present-entry missing EARLY_CHECKOUT_EXPIRY_SWITCH checkout test verifying skip-and-continue behavior in tests/unit/test_checkin_sensor.py
 
 ### Implementation for User Story 3
 
-- [ ] T026 [US3] Keep supporting component lookups local with existing .get(...) fallback behavior after get_entry_data succeeds in custom_components/rental_control/__init__.py and custom_components/rental_control/sensors/checkinsensor.py
+- [X] T026 [US3] Keep supporting component lookups local with existing .get(...) fallback behavior after get_entry_data succeeds in custom_components/rental_control/__init__.py and custom_components/rental_control/sensors/checkinsensor.py
 
 **Checkpoint**: Missing components inside present entry data remain distinct
 from missing entry data and preserve their existing outcomes.
@@ -146,12 +146,12 @@ reported path is explicit and unrelated behavior is unchanged.
 
 ### Tests for User Story 4
 
-- [ ] T027 [P] [US4] Add or extend loaded-entry smoke coverage for normal setup and unload in tests/integration/test_full_setup.py only if unit tests do not already cover a changed behavior
+- [X] T027 [P] [US4] Add or extend loaded-entry smoke coverage for normal setup and unload in tests/integration/test_full_setup.py only if unit tests do not already cover a changed behavior
 
 ### Implementation for User Story 4
 
-- [ ] T028 [US4] Confirm no user-facing configuration, entity state, service, migration, or unrelated data-access changes were introduced outside custom_components/rental_control/util.py, custom_components/rental_control/__init__.py, custom_components/rental_control/sensors/checkinsensor.py, and custom_components/rental_control/switch.py
-- [ ] T029 [US4] Run the quickstart chained-get search and confirm the six issue-reported paths no longer use hass.data.get(DOMAIN, {}) defaults in custom_components/rental_control/__init__.py, custom_components/rental_control/sensors/checkinsensor.py, and custom_components/rental_control/switch.py
+- [X] T028 [US4] Confirm no user-facing configuration, entity state, service, migration, or unrelated data-access changes were introduced outside custom_components/rental_control/util.py, custom_components/rental_control/__init__.py, custom_components/rental_control/sensors/checkinsensor.py, and custom_components/rental_control/switch.py
+- [X] T029 [US4] Run the quickstart chained-get search and confirm the six issue-reported paths no longer use hass.data.get(DOMAIN, {}) defaults in custom_components/rental_control/__init__.py, custom_components/rental_control/sensors/checkinsensor.py, and custom_components/rental_control/switch.py
 
 **Checkpoint**: Scope remains bounded to issue #571 and all six reported paths
 have explicit domain and entry guards.
@@ -162,11 +162,11 @@ have explicit domain and entry guards.
 
 **Purpose**: Final validation across all stories
 
-- [ ] T030 Run targeted pytest validation for tests/unit/test_util.py, tests/unit/test_init.py, tests/unit/test_keymaster_event_diagnostics.py, tests/unit/test_checkin_sensor.py, tests/unit/test_switch.py, and tests/integration/test_full_setup.py
-- [ ] T031 Run ruff validation for custom_components/rental_control/util.py, custom_components/rental_control/__init__.py, custom_components/rental_control/sensors/checkinsensor.py, custom_components/rental_control/switch.py, tests/unit/test_util.py, tests/unit/test_init.py, tests/unit/test_keymaster_event_diagnostics.py, tests/unit/test_checkin_sensor.py, and tests/unit/test_switch.py
-- [ ] T032 Run full test suite via `uv run pytest tests/ -v` covering tests/unit/ and tests/integration/
-- [ ] T033 Run pre-commit hook validation for custom_components/rental_control/, tests/, and specs/010-explicit-entry-guards/tasks.md
-- [ ] T034 Validate the implementation against specs/010-explicit-entry-guards/quickstart.md acceptance checks
+- [X] T030 Run targeted pytest validation for tests/unit/test_util.py, tests/unit/test_init.py, tests/unit/test_keymaster_event_diagnostics.py, tests/unit/test_checkin_sensor.py, tests/unit/test_switch.py, and tests/integration/test_full_setup.py
+- [X] T031 Run ruff validation for custom_components/rental_control/util.py, custom_components/rental_control/__init__.py, custom_components/rental_control/sensors/checkinsensor.py, custom_components/rental_control/switch.py, tests/unit/test_util.py, tests/unit/test_init.py, tests/unit/test_keymaster_event_diagnostics.py, tests/unit/test_checkin_sensor.py, and tests/unit/test_switch.py
+- [X] T032 Run full test suite via `uv run pytest tests/ -v` covering tests/unit/ and tests/integration/
+- [X] T033 Run pre-commit hook validation for custom_components/rental_control/, tests/, and specs/010-explicit-entry-guards/tasks.md
+- [X] T034 Validate the implementation against specs/010-explicit-entry-guards/quickstart.md acceptance checks
 
 ---
 

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -3538,6 +3538,46 @@ class TestChildLockMonitoringSwitch:
         sensor.async_handle_keymaster_unlock.assert_not_called()
 
 
+class TestKeymasterMonitoringEntryData:
+    """Tests for keymaster monitoring entry-data lookups."""
+
+    async def test_present_switch_on_wins_over_missing_lockname_fallback(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify an on switch enables monitoring even without lockname."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = None
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=True),
+        }
+
+        assert sensor._is_keymaster_monitoring_enabled() is True
+
+    async def test_present_switch_off_wins_over_configured_lockname_fallback(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify an off switch disables monitoring despite lockname."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = "front_door"
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=False),
+        }
+
+        assert sensor._is_keymaster_monitoring_enabled() is False
+
+
 # ===========================================================================
 # T027: Manual checkout action (async_checkout)
 # ===========================================================================

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -4082,6 +4082,65 @@ def _setup_early_expiry_switch(
     return mock_switch
 
 
+class TestSupportingComponentAbsence:
+    """Tests for missing supporting components inside present entry data."""
+
+    @pytest.mark.parametrize(
+        ("lockname", "expected"),
+        [("front_door", True), (None, False)],
+    )
+    async def test_missing_monitoring_switch_uses_lockname_fallback(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+        lockname: str | None,
+        *,
+        expected: bool,
+    ) -> None:
+        """Verify present entry without monitoring switch uses lockname."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = lockname
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            COORDINATOR: mock_checkin_coordinator,
+            UNSUB_LISTENERS: [],
+        }
+
+        assert sensor._is_keymaster_monitoring_enabled() is expected
+
+    async def test_checkout_missing_early_expiry_switch_continues(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify present entry without early-expiry switch continues checkout."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        now = dt_util.now()
+        original_end = now + timedelta(hours=4)
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - John Smith"
+        sensor._tracked_event_start = now - timedelta(hours=2)
+        sensor._tracked_event_end = original_end
+        sensor._tracked_event_slot_name = "John Smith"
+        mock_checkin_coordinator.data = []
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            COORDINATOR: mock_checkin_coordinator,
+            UNSUB_LISTENERS: [],
+        }
+
+        await sensor.async_checkout()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._tracked_event_end == original_end
+
+
 class TestMissingEntryDataFallbacks:
     """Tests for missing entry-data fallback behavior."""
 

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -4082,6 +4082,92 @@ def _setup_early_expiry_switch(
     return mock_switch
 
 
+class TestMissingEntryDataFallbacks:
+    """Tests for missing entry-data fallback behavior."""
+
+    @pytest.mark.parametrize(
+        ("lockname", "expected"),
+        [("front_door", True), (None, False)],
+    )
+    async def test_monitoring_missing_domain_uses_lockname_fallback(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+        lockname: str | None,
+        *,
+        expected: bool,
+    ) -> None:
+        """Verify missing domain data falls back to configured lockname."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = lockname
+        hass.data.pop(DOMAIN, None)
+
+        assert sensor._is_keymaster_monitoring_enabled() is expected
+
+    @pytest.mark.parametrize(
+        ("lockname", "expected"),
+        [("front_door", True), (None, False)],
+    )
+    async def test_monitoring_missing_entry_uses_lockname_fallback(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+        lockname: str | None,
+        *,
+        expected: bool,
+    ) -> None:
+        """Verify missing entry data falls back to configured lockname."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        mock_checkin_coordinator.lockname = lockname
+        domain_data: dict[str, object] = {}
+        hass.data[DOMAIN] = domain_data
+
+        assert sensor._is_keymaster_monitoring_enabled() is expected
+        assert hass.data[DOMAIN] is domain_data
+
+    @pytest.mark.parametrize("remove_domain", [True, False])
+    async def test_checkout_missing_entry_data_continues_without_early_expiry(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+        *,
+        remove_domain: bool,
+    ) -> None:
+        """Verify checkout continues unchanged when entry data is missing."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        now = dt_util.now()
+        original_end = now + timedelta(hours=4)
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = "Reserved - John Smith"
+        sensor._tracked_event_start = now - timedelta(hours=2)
+        sensor._tracked_event_end = original_end
+        sensor._tracked_event_slot_name = "John Smith"
+        mock_checkin_coordinator.data = []
+        if remove_domain:
+            hass.data.pop(DOMAIN, None)
+        else:
+            domain_data: dict[str, object] = {}
+            hass.data[DOMAIN] = domain_data
+
+        await sensor.async_checkout()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+        assert sensor._tracked_event_end == original_end
+        if remove_domain:
+            assert DOMAIN not in hass.data
+        else:
+            assert hass.data[DOMAIN] == {}
+
+
 class TestEarlyCheckoutExpiry:
     """Tests for early checkout expiry behavior on CheckinTrackingSensor (T032).
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -237,6 +237,108 @@ async def test_update_listener_present_data_updates_config_and_listeners(
     register_listener.assert_called_once_with(hass, mock_config_entry)
 
 
+async def test_update_listener_missing_entry_before_update_returns(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify update_listener returns before mutation without entry data."""
+    mock_config_entry.add_to_hass(hass)
+    original_data = dict(mock_config_entry.data)
+    updated_options = dict(mock_config_entry.data)
+    updated_options[CONF_NAME] = "Updated Rental"
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options=updated_options,
+    )
+    hass.data[DOMAIN] = {}
+
+    with patch.object(
+        hass.config_entries,
+        "async_update_entry",
+        wraps=hass.config_entries.async_update_entry,
+    ) as update_entry:
+        await update_listener(hass, mock_config_entry)
+
+    update_entry.assert_not_called()
+    assert mock_config_entry.data == original_data
+    assert hass.data[DOMAIN] == {}
+
+
+async def test_update_listener_missing_domain_before_update_returns(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify update_listener returns before mutation without domain data."""
+    mock_config_entry.add_to_hass(hass)
+    original_data = dict(mock_config_entry.data)
+    updated_options = dict(mock_config_entry.data)
+    updated_options[CONF_NAME] = "Updated Rental"
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options=updated_options,
+    )
+    hass.data.pop(DOMAIN, None)
+
+    with patch.object(
+        hass.config_entries,
+        "async_update_entry",
+        wraps=hass.config_entries.async_update_entry,
+    ) as update_entry:
+        await update_listener(hass, mock_config_entry)
+
+    update_entry.assert_not_called()
+    assert mock_config_entry.data == original_data
+    assert DOMAIN not in hass.data
+
+
+async def test_update_listener_entry_vanishes_after_config_update_returns(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify listener refresh is skipped when entry data vanishes."""
+    mock_config_entry.add_to_hass(hass)
+    updated_options = dict(mock_config_entry.data)
+    updated_options[CONF_NAME] = "Updated Rental"
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options=updated_options,
+    )
+
+    coordinator = MagicMock()
+    coordinator.created = "2026-06-18T15:00:00+00:00"
+    coordinator.lockname = "front_door"
+    unsub_listener = MagicMock()
+
+    async def _remove_entry(_new_data: dict[str, object]) -> None:
+        """Remove entry data while update_listener is updating config."""
+        hass.data[DOMAIN].pop(mock_config_entry.entry_id)
+
+    coordinator.update_config = AsyncMock(side_effect=_remove_entry)
+    hass.data[DOMAIN] = {
+        mock_config_entry.entry_id: {
+            COORDINATOR: coordinator,
+            UNSUB_LISTENERS: [unsub_listener],
+        },
+    }
+
+    with (
+        patch(
+            "custom_components.rental_control.async_start_listener",
+            new_callable=AsyncMock,
+        ) as start_listener,
+        patch(
+            "custom_components.rental_control.async_register_keymaster_listener",
+        ) as register_listener,
+    ):
+        await update_listener(hass, mock_config_entry)
+
+    coordinator.update_config.assert_awaited_once()
+    unsub_listener.assert_not_called()
+    start_listener.assert_not_called()
+    register_listener.assert_not_called()
+    assert mock_config_entry.entry_id not in hass.data[DOMAIN]
+
+
 # Note: Tasks T039a-T039d test features that are either not yet implemented
 # or are better tested at the integration level:
 # - T039a (service_registration): No services currently registered in __init__.py

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -6,12 +6,18 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_NAME
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.rental_control import update_listener
 from custom_components.rental_control.const import CONF_CODE_LENGTH
+from custom_components.rental_control.const import CONF_CREATION_DATETIME
 from custom_components.rental_control.const import CONF_GENERATE
 from custom_components.rental_control.const import CONF_HONOR_EVENT_TIMES
 from custom_components.rental_control.const import CONF_PATH
@@ -20,6 +26,7 @@ from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DEFAULT_CODE_LENGTH
 from custom_components.rental_control.const import DEFAULT_GENERATE
 from custom_components.rental_control.const import DOMAIN
+from custom_components.rental_control.const import UNSUB_LISTENERS
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -181,6 +188,53 @@ async def test_config_entry_reload(
     updated_coordinator = hass.data[DOMAIN][mock_config_entry.entry_id][COORDINATOR]
     assert updated_coordinator.refresh_frequency == 30
     assert updated_coordinator.refresh_frequency != original_refresh_frequency
+
+
+async def test_update_listener_present_data_updates_config_and_listeners(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify update_listener preserves loaded-entry update behavior."""
+    mock_config_entry.add_to_hass(hass)
+    updated_options = dict(mock_config_entry.data)
+    updated_options[CONF_NAME] = "Updated Rental"
+    updated_options["refresh_frequency"] = 12
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options=updated_options,
+    )
+
+    coordinator = MagicMock()
+    coordinator.created = "2026-06-18T15:00:00+00:00"
+    coordinator.lockname = "front_door"
+    coordinator.update_config = AsyncMock()
+    unsub_listener = MagicMock()
+    hass.data[DOMAIN] = {
+        mock_config_entry.entry_id: {
+            COORDINATOR: coordinator,
+            UNSUB_LISTENERS: [unsub_listener],
+        },
+    }
+
+    with (
+        patch(
+            "custom_components.rental_control.async_start_listener",
+            new_callable=AsyncMock,
+        ) as start_listener,
+        patch(
+            "custom_components.rental_control.async_register_keymaster_listener",
+        ) as register_listener,
+    ):
+        await update_listener(hass, mock_config_entry)
+
+    assert mock_config_entry.data[CONF_NAME] == "Updated Rental"
+    assert mock_config_entry.data[CONF_CREATION_DATETIME] == coordinator.created
+    assert mock_config_entry.options == {}
+    coordinator.update_config.assert_awaited_once()
+    unsub_listener.assert_called_once_with()
+    assert hass.data[DOMAIN][mock_config_entry.entry_id][UNSUB_LISTENERS] == []
+    start_listener.assert_awaited_once_with(hass, mock_config_entry)
+    register_listener.assert_called_once_with(hass, mock_config_entry)
 
 
 # Note: Tasks T039a-T039d test features that are either not yet implemented

--- a/tests/unit/test_keymaster_event_diagnostics.py
+++ b/tests/unit/test_keymaster_event_diagnostics.py
@@ -40,6 +40,7 @@ def _setup_entry(
     *,
     monitoring_on: bool = True,
     include_sensor: bool = True,
+    include_monitoring_switch: bool = True,
 ) -> MagicMock:
     """Wire coordinator/sensor/switch into ``hass.data`` for the listener.
 
@@ -57,8 +58,9 @@ def _setup_entry(
     entry_data: dict = {
         COORDINATOR: coordinator,
         UNSUB_LISTENERS: [],
-        KEYMASTER_MONITORING_SWITCH: MagicMock(is_on=monitoring_on),
     }
+    if include_monitoring_switch:
+        entry_data[KEYMASTER_MONITORING_SWITCH] = MagicMock(is_on=monitoring_on)
     if include_sensor:
         entry_data[CHECKIN_SENSOR] = sensor
     hass.data[DOMAIN][config_entry.entry_id] = entry_data
@@ -181,7 +183,7 @@ class TestDiagnosticsBuffer:
         mock_checkin_config_entry: MockConfigEntry,
     ) -> None:
         """Missing CHECKIN_SENSOR records rejected_no_checkin_sensor."""
-        _setup_entry(
+        sensor = _setup_entry(
             hass,
             mock_checkin_coordinator,
             mock_checkin_config_entry,
@@ -196,9 +198,37 @@ class TestDiagnosticsBuffer:
         )
         await hass.async_block_till_done()
 
+        sensor.async_handle_keymaster_unlock.assert_not_called()
         buf = list(mock_checkin_coordinator.keymaster_event_diagnostics)
         assert len(buf) == 1
         assert buf[0]["disposition"] == "rejected_no_checkin_sensor"
+
+    async def test_rejected_missing_monitoring_switch(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Missing monitoring switch records rejected_monitoring_off."""
+        sensor = _setup_entry(
+            hass,
+            mock_checkin_coordinator,
+            mock_checkin_config_entry,
+            include_monitoring_switch=False,
+        )
+        _set_diag(mock_checkin_config_entry, hass, True)
+        async_register_keymaster_listener(hass, mock_checkin_config_entry)
+
+        hass.bus.async_fire(
+            "keymaster_lock_state_changed",
+            {"lockname": "front_door", "state": "unlocked", "code_slot_num": 11},
+        )
+        await hass.async_block_till_done()
+
+        sensor.async_handle_keymaster_unlock.assert_not_called()
+        buf = list(mock_checkin_coordinator.keymaster_event_diagnostics)
+        assert len(buf) == 1
+        assert buf[0]["disposition"] == "rejected_monitoring_off"
 
     async def test_rejected_monitoring_off(
         self,

--- a/tests/unit/test_keymaster_event_diagnostics.py
+++ b/tests/unit/test_keymaster_event_diagnostics.py
@@ -110,7 +110,10 @@ class TestDiagnosticsBuffer:
         )
         await hass.async_block_till_done()
 
-        sensor.async_handle_keymaster_unlock.assert_called_once()
+        sensor.async_handle_keymaster_unlock.assert_called_once_with(
+            code_slot_num=11,
+            lock_name="Front Door",
+        )
         buf = list(mock_checkin_coordinator.keymaster_event_diagnostics)
         assert len(buf) == 1
         entry = buf[0]

--- a/tests/unit/test_keymaster_event_diagnostics.py
+++ b/tests/unit/test_keymaster_event_diagnostics.py
@@ -226,6 +226,33 @@ class TestDiagnosticsBuffer:
         assert len(buf) == 1
         assert buf[0]["disposition"] == "rejected_monitoring_off"
 
+    @pytest.mark.parametrize("remove_domain", [True, False])
+    async def test_missing_entry_data_rejects_without_accepting(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+        *,
+        remove_domain: bool,
+    ) -> None:
+        """Missing domain or entry data must not forward or record accepted."""
+        sensor = _setup_entry(hass, mock_checkin_coordinator, mock_checkin_config_entry)
+        _set_diag(mock_checkin_config_entry, hass, True)
+        async_register_keymaster_listener(hass, mock_checkin_config_entry)
+        if remove_domain:
+            hass.data.pop(DOMAIN)
+        else:
+            hass.data[DOMAIN].pop(mock_checkin_config_entry.entry_id)
+
+        hass.bus.async_fire(
+            "keymaster_lock_state_changed",
+            {"lockname": "front_door", "state": "unlocked", "code_slot_num": 11},
+        )
+        await hass.async_block_till_done()
+
+        sensor.async_handle_keymaster_unlock.assert_not_called()
+        assert list(mock_checkin_coordinator.keymaster_event_diagnostics) == []
+
     async def test_ring_buffer_truncates_at_ten(
         self,
         hass: HomeAssistant,

--- a/tests/unit/test_switch.py
+++ b/tests/unit/test_switch.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
+
 from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.const import EARLY_CHECKOUT_EXPIRY_SWITCH
@@ -303,6 +305,34 @@ class TestKeymasterMonitoringSwitchRestore:
             KEYMASTER_MONITORING_SWITCH,
         )
         assert stored is switch
+
+    @pytest.mark.parametrize("remove_domain", [True, False])
+    async def test_added_to_hass_missing_entry_data_does_not_mutate_state(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_config_entry: MockConfigEntry,
+        *,
+        remove_domain: bool,
+    ) -> None:
+        """Test missing entry data does not create phantom switch state."""
+        coordinator = _make_coordinator(hass)
+        switch = _create_switch(hass, coordinator, mock_checkin_config_entry)
+        mock_state = MagicMock()
+        mock_state.state = "on"
+        if remove_domain:
+            hass.data.pop(DOMAIN)
+        else:
+            domain_data: dict[str, object] = {}
+            hass.data[DOMAIN] = domain_data
+
+        with patch.object(switch, "async_get_last_state", return_value=mock_state):
+            await switch.async_added_to_hass()
+
+        assert switch.is_on is True
+        if remove_domain:
+            assert DOMAIN not in hass.data
+        else:
+            assert hass.data[DOMAIN] == {}
 
 
 class TestSwitchPlatformSetup:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
+from importlib import import_module
 import logging
+from typing import TYPE_CHECKING
+from typing import cast
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -40,6 +43,73 @@ from custom_components.rental_control.util import get_slot_name
 from custom_components.rental_control.util import handle_state_change
 from custom_components.rental_control.util import normalize_uid
 from custom_components.rental_control.util import trim_name
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from homeassistant.core import HomeAssistant
+
+
+# ---------------------------------------------------------------------------
+# get_entry_data tests
+# ---------------------------------------------------------------------------
+
+
+def _get_entry_data_helper() -> Callable[
+    [HomeAssistant, str], dict[str, object] | None
+]:
+    """Return the entry data helper under test."""
+    helper = import_module("custom_components.rental_control.util").get_entry_data
+    return cast("Callable[[HomeAssistant, str], dict[str, object] | None]", helper)
+
+
+class TestGetEntryData:
+    """Tests for the shared entry-data lookup helper."""
+
+    def test_present_entry_data_returns_existing_dict(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Verify present entry data is returned by identity."""
+        entry_data: dict[str, object] = {COORDINATOR: object()}
+        hass.data[DOMAIN] = {"entry-id": entry_data}
+
+        assert _get_entry_data_helper()(hass, "entry-id") is entry_data
+
+    def test_missing_domain_data_returns_none(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Verify a missing domain bucket returns None."""
+        hass.data.pop(DOMAIN, None)
+
+        assert _get_entry_data_helper()(hass, "entry-id") is None
+        assert DOMAIN not in hass.data
+
+    def test_missing_entry_data_returns_none(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Verify a missing entry inside domain data returns None."""
+        domain_data: dict[str, dict[str, object]] = {}
+        hass.data[DOMAIN] = domain_data
+
+        assert _get_entry_data_helper()(hass, "entry-id") is None
+        assert hass.data[DOMAIN] is domain_data
+
+    def test_missing_entry_does_not_create_throwaway_state(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Verify missing lookups do not create phantom entry state."""
+        domain_data: dict[str, dict[str, object]] = {}
+        hass.data[DOMAIN] = domain_data
+
+        assert _get_entry_data_helper()(hass, "missing-entry") is None
+
+        assert hass.data[DOMAIN] is domain_data
+        assert "missing-entry" not in domain_data
+
 
 # ---------------------------------------------------------------------------
 # gen_uuid tests


### PR DESCRIPTION
## Summary
- Add shared get_entry_data(hass, entry_id) helper for explicit Rental Control domain and entry guards.
- Update the six issue-reported sites: update_listener (two lookups), _handle_keymaster_event, _is_keymaster_monitoring_enabled, async_checkout, and KeymasterMonitoringSwitch.async_added_to_hass.
- Preserve normal loaded-entry behavior while making missing domain/entry fallback behavior explicit.
- Complete the final speckit IMPLEMENT stage for issue #571.

Closes #571

## Validation
- uv run pytest tests/unit/test_util.py tests/unit/test_init.py tests/unit/test_keymaster_event_diagnostics.py tests/unit/test_checkin_sensor.py tests/unit/test_switch.py tests/integration/test_full_setup.py -q
- uv run pytest tests/ -q
- uv run ruff check custom_components/ tests/
- uv run pre-commit run --all-files