### PR TITLE
Refactor: Decompose integration entry module

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -35,30 +35,18 @@ from homeassistant.util import dt as dt_util
 from homeassistant.util import slugify
 
 from .const import CHECKIN_SENSOR
-from .const import CONF_CODE_BUFFER_AFTER
-from .const import CONF_CODE_BUFFER_BEFORE
-from .const import CONF_CODE_LENGTH
 from .const import CONF_CREATION_DATETIME
 from .const import CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
 from .const import CONF_GENERATE
-from .const import CONF_HONOR_EVENT_TIMES
-from .const import CONF_MAX_NAME_LENGTH
-from .const import CONF_PATH
-from .const import CONF_SHOULD_UPDATE_CODE
-from .const import CONF_TRIM_NAMES
 from .const import COORDINATOR
-from .const import DEFAULT_CODE_BUFFER_AFTER
-from .const import DEFAULT_CODE_BUFFER_BEFORE
-from .const import DEFAULT_CODE_LENGTH
 from .const import DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
-from .const import DEFAULT_GENERATE
-from .const import DEFAULT_MAX_NAME_LENGTH
 from .const import DOMAIN
 from .const import KEYMASTER_MONITORING_SWITCH
 from .const import NAME
 from .const import PLATFORMS
 from .const import UNSUB_LISTENERS
 from .coordinator import RentalControlCoordinator
+from .migrations import async_migrate_entry as async_migrate_entry
 from .util import async_reload_package_platforms
 from .util import delete_rc_and_base_folder
 from .util import get_entry_data
@@ -164,140 +152,6 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     async_dismiss(hass, notification_id)
 
     return unload_ok
