### PR TITLE
Fix(reconcile): Win manual edit on refresh race

### DIFF
--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -20,6 +20,7 @@ from datetime import date
 from datetime import datetime
 from datetime import time
 import logging
+from time import monotonic
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import NamedTuple
@@ -50,6 +51,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 SLOT_MISS_THRESHOLD = 2
+SUPPRESSED_STATE_CHANGE_TTL = 5.0
 
 
 def _to_utc(value: datetime) -> datetime:
@@ -71,6 +73,18 @@ def _to_utc(value: datetime) -> datetime:
         return result
     utc: datetime = dt.as_utc(value)
     return utc
+
+
+def _states_match(expected: str, actual: str) -> bool:
+    """Compare raw HA state strings, normalizing datetimes when possible."""
+    if expected == actual:
+        return True
+
+    expected_dt = dt.parse_datetime(expected)
+    actual_dt = dt.parse_datetime(actual)
+    if expected_dt is not None and actual_dt is not None:
+        return _to_utc(expected_dt) == _to_utc(actual_dt)
+    return False
 
 
 def _strip_prefix(slot_name: str, prefix: str) -> str:
@@ -163,6 +177,8 @@ class EventOverrides:
 
         # Per-slot error tracking for diagnostics (T096)
         self._last_slot_errors: dict[int, str] = {}
+        # Coordinator-originated state feedback awaiting callback suppression
+        self._suppressed_state_changes: dict[int, dict[str, tuple[str, float]]] = {}
         # Latest diagnostics snapshot for HA diagnostics collection (T096)
         self._diagnostics_snapshot: dict[str, Any] = {}
 
@@ -249,6 +265,40 @@ class EventOverrides:
     def reconciliation_active(self) -> bool:
         """True while async_apply_plan is executing."""
         return self._reconciliation_active
+
+    def suppress_state_changes(self, slot: int, changes: dict[str, Any]) -> None:
+        """Mark coordinator-originated state changes to ignore in callbacks."""
+        now = monotonic()
+        pending = self._suppressed_state_changes.setdefault(slot, {})
+        for entity_id, value in changes.items():
+            pending[entity_id] = (str(value), now)
+
+    def should_suppress_state_change(
+        self, slot: int, entity_id: str, state: str
+    ) -> bool:
+        """Return True when a callback is feedback from our own service call."""
+        pending = self._suppressed_state_changes.get(slot)
+        if not pending:
+            return False
+
+        now = monotonic()
+        for pending_entity_id, (_, created) in list(pending.items()):
+            if now - created > SUPPRESSED_STATE_CHANGE_TTL:
+                pending.pop(pending_entity_id, None)
+
+        expected = pending.get(entity_id)
+        if expected is None:
+            if not pending:
+                self._suppressed_state_changes.pop(slot, None)
+            return False
+
+        expected_state, _ = expected
+        if _states_match(expected_state, state):
+            pending.pop(entity_id, None)
+            if not pending:
+                self._suppressed_state_changes.pop(slot, None)
+            return True
+        return False
 
     @property
     def diagnostics_snapshot(self) -> dict[str, Any]:
@@ -978,6 +1028,21 @@ class EventOverrides:
                 "end_time": res.buffered_end,
             }
             self._slot_miss_counts.pop(slot, None)
+            self.suppress_state_changes(
+                slot,
+                {
+                    f"switch.{coordinator.lockname}_code_slot_"
+                    f"{slot}_use_date_range_limits": "on",
+                    f"text.{coordinator.lockname}_code_slot_{slot}_name": (
+                        res.display_slot_name
+                    ),
+                    f"text.{coordinator.lockname}_code_slot_{slot}_pin": res.slot_code,
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_start": res.buffered_start.isoformat(),
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_end": res.buffered_end.isoformat(),
+                },
+            )
 
         event = _SlotEvent(
             slot_name=res.slot_name,
@@ -1032,6 +1097,17 @@ class EventOverrides:
         res: Reservation,
     ) -> OperationResult:
         """Apply an UPDATE_TIMES action for one slot."""