-
-
-async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Migrate configuration."""
-
-    version = config_entry.version
-
-    # Versions 1 and 2 are no longer supported (oldest supported: v0.9.0 = version 3)
-    if version < 3:
-        _LOGGER.error(
-            "Config entry version %s is too old to migrate; "
-            "please remove and re-add the integration",
-            version,
-        )
-        return False
-
-    # 3 -> 4: Migrate code length
-    if version == 3:
-        _LOGGER.debug("Migrating from version %s", version)
-        if CONF_CODE_LENGTH not in config_entry.data:
-            data = config_entry.data.copy()
-            data[CONF_CODE_LENGTH] = DEFAULT_CODE_LENGTH
-            hass.config_entries.async_update_entry(
-                entry=config_entry,
-                unique_id=config_entry.unique_id,
-                data=data,
-                version=4,
-            )
-
-        version = 4
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
-
-    # 4 -> 5: Drop startup automation
-    if version == 4:
-        _LOGGER.debug("Migrating from version %s", version)
-
-        data = config_entry.data.copy()
-        data[CONF_GENERATE] = DEFAULT_GENERATE
-        hass.config_entries.async_update_entry(
-            entry=config_entry,
-            unique_id=config_entry.unique_id,
-            data=data,
-            version=5,
-        )
-
-        version = 5
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
-
-    # 5 -> 6: Drop package_path from configuration
-    if version == 5:
-        _LOGGER.debug("Migrating from version %s", version)
-
-        data = config_entry.data.copy()
-        data.pop(CONF_PATH, None)
-        hass.config_entries.async_update_entry(
-            entry=config_entry,
-            unique_id=config_entry.unique_id,
-            data=data,
-            version=6,
-        )
-
-        version = 6
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
-
-    # 6 -> 7: Add should_update_code to configuration
-    if version == 6:
-        _LOGGER.debug("Migrating from version %s", version)
-
-        data = config_entry.data.copy()
-        # Default to False since prior versions didn't have this
-        # new setups will default to True
-        data[CONF_SHOULD_UPDATE_CODE] = False
-        hass.config_entries.async_update_entry(
-            entry=config_entry,
-            unique_id=config_entry.unique_id,
-            data=data,
-            version=7,
-        )
-
-        version = 7
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
-
-    # 7 -> 8: Add honor_event_times to configuration
-    if version == 7:
-        _LOGGER.debug("Migrating from version %s", version)
-
-        data = config_entry.data.copy()
-        if CONF_HONOR_EVENT_TIMES not in data:
-            data[CONF_HONOR_EVENT_TIMES] = False
-        hass.config_entries.async_update_entry(
-            entry=config_entry,
-            unique_id=config_entry.unique_id,
-            data=data,
-            version=8,
-        )
-
-        version = 8
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
-
-    # 8 -> 9: Add trim_names and max_name_length to configuration
-    if version == 8:
-        _LOGGER.debug("Migrating from version %s", version)
-
-        data = config_entry.data.copy()
-        data[CONF_TRIM_NAMES] = False
-        data[CONF_MAX_NAME_LENGTH] = DEFAULT_MAX_NAME_LENGTH
-        hass.config_entries.async_update_entry(
-            entry=config_entry,
-            unique_id=config_entry.unique_id,
-            data=data,
-            version=9,
-        )
-
-        version = 9
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
-
-    # 9 -> 10: Add code buffer before/after to configuration
-    if version == 9:
-        _LOGGER.debug("Migrating from version %s", version)
-
-        data = config_entry.data.copy()
-        data.setdefault(CONF_CODE_BUFFER_BEFORE, DEFAULT_CODE_BUFFER_BEFORE)
-        data.setdefault(CONF_CODE_BUFFER_AFTER, DEFAULT_CODE_BUFFER_AFTER)
-        hass.config_entries.async_update_entry(
-            entry=config_entry,
-            unique_id=config_entry.unique_id,
-            data=data,
-            version=10,
-        )
-
-        version = 10
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
-
-    return True
 
 
 async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> None:

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -26,26 +26,21 @@ from homeassistant.components.switch import DOMAIN as SWITCH
 from homeassistant.components.text import DOMAIN as TEXT
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import Event
 from homeassistant.core import HomeAssistant
-from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.util import dt as dt_util
-from homeassistant.util import slugify
 
-from .const import CHECKIN_SENSOR
 from .const import CONF_CREATION_DATETIME
-from .const import CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
 from .const import CONF_GENERATE
 from .const import COORDINATOR
-from .const import DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
 from .const import DOMAIN
-from .const import KEYMASTER_MONITORING_SWITCH
 from .const import NAME
 from .const import PLATFORMS
 from .const import UNSUB_LISTENERS
 from .coordinator import RentalControlCoordinator
+from .listeners import (
+    async_register_keymaster_listener as async_register_keymaster_listener,
+)
 from .migrations import async_migrate_entry as async_migrate_entry
 from .util import async_reload_package_platforms
 from .util import delete_rc_and_base_folder
@@ -227,171 +222,4 @@ async def async_start_listener(hass: HomeAssistant, config_entry: ConfigEntry) -
             list(entities),
             functools.partial(handle_state_change, hass, config_entry),
         )
-    )
-
-
-@callback
-def async_register_keymaster_listener(
-    hass: HomeAssistant, config_entry: ConfigEntry
-) -> None:
-    """Register keymaster event bus listener for unlock detection (T024/T026).
-
-    Listens for ``keymaster_lock_state_changed`` events and forwards
-    matching unlock events to the check-in tracking sensor.
-
-    The listener validates:
-    - ``lockname`` is in ``coordinator.monitored_locknames`` (parent + children)
-    - ``state`` is ``"unlocked"``
-    - ``code_slot_num != 0`` (FR-017)
-    - ``code_slot_num`` is in ``[start_slot, start_slot + max_events)``
-
-    Args:
-        hass: Home Assistant instance.
-        config_entry: The integration config entry.
-    """
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
-    start_slot = coordinator.start_slot
-    max_events = coordinator.max_events
-
-    @callback
-    def _handle_keymaster_event(event: Event) -> None:
-        """Handle a keymaster_lock_state_changed event.
-
-        Args:
-            event: The HA event bus event.
-        """
-        event_data = event.data
-
-        # Validate lockname matches parent or any child lock.
-        # Keymaster sends the raw (friendly) lockname in event data,
-        # but monitored_locknames contains slugified names, so we
-        # must slugify before comparison.
-        raw_lockname = event_data.get("lockname", "")
-        event_lockname = (
-            slugify(raw_lockname)
-            if raw_lockname and isinstance(raw_lockname, str)
-            else ""
-        )
-
-        # Drop unmonitored-lock events as early as possible: in
-        # deployments with many RC integrations, every integration
-        # sees every event on the HA bus, and the unmonitored case
-        # is by far the hottest path. Recording these events with
-        # disposition "rejected_not_monitored" would flood the
-        # 10-entry diagnostics ring buffer with noise from other
-        # integrations' locks. The "rejected_not_monitored"
-        # disposition string is retained as a reserved value for
-        # schema stability with downstream consumers but is no
-        # longer emitted.
-        if event_lockname not in coordinator.monitored_locknames:
-            return
-
-        code_slot_num = event_data.get("code_slot_num")
-
-        diagnostics_enabled = config_entry.data.get(
-            CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS,
-            DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS,
-        )
-
-        def _record(disposition: str) -> None:
-            """Append a diagnostic entry and refresh the sensor state.
-
-            Only invoked when the diagnostics option is enabled. Also
-            triggers ``async_write_ha_state`` on the check-in sensor (when
-            available) so the new entry becomes visible in HA without
-            waiting for the next coordinator update.
-            """
-            coordinator.keymaster_event_diagnostics.append(
-                {
-                    "timestamp": dt_util.utcnow().isoformat(),
-                    "lockname": str(raw_lockname),
-                    "lockname_slug": event_lockname,
-                    "state": event_data.get("state"),
-                    "code_slot_num": code_slot_num,
-                    "disposition": disposition,
-                }
-            )
-            sensor = (
-                hass.data.get(DOMAIN, {})
-                .get(config_entry.entry_id, {})
-                .get(CHECKIN_SENSOR)
-            )
-            if sensor is not None and sensor.hass is not None:
-                sensor.async_write_ha_state()
-
-        if event_data.get("state") != "unlocked":
-            if diagnostics_enabled:
-                _record("rejected_state")
-            return
-
-        # FR-017: Ignore code_slot_num == 0
-        if code_slot_num is None or code_slot_num == 0:
-            if diagnostics_enabled:
-                _record("rejected_slot_zero")
-            return
-
-        if not (start_slot <= code_slot_num < start_slot + max_events):
-            if diagnostics_enabled:
-                _record("rejected_out_of_range")
-            return
-
-        # Retrieve the checkin sensor and forward the unlock
-        entry_data = get_entry_data(hass, config_entry.entry_id)
-        if entry_data is None:
-            _LOGGER.debug(
-                "Keymaster unlock event received but entry data "
-                "not available for entry %s",
-                config_entry.entry_id,
-            )
-            return
-
-        checkin_sensor = entry_data.get(CHECKIN_SENSOR)
-        if checkin_sensor is None:
-            _LOGGER.debug(
-                "Keymaster unlock event received but checkin sensor "
-                "not yet available for entry %s",
-                config_entry.entry_id,
-            )
-            if diagnostics_enabled:
-                _record("rejected_no_checkin_sensor")
-            return
-
-        monitoring_switch = entry_data.get(KEYMASTER_MONITORING_SWITCH)
-        if monitoring_switch is None:
-            _LOGGER.debug(
-                "Keymaster unlock event received but monitoring "
-                "switch not yet available for entry %s",
-                config_entry.entry_id,
-            )
-            if diagnostics_enabled:
-                _record("rejected_monitoring_off")
-            return
-
-        if not monitoring_switch.is_on:
-            _LOGGER.debug(
-                "Ignoring keymaster unlock: monitoring switch is off",
-            )
-            if diagnostics_enabled:
-                _record("rejected_monitoring_off")
-            return
-
-        _LOGGER.debug(
-            "Forwarding keymaster unlock (slot=%d, lock=%s) to checkin sensor",
-            code_slot_num,
-            raw_lockname,
-        )
-        if diagnostics_enabled:
-            _record("accepted")
-        checkin_sensor.async_handle_keymaster_unlock(
-            code_slot_num=code_slot_num,
-            lock_name=raw_lockname,
-        )
-
-    unsub = hass.bus.async_listen(
-        "keymaster_lock_state_changed", _handle_keymaster_event
-    )
-    hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(unsub)
-    _LOGGER.debug(
-        "Registered keymaster event bus listener for monitored locknames=%s",
-        sorted(coordinator.monitored_locknames),
     )

--- a/custom_components/rental_control/listeners.py
+++ b/custom_components/rental_control/listeners.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+
+"""Keymaster listener registration for Rental Control."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import Event
+from homeassistant.core import HomeAssistant
+from homeassistant.core import callback
+from homeassistant.util import dt as dt_util
+from homeassistant.util import slugify
+
+from .const import CHECKIN_SENSOR
+from .const import CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
+from .const import COORDINATOR
+from .const import DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
+from .const import DOMAIN
+from .const import KEYMASTER_MONITORING_SWITCH
+from .const import UNSUB_LISTENERS
+from .util import get_entry_data
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _KeymasterEventContext:
+    """Context for handling one monitored Keymaster event."""
+
+    hass: HomeAssistant
+    config_entry: ConfigEntry
+    coordinator: Any
+    raw_lockname: Any
+    event_lockname: str
+    event_data: dict[str, Any]
+    code_slot_num: Any
+    diagnostics_enabled: bool
+
+
+@callback
+def async_register_keymaster_listener(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Register keymaster event bus listener for unlock detection (T024/T026).
+
+    Listens for ``keymaster_lock_state_changed`` events and forwards
+    matching unlock events to the check-in tracking sensor.
+
+    The listener validates:
+    - ``lockname`` is in ``coordinator.monitored_locknames`` (parent + children)
+    - ``state`` is ``"unlocked"``
+    - ``code_slot_num != 0`` (FR-017)
+    - ``code_slot_num`` is in ``[start_slot, start_slot + max_events)``
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: The integration config entry.
+    """
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
+    start_slot = coordinator.start_slot
+    max_events = coordinator.max_events
+
+    @callback
+    def _handle_event(event: Event) -> None:
+        """Handle a keymaster lock-state event."""
+        _handle_keymaster_event(
+            hass=hass,
+            config_entry=config_entry,
+            event=event,
+            coordinator=coordinator,
+            start_slot=start_slot,
+            max_events=max_events,
+        )
+
+    unsub = hass.bus.async_listen("keymaster_lock_state_changed", _handle_event)
+    hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(unsub)
+    _LOGGER.debug(
+        "Registered keymaster event bus listener for monitored locknames=%s",
+        sorted(coordinator.monitored_locknames),
+    )
+
+
+def _handle_keymaster_event(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    event: Event,
+    coordinator: Any,
+    start_slot: int,
+    max_events: int,
+) -> None:
+    """Handle a keymaster_lock_state_changed event."""
+    event_data = event.data
+
+    raw_lockname, event_lockname = _normalized_event_lockname(event_data)
+
+    # Drop unmonitored-lock events as early as possible: in
+    # deployments with many RC integrations, every integration
+    # sees every event on the HA bus, and the unmonitored case
+    # is by far the hottest path. Recording these events with
+    # disposition "rejected_not_monitored" would flood the
+    # 10-entry diagnostics ring buffer with noise from other
+    # integrations' locks. The "rejected_not_monitored"
+    # disposition string is retained as a reserved value for
+    # schema stability with downstream consumers but is no
+    # longer emitted.
+    if event_lockname not in coordinator.monitored_locknames:
+        return
+
+    code_slot_num = event_data.get("code_slot_num")
+    diagnostics_enabled = config_entry.data.get(
+        CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS,
+        DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS,
+    )
+    context = _KeymasterEventContext(
+        hass=hass,
+        config_entry=config_entry,
+        coordinator=coordinator,
+        raw_lockname=raw_lockname,
+        event_lockname=event_lockname,
+        event_data=event_data,
+        code_slot_num=code_slot_num,
+        diagnostics_enabled=diagnostics_enabled,
+    )
+
+    if _event_should_be_rejected(
+        context,
+        start_slot,
+        max_events,
+    ):
+        return
+
+    _forward_keymaster_unlock(context)
+
+
+def _normalized_event_lockname(event_data: dict[str, Any]) -> tuple[Any, str]:
+    """Return the raw and slugified Keymaster lock name."""
+    raw_lockname = event_data.get("lockname", "")
+    event_lockname = (
+        slugify(raw_lockname) if raw_lockname and isinstance(raw_lockname, str) else ""
+    )
+    return raw_lockname, event_lockname
+
+
+def _event_should_be_rejected(
+    context: _KeymasterEventContext,
+    start_slot: int,
+    max_events: int,
+) -> bool:
+    """Return whether a monitored Keymaster event should be rejected."""
+    disposition: str | None = None
+    if context.event_data.get("state") != "unlocked":
+        disposition = "rejected_state"
+    # FR-017: Ignore code_slot_num == 0
+    elif context.code_slot_num is None or context.code_slot_num == 0:
+        disposition = "rejected_slot_zero"
+    elif not (start_slot <= context.code_slot_num < start_slot + max_events):
+        disposition = "rejected_out_of_range"
+
+    if disposition is None:
+        return False
+
+    _record_if_enabled(context, disposition)
+    return True
+
+
+def _record_if_enabled(
+    context: _KeymasterEventContext,
+    disposition: str,
+) -> None:
+    """Record a Keymaster event disposition when diagnostics are enabled."""
+    if context.diagnostics_enabled:
+        _record_keymaster_event_disposition(context, disposition)
+
+
+def _record_keymaster_event_disposition(
+    context: _KeymasterEventContext,
+    disposition: str,
+) -> None:
+    """Append a diagnostic entry and refresh the sensor state."""
+    context.coordinator.keymaster_event_diagnostics.append(
+        {
+            "timestamp": dt_util.utcnow().isoformat(),
+            "lockname": str(context.raw_lockname),
+            "lockname_slug": context.event_lockname,
+            "state": context.event_data.get("state"),
+            "code_slot_num": context.code_slot_num,
+            "disposition": disposition,
+        }
+    )
+    _refresh_checkin_sensor_state(context.hass, context.config_entry)
+
+
+def _refresh_checkin_sensor_state(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> None:
+    """Refresh the check-in sensor after diagnostics change."""
+    domain_data = hass.data.get(DOMAIN, {})
+    entry_data = domain_data.get(config_entry.entry_id, {})
+    sensor = entry_data.get(CHECKIN_SENSOR)
+    if sensor is not None and sensor.hass is not None:
+        sensor.async_write_ha_state()
+
+
+def _forward_keymaster_unlock(context: _KeymasterEventContext) -> bool:
+    """Forward an accepted Keymaster unlock to the check-in sensor."""
+    entry_data = _entry_data_for_unlock(context)
+    if entry_data is None:
+        return False
+
+    checkin_sensor = _checkin_sensor_for_unlock(
+        entry_data,
+        context,
+    )
+    if checkin_sensor is None:
+        return False
+
+    if not _monitoring_switch_allows_unlock(
+        entry_data,
+        context,
+    ):
+        return False
+
+    _LOGGER.debug(
+        "Forwarding keymaster unlock (slot=%d, lock=%s) to checkin sensor",
+        context.code_slot_num,
+        context.raw_lockname,
+    )
+    _record_if_enabled(context, "accepted")
+    checkin_sensor.async_handle_keymaster_unlock(
+        code_slot_num=context.code_slot_num,
+        lock_name=context.raw_lockname,
+    )
+    return True
+
+
+def _entry_data_for_unlock(context: _KeymasterEventContext) -> dict[str, Any] | None:
+    """Return entry data for forwarding a Keymaster unlock."""
+    entry_data = get_entry_data(context.hass, context.config_entry.entry_id)
+    if entry_data is None:
+        _LOGGER.debug(
+            "Keymaster unlock event received but entry data not available for entry %s",
+            context.config_entry.entry_id,
+        )
+    return entry_data
+
+
+def _checkin_sensor_for_unlock(
+    entry_data: dict[str, Any],
+    context: _KeymasterEventContext,
+) -> Any | None:
+    """Return the check-in sensor for forwarding a Keymaster unlock."""
+    checkin_sensor = entry_data.get(CHECKIN_SENSOR)
+    if checkin_sensor is not None:
+        return checkin_sensor
+
+    _LOGGER.debug(
+        "Keymaster unlock event received but checkin sensor "
+        "not yet available for entry %s",
+        context.config_entry.entry_id,
+    )
+    _record_if_enabled(context, "rejected_no_checkin_sensor")
+    return None
+
+
+def _monitoring_switch_allows_unlock(
+    entry_data: dict[str, Any],
+    context: _KeymasterEventContext,
+) -> bool:
+    """Return whether the monitoring switch allows unlock forwarding."""
+    monitoring_switch = entry_data.get(KEYMASTER_MONITORING_SWITCH)
+    if monitoring_switch is None:
+        _LOGGER.debug(
+            "Keymaster unlock event received but monitoring "
+            "switch not yet available for entry %s",
+            context.config_entry.entry_id,
+        )
+    elif monitoring_switch.is_on:
+        return True
+    else:
+        _LOGGER.debug(
+            "Ignoring keymaster unlock: monitoring switch is off",
+        )
+
+    _record_if_enabled(context, "rejected_monitoring_off")
+    return False

--- a/custom_components/rental_control/migrations.py
+++ b/custom_components/rental_control/migrations.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+
+"""Configuration entry migrations for Rental Control."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_CODE_BUFFER_AFTER
+from .const import CONF_CODE_BUFFER_BEFORE
+from .const import CONF_CODE_LENGTH
+from .const import CONF_GENERATE
+from .const import CONF_HONOR_EVENT_TIMES
+from .const import CONF_MAX_NAME_LENGTH
+from .const import CONF_PATH
+from .const import CONF_SHOULD_UPDATE_CODE
+from .const import CONF_TRIM_NAMES
+from .const import DEFAULT_CODE_BUFFER_AFTER
+from .const import DEFAULT_CODE_BUFFER_BEFORE
+from .const import DEFAULT_CODE_LENGTH
+from .const import DEFAULT_GENERATE
+from .const import DEFAULT_MAX_NAME_LENGTH
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate configuration."""
+    version = config_entry.version
+
+    # Versions 1 and 2 are no longer supported (oldest supported: v0.9.0 = version 3)
+    if version < 3:
+        _LOGGER.error(
+            "Config entry version %s is too old to migrate; "
+            "please remove and re-add the integration",
+            version,
+        )
+        return False
+
+    if version == 3:
+        version = _migrate_v3_to_v4(hass, config_entry, version)
+
+    if version == 4:
+        version = _migrate_v4_to_v5(hass, config_entry, version)
+
+    if version == 5:
+        version = _migrate_v5_to_v6(hass, config_entry, version)
+
+    if version == 6:
+        version = _migrate_v6_to_v7(hass, config_entry, version)
+
+    if version == 7:
+        version = _migrate_v7_to_v8(hass, config_entry, version)
+
+    if version == 8:
+        version = _migrate_v8_to_v9(hass, config_entry, version)
+
+    if version == 9:
+        version = _migrate_v9_to_v10(hass, config_entry, version)
+
+    return True
+
+
+def _migrate_v3_to_v4(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    version: int,
+) -> int:
+    """Migrate version 3 entries to version 4."""
+    _LOGGER.debug("Migrating from version %s", version)
+    if CONF_CODE_LENGTH not in config_entry.data:
+        data = config_entry.data.copy()
+        data[CONF_CODE_LENGTH] = DEFAULT_CODE_LENGTH
+        hass.config_entries.async_update_entry(
+            entry=config_entry,
+            unique_id=config_entry.unique_id,
+            data=data,
+            version=4,
+        )
+
+    version = 4
+    _LOGGER.debug("Migration to version %s complete", config_entry.version)
+    return version
+
+
+def _migrate_v4_to_v5(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    version: int,
+) -> int:
+    """Migrate version 4 entries to version 5."""
+    _LOGGER.debug("Migrating from version %s", version)
+
+    data = config_entry.data.copy()
+    data[CONF_GENERATE] = DEFAULT_GENERATE
+    hass.config_entries.async_update_entry(
+        entry=config_entry,
+        unique_id=config_entry.unique_id,
+        data=data,
+        version=5,
+    )
+
+    version = 5
+    _LOGGER.debug("Migration to version %s complete", config_entry.version)
+    return version
+
+
+def _migrate_v5_to_v6(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    version: int,
+) -> int:
+    """Migrate version 5 entries to version 6."""
+    _LOGGER.debug("Migrating from version %s", version)
+
+    data = config_entry.data.copy()
+    data.pop(CONF_PATH, None)
+    hass.config_entries.async_update_entry(
+        entry=config_entry,
+        unique_id=config_entry.unique_id,
+        data=data,
+        version=6,
+    )
+
+    version = 6
+    _LOGGER.debug("Migration to version %s complete", config_entry.version)
+    return version
+
+
+def _migrate_v6_to_v7(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    version: int,
+) -> int:
+    """Migrate version 6 entries to version 7."""
+    _LOGGER.debug("Migrating from version %s", version)
+
+    data = config_entry.data.copy()
+    # Default to False since prior versions didn't have this
+    # new setups will default to True
+    data[CONF_SHOULD_UPDATE_CODE] = False
+    hass.config_entries.async_update_entry(
+        entry=config_entry,
+        unique_id=config_entry.unique_id,
+        data=data,
+        version=7,
+    )
+
+    version = 7
+    _LOGGER.debug("Migration to version %s complete", config_entry.version)
+    return version
+
+
+def _migrate_v7_to_v8(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    version: int,
+) -> int:
+    """Migrate version 7 entries to version 8."""
+    _LOGGER.debug("Migrating from version %s", version)
+
+    data = config_entry.data.copy()
+    if CONF_HONOR_EVENT_TIMES not in data:
+        data[CONF_HONOR_EVENT_TIMES] = False
+    hass.config_entries.async_update_entry(
+        entry=config_entry,
+        unique_id=config_entry.unique_id,
+        data=data,
+        version=8,
+    )
+
+    version = 8
+    _LOGGER.debug("Migration to version %s complete", config_entry.version)
+    return version
+
+
+def _migrate_v8_to_v9(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    version: int,
+) -> int:
+    """Migrate version 8 entries to version 9."""
+    _LOGGER.debug("Migrating from version %s", version)
+
+    data = config_entry.data.copy()
+    data[CONF_TRIM_NAMES] = False
+    data[CONF_MAX_NAME_LENGTH] = DEFAULT_MAX_NAME_LENGTH
+    hass.config_entries.async_update_entry(
+        entry=config_entry,
+        unique_id=config_entry.unique_id,
+        data=data,
+        version=9,
+    )
+
+    version = 9
+    _LOGGER.debug("Migration to version %s complete", config_entry.version)
+    return version
+
+
+def _migrate_v9_to_v10(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    version: int,
+) -> int:
+    """Migrate version 9 entries to version 10."""
+    _LOGGER.debug("Migrating from version %s", version)
+
+    data = config_entry.data.copy()
+    data.setdefault(CONF_CODE_BUFFER_BEFORE, DEFAULT_CODE_BUFFER_BEFORE)
+    data.setdefault(CONF_CODE_BUFFER_AFTER, DEFAULT_CODE_BUFFER_AFTER)
+    hass.config_entries.async_update_entry(
+        entry=config_entry,
+        unique_id=config_entry.unique_id,
+        data=data,
+        version=10,
+    )
+
+    version = 10
+    _LOGGER.debug("Migration to version %s complete", config_entry.version)
+    return version

--- a/specs/011-decompose-init/tasks.md
+++ b/specs/011-decompose-init/tasks.md
@@ -34,10 +34,10 @@ atomic work streams, with behavior preserved by existing tests.
 
 **Purpose**: Establish the issue #572 baseline before changing tests or code
 
-- [ ] T001 Run `.specify/scripts/bash/check-prerequisites.sh --json` with `SPECIFY_FEATURE=011-decompose-init` from the repository root and confirm `specs/011-decompose-init/` plus `research.md` and `quickstart.md` are reported
-- [ ] T002 Inventory the live migration, listener, and package-level import symbols in `custom_components/rental_control/__init__.py`, `tests/unit/test_init.py`, `tests/unit/test_keymaster_event_diagnostics.py`, and `tests/unit/test_checkin_sensor.py`
-- [ ] T003 Run the full unchanged baseline test suite with `uv run pytest tests/` against `tests/`
-- [ ] T004 Confirm the planned refactor scope is limited to `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, `custom_components/rental_control/listeners.py`, and import-stability coverage in `tests/unit/test_init.py`
+- [X] T001 Run `.specify/scripts/bash/check-prerequisites.sh --json` with `SPECIFY_FEATURE=011-decompose-init` from the repository root and confirm `specs/011-decompose-init/` plus `research.md` and `quickstart.md` are reported
+- [X] T002 Inventory the live migration, listener, and package-level import symbols in `custom_components/rental_control/__init__.py`, `tests/unit/test_init.py`, `tests/unit/test_keymaster_event_diagnostics.py`, and `tests/unit/test_checkin_sensor.py`
+- [X] T003 Run the full unchanged baseline test suite with `uv run pytest tests/` against `tests/`
+- [X] T004 Confirm the planned refactor scope is limited to `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, `custom_components/rental_control/listeners.py`, and import-stability coverage in `tests/unit/test_init.py`
 
 ---
 
@@ -48,15 +48,15 @@ points, preserve package-level re-exports, and avoid circular imports.
 
 **⚠️ CRITICAL**: No user story validation can complete until this phase is done.
 
-- [ ] T005 [P] Add `custom_components/rental_control/migrations.py` with SPDX headers, a module docstring, type hints, local `_LOGGER = logging.getLogger(__name__)`, and direct imports from Home Assistant and `custom_components/rental_control/const.py`
-- [ ] T006 [P] Add `custom_components/rental_control/listeners.py` with SPDX headers, a module docstring, type hints, local `_LOGGER = logging.getLogger(__name__)`, and direct imports from Home Assistant, `custom_components/rental_control/const.py`, and `custom_components/rental_control/util.py`
-- [ ] T007 Move `async_migrate_entry` from `custom_components/rental_control/__init__.py` into `custom_components/rental_control/migrations.py` without changing supported-version range, defaults, removals, update-entry calls, logging, or return values
-- [ ] T008 Split the moved migration flow in `custom_components/rental_control/migrations.py` into private per-version helpers for v3→v4, v4→v5, v5→v6, v6→v7, v7→v8, v8→v9, and v9→v10 while keeping each function at or below 80 lines
-- [ ] T009 Re-export `async_migrate_entry` from `custom_components/rental_control/__init__.py` via `from .migrations import async_migrate_entry` and remove migration-only imports from `custom_components/rental_control/__init__.py`
-- [ ] T010 Move `async_register_keymaster_listener` from `custom_components/rental_control/__init__.py` into `custom_components/rental_control/listeners.py` without changing event-bus registration, unsubscribe tracking, monitored-lock checks, diagnostics, or forwarding behavior
-- [ ] T011 Split the moved listener flow in `custom_components/rental_control/listeners.py` into private helpers for `_handle_keymaster_event`, diagnostic recording, check-in sensor refresh, monitoring checks, and unlock forwarding while keeping each function at or below 80 lines
-- [ ] T012 Re-export `async_register_keymaster_listener` from `custom_components/rental_control/__init__.py` via `from .listeners import async_register_keymaster_listener` and remove listener-only imports from `custom_components/rental_control/__init__.py`
-- [ ] T013 Confirm `custom_components/rental_control/migrations.py` and `custom_components/rental_control/listeners.py` import no symbols from `custom_components/rental_control/__init__.py` or `custom_components.rental_control`
+- [X] T005 [P] Add `custom_components/rental_control/migrations.py` with SPDX headers, a module docstring, type hints, local `_LOGGER = logging.getLogger(__name__)`, and direct imports from Home Assistant and `custom_components/rental_control/const.py`
+- [X] T006 [P] Add `custom_components/rental_control/listeners.py` with SPDX headers, a module docstring, type hints, local `_LOGGER = logging.getLogger(__name__)`, and direct imports from Home Assistant, `custom_components/rental_control/const.py`, and `custom_components/rental_control/util.py`
+- [X] T007 Move `async_migrate_entry` from `custom_components/rental_control/__init__.py` into `custom_components/rental_control/migrations.py` without changing supported-version range, defaults, removals, update-entry calls, logging, or return values
+- [X] T008 Split the moved migration flow in `custom_components/rental_control/migrations.py` into private per-version helpers for v3→v4, v4→v5, v5→v6, v6→v7, v7→v8, v8→v9, and v9→v10 while keeping each function at or below 80 lines
+- [X] T009 Re-export `async_migrate_entry` from `custom_components/rental_control/__init__.py` via `from .migrations import async_migrate_entry` and remove migration-only imports from `custom_components/rental_control/__init__.py`
+- [X] T010 Move `async_register_keymaster_listener` from `custom_components/rental_control/__init__.py` into `custom_components/rental_control/listeners.py` without changing event-bus registration, unsubscribe tracking, monitored-lock checks, diagnostics, or forwarding behavior
+- [X] T011 Split the moved listener flow in `custom_components/rental_control/listeners.py` into private helpers for `_handle_keymaster_event`, diagnostic recording, check-in sensor refresh, monitoring checks, and unlock forwarding while keeping each function at or below 80 lines
+- [X] T012 Re-export `async_register_keymaster_listener` from `custom_components/rental_control/__init__.py` via `from .listeners import async_register_keymaster_listener` and remove listener-only imports from `custom_components/rental_control/__init__.py`
+- [X] T013 Confirm `custom_components/rental_control/migrations.py` and `custom_components/rental_control/listeners.py` import no symbols from `custom_components/rental_control/__init__.py` or `custom_components.rental_control`
 
 **Checkpoint**: New modules own the detailed migration and keymaster listener
 logic. `__init__.py` still owns setup, unload, update-listener, and
@@ -77,15 +77,15 @@ entry points remain importable from `custom_components.rental_control`.
 > **NOTE: Keep existing behavior assertions unchanged. Add only import-stability
 > coverage if the current tests do not already assert the moved public names.**
 
-- [ ] T014 [US1] Add or confirm package-level import-stability assertions for `async_migrate_entry` and `async_register_keymaster_listener` in `tests/unit/test_init.py`
-- [ ] T015 [P] [US1] Run existing integration setup, unload, update-listener, and migration tests in `tests/unit/test_init.py`
-- [ ] T016 [P] [US1] Run existing keymaster diagnostics behavior tests in `tests/unit/test_keymaster_event_diagnostics.py`
-- [ ] T017 [P] [US1] Run existing keymaster forwarding and rejection behavior tests in `tests/unit/test_checkin_sensor.py`
+- [X] T014 [US1] Add or confirm package-level import-stability assertions for `async_migrate_entry` and `async_register_keymaster_listener` in `tests/unit/test_init.py`
+- [X] T015 [P] [US1] Run existing integration setup, unload, update-listener, and migration tests in `tests/unit/test_init.py`
+- [X] T016 [P] [US1] Run existing keymaster diagnostics behavior tests in `tests/unit/test_keymaster_event_diagnostics.py`
+- [X] T017 [P] [US1] Run existing keymaster forwarding and rejection behavior tests in `tests/unit/test_checkin_sensor.py`
 
 ### Implementation for User Story 1
 
-- [ ] T018 [US1] Preserve `async_setup_entry`, `async_unload_entry`, `update_listener`, and `async_start_listener` behavior in `custom_components/rental_control/__init__.py` while using the package-level `async_register_keymaster_listener` re-export
-- [ ] T019 [US1] Preserve Home Assistant and test-suite public imports for `async_migrate_entry` and `async_register_keymaster_listener` from `custom_components/rental_control/__init__.py`
+- [X] T018 [US1] Preserve `async_setup_entry`, `async_unload_entry`, `update_listener`, and `async_start_listener` behavior in `custom_components/rental_control/__init__.py` while using the package-level `async_register_keymaster_listener` re-export
+- [X] T019 [US1] Preserve Home Assistant and test-suite public imports for `async_migrate_entry` and `async_register_keymaster_listener` from `custom_components/rental_control/__init__.py`
 
 **Checkpoint**: The MVP behavior surface is unchanged and package-level imports
 continue to work for Home Assistant, project modules, and tests.
@@ -102,14 +102,14 @@ old-version path with unchanged expectations.
 
 ### Tests for User Story 2
 
-- [ ] T020 [US2] Confirm existing unsupported-version migration coverage remains unchanged in `tests/unit/test_init.py`
-- [ ] T021 [US2] Confirm existing v3→v10, v6→v10, v7→v10, v8→v10, and v9→v10 migration assertions remain unchanged in `tests/unit/test_init.py`
+- [X] T020 [US2] Confirm existing unsupported-version migration coverage remains unchanged in `tests/unit/test_init.py`
+- [X] T021 [US2] Confirm existing v3→v10, v6→v10, v7→v10, v8→v10, and v9→v10 migration assertions remain unchanged in `tests/unit/test_init.py`
 
 ### Implementation for User Story 2
 
-- [ ] T022 [US2] Preserve the unsupported version `< 3` safe-failure path and error logging in `custom_components/rental_control/migrations.py`
-- [ ] T023 [US2] Preserve per-version data mutations, defaults, removals, `unique_id`, `version`, and final success behavior in `custom_components/rental_control/migrations.py`
-- [ ] T024 [US2] Run targeted migration validation with `uv run pytest tests/unit/test_init.py -k migrate` against `tests/unit/test_init.py`
+- [X] T022 [US2] Preserve the unsupported version `< 3` safe-failure path and error logging in `custom_components/rental_control/migrations.py`
+- [X] T023 [US2] Preserve per-version data mutations, defaults, removals, `unique_id`, `version`, and final success behavior in `custom_components/rental_control/migrations.py`
+- [X] T024 [US2] Run targeted migration validation with `uv run pytest tests/unit/test_init.py -k migrate` against `tests/unit/test_init.py`
 
 **Checkpoint**: Migration behavior is reviewable in one module and remains
 behaviorally identical across every existing migration test.
@@ -127,15 +127,15 @@ check-in forwarding.
 
 ### Tests for User Story 3
 
-- [ ] T025 [P] [US3] Confirm existing diagnostics acceptance and rejection assertions remain unchanged in `tests/unit/test_keymaster_event_diagnostics.py`
-- [ ] T026 [P] [US3] Confirm existing keymaster forwarding, monitoring switch, entry-data, and slot-range assertions remain unchanged in `tests/unit/test_checkin_sensor.py`
+- [X] T025 [P] [US3] Confirm existing diagnostics acceptance and rejection assertions remain unchanged in `tests/unit/test_keymaster_event_diagnostics.py`
+- [X] T026 [P] [US3] Confirm existing keymaster forwarding, monitoring switch, entry-data, and slot-range assertions remain unchanged in `tests/unit/test_checkin_sensor.py`
 
 ### Implementation for User Story 3
 
-- [ ] T027 [US3] Preserve keymaster event hot-path ordering in `custom_components/rental_control/listeners.py`: slugify lock name, return early for unmonitored locks, then evaluate state, slot, range, entry data, check-in sensor, monitoring switch, diagnostics, and forwarding
-- [ ] T028 [US3] Preserve diagnostic ring-buffer entries, timestamps, dispositions, and check-in sensor state refresh behavior in `custom_components/rental_control/listeners.py`
-- [ ] T029 [US3] Preserve listener lifecycle behavior by appending the keymaster bus unsubscribe callback to `UNSUB_LISTENERS` in `custom_components/rental_control/listeners.py`
-- [ ] T030 [US3] Run targeted listener validation with `uv run pytest tests/unit/test_keymaster_event_diagnostics.py tests/unit/test_checkin_sensor.py -k keymaster` against `tests/unit/test_keymaster_event_diagnostics.py` and `tests/unit/test_checkin_sensor.py`
+- [X] T027 [US3] Preserve keymaster event hot-path ordering in `custom_components/rental_control/listeners.py`: slugify lock name, return early for unmonitored locks, then evaluate state, slot, range, entry data, check-in sensor, monitoring switch, diagnostics, and forwarding
+- [X] T028 [US3] Preserve diagnostic ring-buffer entries, timestamps, dispositions, and check-in sensor state refresh behavior in `custom_components/rental_control/listeners.py`
+- [X] T029 [US3] Preserve listener lifecycle behavior by appending the keymaster bus unsubscribe callback to `UNSUB_LISTENERS` in `custom_components/rental_control/listeners.py`
+- [X] T030 [US3] Run targeted listener validation with `uv run pytest tests/unit/test_keymaster_event_diagnostics.py tests/unit/test_checkin_sensor.py -k keymaster` against `tests/unit/test_keymaster_event_diagnostics.py` and `tests/unit/test_checkin_sensor.py`
 
 **Checkpoint**: Listener behavior is reviewable in one module and remains
 behaviorally identical across existing diagnostics and forwarding tests.
@@ -152,13 +152,13 @@ in-scope files only.
 
 ### Tests for User Story 4
 
-- [ ] T031 [US4] Confirm no existing behavior assertions were rewritten in `tests/unit/test_init.py`, `tests/unit/test_keymaster_event_diagnostics.py`, or `tests/unit/test_checkin_sensor.py` beyond import-stability coverage
+- [X] T031 [US4] Confirm no existing behavior assertions were rewritten in `tests/unit/test_init.py`, `tests/unit/test_keymaster_event_diagnostics.py`, or `tests/unit/test_checkin_sensor.py` beyond import-stability coverage
 
 ### Implementation for User Story 4
 
-- [ ] T032 [US4] Verify `async_start_listener` stays in `custom_components/rental_control/__init__.py` and is not moved into `custom_components/rental_control/listeners.py`
-- [ ] T033 [US4] Verify `custom_components/rental_control/__init__.py` contains setup, unload, update-listener, package-listener startup, and re-export orchestration only, with no detailed migration or keymaster event-handler bodies remaining
-- [ ] T034 [US4] Confirm the final implementation diff is limited to `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, `custom_components/rental_control/listeners.py`, and `tests/unit/test_init.py`
+- [X] T032 [US4] Verify `async_start_listener` stays in `custom_components/rental_control/__init__.py` and is not moved into `custom_components/rental_control/listeners.py`
+- [X] T033 [US4] Verify `custom_components/rental_control/__init__.py` contains setup, unload, update-listener, package-listener startup, and re-export orchestration only, with no detailed migration or keymaster event-handler bodies remaining
+- [X] T034 [US4] Confirm the final implementation diff is limited to `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, `custom_components/rental_control/listeners.py`, and `tests/unit/test_init.py`
 
 **Checkpoint**: Scope remains bounded to issue #572 and unrelated functionality or
 complexity warnings are not changed.
@@ -169,14 +169,14 @@ complexity warnings are not changed.
 
 **Purpose**: Final validation across all user stories and quality gates
 
-- [ ] T035 Run the full unchanged acceptance suite with `uv run pytest tests/` against `tests/`
-- [ ] T036 Run ruff validation for `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, `custom_components/rental_control/listeners.py`, `tests/unit/test_init.py`, `tests/unit/test_keymaster_event_diagnostics.py`, and `tests/unit/test_checkin_sensor.py`
-- [ ] T037 Run mypy validation through the existing pre-commit hook for `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, `custom_components/rental_control/listeners.py`, and `tests/unit/test_init.py`
-- [ ] T038 Run interrogate validation through the existing pre-commit hook for `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, and `custom_components/rental_control/listeners.py`
-- [ ] T039 Verify `custom_components/rental_control/__init__.py` has fewer than 400 lines and every function in `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, and `custom_components/rental_control/listeners.py` is at or below 80 lines using the AST check from `specs/011-decompose-init/quickstart.md`
-- [ ] T040 Run the staged aislop scan and confirm `custom_components/rental_control/__init__.py` no longer reports `complexity/file-too-large` and no in-scope function in `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, or `custom_components/rental_control/listeners.py` reports `complexity/function-too-long`
-- [ ] T041 Run the public import script from `specs/011-decompose-init/quickstart.md` and confirm `async_migrate_entry` and `async_register_keymaster_listener` are callable from `custom_components/rental_control/__init__.py`
-- [ ] T042 Run full pre-commit validation for `custom_components/rental_control/`, `tests/unit/test_init.py`, and `specs/011-decompose-init/tasks.md`
+- [X] T035 Run the full unchanged acceptance suite with `uv run pytest tests/` against `tests/`
+- [X] T036 Run ruff validation for `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, `custom_components/rental_control/listeners.py`, `tests/unit/test_init.py`, `tests/unit/test_keymaster_event_diagnostics.py`, and `tests/unit/test_checkin_sensor.py`
+- [X] T037 Run mypy validation through the existing pre-commit hook for `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, `custom_components/rental_control/listeners.py`, and `tests/unit/test_init.py`
+- [X] T038 Run interrogate validation through the existing pre-commit hook for `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, and `custom_components/rental_control/listeners.py`
+- [X] T039 Verify `custom_components/rental_control/__init__.py` has fewer than 400 lines and every function in `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, and `custom_components/rental_control/listeners.py` is at or below 80 lines using the AST check from `specs/011-decompose-init/quickstart.md`
+- [X] T040 Run the staged aislop scan and confirm `custom_components/rental_control/__init__.py` no longer reports `complexity/file-too-large` and no in-scope function in `custom_components/rental_control/__init__.py`, `custom_components/rental_control/migrations.py`, or `custom_components/rental_control/listeners.py` reports `complexity/function-too-long`
+- [X] T041 Run the public import script from `specs/011-decompose-init/quickstart.md` and confirm `async_migrate_entry` and `async_register_keymaster_listener` are callable from `custom_components/rental_control/__init__.py`
+- [X] T042 Run full pre-commit validation for `custom_components/rental_control/`, `tests/unit/test_init.py`, and `specs/011-decompose-init/tasks.md`
 
 ---
 


### PR DESCRIPTION
## Summary
- Move config entry migrations into custom_components/rental_control/migrations.py with per-version helpers.
- Move Keymaster event-bus listener handling into custom_components/rental_control/listeners.py with focused helpers.
- Re-export async_migrate_entry and async_register_keymaster_listener from the package while keeping async_start_listener in __init__.py.

## Validation
- Behavior preserved; existing assertions unchanged.
- uv run pytest tests/ -q: 869 passed.
- uv run pytest tests/unit/test_init.py tests/unit/test_keymaster_event_diagnostics.py tests/unit/test_checkin_sensor.py -q: 194 passed.
- uv run ruff check custom_components/ tests/: passed.
- Pre-commit targeted files: passed.
- __init__.py is 225 lines; all in-scope functions are <=80 lines.
- aislop no longer reports __init__.py file-too-large or in-scope function-too-long findings.

Final speckit IMPLEMENT stage for #572.

Closes #572