+        async with self._lock:
+            self.suppress_state_changes(
+                slot,
+                {
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_start": res.buffered_start.isoformat(),
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_end": res.buffered_end.isoformat(),
+                },
+            )
+
         event = _SlotEvent(
             slot_name=res.slot_name,
             slot_code=res.slot_code,
@@ -1132,6 +1208,21 @@ class EventOverrides:
                 "end_time": res.buffered_end,
             }
             self._slot_miss_counts.pop(slot, None)
+            self.suppress_state_changes(
+                slot,
+                {
+                    f"switch.{coordinator.lockname}_code_slot_"
+                    f"{slot}_use_date_range_limits": "on",
+                    f"text.{coordinator.lockname}_code_slot_{slot}_name": (
+                        res.display_slot_name
+                    ),
+                    f"text.{coordinator.lockname}_code_slot_{slot}_pin": res.slot_code,
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_start": res.buffered_start.isoformat(),
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_end": res.buffered_end.isoformat(),
+                },
+            )
 
         event = _SlotEvent(
             slot_name=res.slot_name,

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -781,6 +781,11 @@ async def handle_state_change(
     await asyncio.sleep(0.1)
 
     entity_id = event.data["entity_id"]
+    event_new_state = event.data.get("new_state")
+    event_new_value = (
+        getattr(event_new_state, "state", None) if event_new_state is not None else None
+    )
+    event_has_new_value = event_new_value is not None
 
     _LOGGER.debug(
         "Handling state change for %s in %s with event: %s",
@@ -794,6 +799,9 @@ async def handle_state_change(
         _LOGGER.warning("Could not extract slot number from entity_id: %s", entity_id)
         return
     slot_num = int(slot_match.group(1))
+    existing_override: dict[str, Any] | None = None
+    if event_has_new_value and coordinator.event_overrides:
+        existing_override = coordinator.event_overrides.overrides.get(slot_num)
 
     if "_reset" in entity_id:
         _LOGGER.debug("Resetting overrides %s for %s.", slot_num, lockname)
@@ -802,12 +810,29 @@ async def handle_state_change(
         )
         return
 
+    if event_has_new_value and coordinator.event_overrides.should_suppress_state_change(
+        slot_num, entity_id, event_new_value
+    ):
+        _LOGGER.debug(
+            "Ignoring coordinator feedback for %s slot %s.",
+            lockname,
+            slot_num,
+        )
+        return
+
     slot_state = hass.states.get(f"switch.{lockname}_code_slot_{slot_num}_enabled")
     _LOGGER.debug("Slot %s state: %s", slot_num, slot_state)
     if slot_state is None:
         return
 
-    if slot_state.state != "on":
+    slot_enabled_entity_id = f"switch.{lockname}_code_slot_{slot_num}_enabled"
+    slot_enabled_state = (
+        event_new_value
+        if event_has_new_value and entity_id == slot_enabled_entity_id
+        else slot_state.state
+    )
+
+    if slot_enabled_state != "on":
         _LOGGER.debug(
             "Slot %s is not enabled, skipping update for %s.",
             slot_num,
@@ -815,47 +840,86 @@ async def handle_state_change(
         )
         return
 
-    slot_code = hass.states.get(f"text.{lockname}_code_slot_{slot_num}_pin")
-    slot_name = hass.states.get(f"text.{lockname}_code_slot_{slot_num}_name")
+    slot_code_entity_id = f"text.{lockname}_code_slot_{slot_num}_pin"
+    slot_name_entity_id = f"text.{lockname}_code_slot_{slot_num}_name"
+    slot_code = hass.states.get(slot_code_entity_id)
+    slot_name = hass.states.get(slot_name_entity_id)
 
-    use_date_range = hass.states.get(
+    use_date_range_entity_id = (
         f"switch.{lockname}_code_slot_{slot_num}_use_date_range_limits"
     )
+    use_date_range = hass.states.get(use_date_range_entity_id)
     _LOGGER.debug("Use Date Range: %s", use_date_range)
-    if use_date_range and use_date_range.state == "on":
-        g_start_time = hass.states.get(
+    use_date_range_state = (
+        event_new_value
+        if event_has_new_value and entity_id == use_date_range_entity_id
+        else use_date_range.state
+        if use_date_range
+        else None
+    )
+    if use_date_range_state == "on":
+        start_time_entity_id = (
             f"datetime.{lockname}_code_slot_{slot_num}_date_range_start"
         )
-        g_end_time = hass.states.get(
-            f"datetime.{lockname}_code_slot_{slot_num}_date_range_end"
-        )
+        end_time_entity_id = f"datetime.{lockname}_code_slot_{slot_num}_date_range_end"
+        g_start_time = hass.states.get(start_time_entity_id)
+        g_end_time = hass.states.get(end_time_entity_id)
     else:
+        start_time_entity_id = ""
+        end_time_entity_id = ""
         g_start_time = None
         g_end_time = None
 
     if slot_code is None:
         return
-    slot_code_value = (
-        "" if slot_code.state in ("unknown", "unavailable") else slot_code.state
-    )
+    if event_has_new_value and entity_id == slot_code_entity_id:
+        slot_code_value = (
+            "" if event_new_value in ("unknown", "unavailable") else event_new_value
+        )
+    elif event_has_new_value and existing_override is not None:
+        slot_code_value = str(existing_override["slot_code"])
+    else:
+        slot_code_value = (
+            "" if slot_code.state in ("unknown", "unavailable") else slot_code.state
+        )
     if slot_name is None:
         return
-    slot_name_value = (
-        "" if slot_name.state in ("unknown", "unavailable") else slot_name.state
-    )
+    if event_has_new_value and entity_id == slot_name_entity_id:
+        slot_name_value = (
+            "" if event_new_value in ("unknown", "unavailable") else event_new_value
+        )
+    elif event_has_new_value and existing_override is not None:
+        slot_name_value = str(existing_override["slot_name"])
+    else:
+        slot_name_value = (
+            "" if slot_name.state in ("unknown", "unavailable") else slot_name.state
+        )
 
     start_time = dt.start_of_local_day()
     end_time = dt.start_of_local_day()
+    if event_has_new_value and existing_override is not None:
+        start_time = existing_override["start_time"]
+        end_time = existing_override["end_time"]
 
     if g_start_time is not None:
-        p_start_time = dt.parse_datetime(g_start_time.state)
-        if p_start_time:
-            start_time = p_start_time
+        if event_has_new_value and entity_id == start_time_entity_id:
+            p_start_time = dt.parse_datetime(event_new_value)
+            if p_start_time:
+                start_time = p_start_time
+        elif not (event_has_new_value and existing_override is not None):
+            p_start_time = dt.parse_datetime(g_start_time.state)
+            if p_start_time:
+                start_time = p_start_time
 
     if g_end_time is not None:
-        p_end_time = dt.parse_datetime(g_end_time.state)
-        if p_end_time:
-            end_time = p_end_time
+        if event_has_new_value and entity_id == end_time_entity_id:
+            p_end_time = dt.parse_datetime(event_new_value)
+            if p_end_time:
+                end_time = p_end_time
+        elif not (event_has_new_value and existing_override is not None):
+            p_end_time = dt.parse_datetime(g_end_time.state)
+            if p_end_time:
+                end_time = p_end_time
 
     _LOGGER.debug(
         "updating overrides for %s slot %s. "

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -3010,3 +3010,273 @@ class TestManualOverrideSurvival:
             assert len(observed_plan_ids) == 2
             assert plan.slots[slot].action is ActionKind.NOOP
             assert all(action.slot != slot for action in plan.actions)
+
+    async def test_manual_time_override_wins_pre_feedback_refresh_race(
+        self,
+        hass: "HomeAssistant",
+    ) -> None:
+        """Manual datetime event values survive a pre-feedback refresh race."""
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.util import OperationResult
+        from custom_components.rental_control.util import handle_state_change
+
+        lockname = "front_door"
+        slot = 10
+
+        def _set_keymaster_slot(
+            name: str,
+            pin: str,
+            start: datetime,
+            end: datetime,
+            *,
+            enabled: bool,
+            use_date_range_limits: bool = True,
+        ) -> None:
+            """Populate the Keymaster entities observed by reconciliation."""
+            hass.states.async_set(
+                f"switch.{lockname}_code_slot_{slot}_enabled",
+                "on" if enabled else "off",
+            )
+            hass.states.async_set(
+                f"switch.{lockname}_code_slot_{slot}_use_date_range_limits",
+                "on" if use_date_range_limits else "off",
+            )
+            hass.states.async_set(
+                f"text.{lockname}_code_slot_{slot}_name",
+                name,
+            )
+            hass.states.async_set(
+                f"text.{lockname}_code_slot_{slot}_pin",
+                pin,
+            )
+            hass.states.async_set(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_start",
+                start.isoformat(),
+            )
+            hass.states.async_set(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_end",
+                end.isoformat(),
+            )
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Manual Race Rental",
+            version=10,
+            unique_id="manual-override-race-regression",
+            data={
+                "name": "Manual Race Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": slot,
+                "max_events": 1,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "code_generation": "date_based",
+                "should_update_code": True,
+                "keymaster_entry_id": lockname,
+                "refresh_frequency": 5,
+            },
+            entry_id="manual_override_race_regression",
+        )
+        entry.add_to_hass(hass)
+        MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": lockname},
+            entry_id="km_manual_override_race_regression",
+        ).add_to_hass(hass)
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator.async_request_refresh = AsyncMock()
+        assert coordinator.event_overrides is not None
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {COORDINATOR: coordinator}
+
+        _set_keymaster_slot(
+            "",
+            "",
+            FROZEN_START_OF_DAY,
+            FROZEN_START_OF_DAY,
+            enabled=False,
+        )
+
+        ics_body = future_ics(summary="Reserved - Manual Guest")
+        set_result = OperationResult(kind="set", slot=slot, confirmed=True)
+        update_result = OperationResult(kind="update_times", slot=slot, confirmed=True)
+        clear_result = OperationResult(kind="clear", slot=slot, confirmed=True)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=FROZEN_TIME),
+            patch.object(
+                dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(return_value=set_result),
+            ) as mock_set_code,
+            patch(
+                "custom_components.rental_control.event_overrides."
+                "async_fire_update_times",
+                new=AsyncMock(return_value=update_result),
+            ) as mock_update_times,
+            patch(
+                "custom_components.rental_control.event_overrides."
+                "async_fire_clear_code",
+                new=AsyncMock(return_value=clear_result),
+            ) as mock_clear_code,
+        ):
+            mock_session.get(entry.data["url"], status=200, body=ics_body, repeat=True)
+
+            coordinator.data = await coordinator._async_update_data()
+            await hass.async_block_till_done()
+
+            assert mock_set_code.call_count == 1
+            override = coordinator.event_overrides.overrides[slot]
+            assert override is not None
+            initial_pin = str(override["slot_code"])
+            initial_start = override["start_time"]
+            initial_end = override["end_time"]
+
+            _set_keymaster_slot(
+                "Manual Guest",
+                initial_pin,
+                initial_start,
+                initial_end,
+                enabled=True,
+            )
+
+            manual_pin = "8642"
+            manual_start = initial_start.replace(
+                hour=9,
+                minute=15,
+                second=0,
+                microsecond=0,
+            )
+            manual_end = initial_end.replace(
+                hour=20,
+                minute=45,
+                second=0,
+                microsecond=0,
+            )
+            assert manual_pin != initial_pin
+            assert manual_start != initial_start
+            assert manual_end != initial_end
+            _set_keymaster_slot(
+                "Manual Guest",
+                manual_pin,
+                manual_start,
+                manual_end,
+                enabled=True,
+            )
+            start_state = hass.states.get(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_start"
+            )
+            end_state = hass.states.get(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_end"
+            )
+            pin_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_pin")
+            assert start_state is not None
+            assert end_state is not None
+            assert pin_state is not None
+
+            mock_set_code.reset_mock()
+            mock_update_times.reset_mock()
+            mock_clear_code.reset_mock()
+
+            coordinator.data = await coordinator._async_update_data()
+            await hass.async_block_till_done()
+
+            plan = coordinator.latest_plan
+            assert plan is not None
+            assert plan.slots[slot].action is ActionKind.UPDATE_TIMES
+            assert mock_update_times.call_count == 1
+            racing_update = mock_update_times.call_args.args[1]
+            assert racing_update.extra_state_attributes["start"] == initial_start
+            assert racing_update.extra_state_attributes["end"] == initial_end
+
+            _set_keymaster_slot(
+                "Manual Guest",
+                manual_pin,
+                initial_start,
+                initial_end,
+                enabled=True,
+            )
+            feedback_start_state = hass.states.get(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_start"
+            )
+            feedback_end_state = hass.states.get(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_end"
+            )
+            assert feedback_start_state is not None
+            assert feedback_end_state is not None
+
+            for changed_state in (start_state, end_state, pin_state):
+                event = MagicMock()
+                event.data = {
+                    "entity_id": changed_state.entity_id,
+                    "new_state": changed_state,
+                }
+                with patch(
+                    "custom_components.rental_control.util.asyncio.sleep",
+                    new_callable=AsyncMock,
+                ):
+                    await handle_state_change(hass, entry, event)
+            for changed_state in (feedback_start_state, feedback_end_state):
+                event = MagicMock()
+                event.data = {
+                    "entity_id": changed_state.entity_id,
+                    "new_state": changed_state,
+                }
+                with patch(
+                    "custom_components.rental_control.util.asyncio.sleep",
+                    new_callable=AsyncMock,
+                ):
+                    await handle_state_change(hass, entry, event)
+            await hass.async_block_till_done()
+
+            override = coordinator.event_overrides.overrides[slot]
+            assert override is not None
+            assert override["slot_code"] == manual_pin
+            assert override["start_time"] == manual_start
+            assert override["end_time"] == manual_end
+
+            mock_set_code.reset_mock()
+            mock_update_times.reset_mock()
+            mock_clear_code.reset_mock()
+
+            coordinator.data = await coordinator._async_update_data()
+            await hass.async_block_till_done()
+
+            plan = coordinator.latest_plan
+            assert plan is not None
+            assert plan.slots[slot].action is ActionKind.UPDATE_TIMES
+            assert mock_update_times.call_count == 1
+            reapply_update = mock_update_times.call_args.args[1]
+            assert reapply_update.extra_state_attributes["start"] == manual_start
+            assert reapply_update.extra_state_attributes["end"] == manual_end
+            assert mock_set_code.call_count == 0
+            assert mock_clear_code.call_count == 0
+
+            _set_keymaster_slot(
+                "Manual Guest",
+                manual_pin,
+                manual_start,
+                manual_end,
+                enabled=True,
+            )
+            mock_update_times.reset_mock()
+
+            coordinator.data = await coordinator._async_update_data()
+            await hass.async_block_till_done()
+
+            plan = coordinator.latest_plan
+            assert plan is not None
+            assert plan.slots[slot].action is ActionKind.NOOP
+            assert all(action.slot != slot for action in plan.actions)
+            assert mock_update_times.call_count == 0


### PR DESCRIPTION
## Summary
- Fix a race where reconciliation could revert a manual Keymaster time edit before handle_state_change persisted the override.
- Capture state-change event values instead of trusting post-settle current state, preserving sibling override fields across state-change storms.
- Suppress coordinator-originated Keymaster feedback so stale reconciliation writes cannot overwrite the captured manual edit.

## Behavior
Manual time-of-day and PIN overrides still win when Honor event times is off. Honor event times behavior is unchanged when enabled.

Follow-up robustness fix related to #589.

## Validation
- uv run pytest tests/integration/test_refresh_cycle.py tests/unit/test_coordinator.py tests/unit/test_event_overrides.py tests/unit/test_util.py -q
- uv run pytest tests/ -q
- uv run pytest tests/ --cov=custom_components.rental_control --cov-report=term -q (94.57%)
- uv run ruff check custom_components/ tests/
- uv run pre-commit run --all-files