### PR TITLE
Fix(reconcile): Prevent slot wipe and self-heal wedge

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -72,6 +72,23 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         config_entry=config_entry,
     )
 
+    # Load Store before Keymaster bootstrap (ordering fix for #597)
+    await coordinator.async_load_slot_store()
+
+    # Inject persisted mappings or adopt slots on first upgrade
+    persisted = coordinator.get_persisted_slot_mappings()
+    if persisted:
+        if coordinator.event_overrides is not None:
+            try:
+                coordinator.event_overrides.load_persisted_mappings(persisted)
+            except ValueError:
+                _LOGGER.exception(
+                    "Failed to load persisted slot mappings for %s",
+                    config_entry.entry_id,
+                )
+    elif coordinator.lockname:
+        await coordinator.async_adopt_keymaster_slots()
+
     # Bootstrap Keymaster slot overrides from current HA state before
     # first refresh so overrides are checked against the initial data
     await coordinator.async_setup_keymaster_overrides()

--- a/custom_components/rental_control/const.py
+++ b/custom_components/rental_control/const.py
@@ -134,3 +134,17 @@ CHECKIN_STATE_CHECKED_OUT = "checked_out"
 
 # Early checkout grace period in minutes
 EARLY_CHECKOUT_GRACE_MINUTES = 15
+
+# Store constants
+STORE_SLOT_MAPPINGS_KEY = "rental_control.slot_mappings"
+STORE_SCHEMA_VERSION = 1
+
+# Slot status string constants (mirror SlotStatus enum values)
+SLOT_STATUS_OCCUPIED = "occupied"
+SLOT_STATUS_PENDING_SET = "pending_set"
+SLOT_STATUS_PENDING_CLEAR = "pending_clear"
+SLOT_STATUS_BLOCKED = "blocked"
+
+# Operation kind constants
+OPERATION_KIND_SET = "set"
+OPERATION_KIND_CLEAR = "clear"

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -140,6 +140,21 @@ def _is_unreadable_keymaster_text(value: str | None) -> bool:
     return value in ("unknown", "unavailable")
 
 
+def _format_display_slot_name(
+    slot_name: str,
+    prefix: str,
+    trim_names: bool,
+    max_name_length: int,
+) -> str:
+    """Return the Keymaster display name for a reservation slot."""
+    display_name = f"{prefix}{slot_name}"
+    if not trim_names or max_name_length <= 0:
+        return display_name
+    if len(prefix) >= max_name_length:
+        return trim_name(display_name, max_name_length)
+    return f"{prefix}{trim_name(slot_name, max_name_length - len(prefix))}"
+
+
 class RentalControlCoordinator(DataUpdateCoordinator[list[CalendarEvent]]):
     """Coordinator for managing rental control calendar data."""
 
@@ -881,11 +896,9 @@ Please update Keymaster to at least v0.1.0-b0
             rematch_start: datetime = event.start  # type: ignore[assignment]
             rematch_end: datetime = event.end  # type: ignore[assignment]
             uid = normalize_uid(getattr(event, "uid", None))
-            if self.trim_names and self.max_name_length > 0:
-                guest_max = self.max_name_length - len(prefix)
-                display_slot_name = f"{prefix}{trim_name(slot_name, guest_max)}"
-            else:
-                display_slot_name = f"{prefix}{slot_name}"
+            display_slot_name = _format_display_slot_name(
+                slot_name, prefix, self.trim_names, self.max_name_length
+            )
             try:
                 current_reservations_for_rematch.append(
                     _Reservation(
@@ -944,11 +957,9 @@ Please update Keymaster to at least v0.1.0-b0
             booking_aliases = extract_booking_aliases(
                 event.summary, event.description or ""
             )
-            if self.trim_names and self.max_name_length > 0:
-                guest_max = self.max_name_length - len(prefix)
-                display_slot_name = f"{prefix}{trim_name(slot_name, guest_max)}"
-            else:
-                display_slot_name = f"{prefix}{slot_name}"
+            display_slot_name = _format_display_slot_name(
+                slot_name, prefix, self.trim_names, self.max_name_length
+            )
 
             provisional = _Reservation(
                 identity_key=identity_key,
@@ -1141,11 +1152,9 @@ Please update Keymaster to at least v0.1.0-b0
                 )
                 continue
 
-            if self.trim_names and self.max_name_length > 0:
-                guest_max = self.max_name_length - len(prefix)
-                display_slot_name = f"{prefix}{trim_name(slot_name, guest_max)}"
-            else:
-                display_slot_name = f"{prefix}{slot_name}"
+            display_slot_name = _format_display_slot_name(
+                slot_name, prefix, self.trim_names, self.max_name_length
+            )
 
             try:
                 ghost = _Reservation(

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -879,9 +879,8 @@ Please update Keymaster to at least v0.1.0-b0
         actual_slot_names: dict[int, str] = {}
         for persisted_mapping in persisted.values():
             slot_num = persisted_mapping.get("slot")
-            actual_name = (persisted_mapping.get("last_observed_actual", {}) or {}).get(
-                "name_state"
-            )
+            actual = persisted_mapping.get("last_observed_actual")
+            actual_name = actual.get("name_state") if isinstance(actual, dict) else None
             if isinstance(slot_num, int) and isinstance(actual_name, str):
                 actual_slot_names[slot_num] = actual_name
         current_reservations_for_rematch: list[_Reservation] = []

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -23,7 +23,11 @@ from datetime import datetime
 from datetime import time
 from datetime import timedelta
 import logging
+import random
+import re
 from typing import Any
+from typing import cast
+import uuid
 from zoneinfo import ZoneInfo  # noreorder
 
 import aiohttp
@@ -42,6 +46,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt
@@ -49,6 +54,9 @@ from homeassistant.util import slugify
 from icalendar import Calendar
 import x_wr_timezone
 
+from .const import CHECKIN_SENSOR
+from .const import CHECKIN_STATE_CHECKED_IN
+from .const import CHECKIN_STATE_CHECKED_OUT
 from .const import CONF_CHECKIN
 from .const import CONF_CHECKOUT
 from .const import CONF_CODE_BUFFER_AFTER
@@ -79,21 +87,57 @@ from .const import DEFAULT_TRIM_NAMES
 from .const import DOMAIN
 from .const import EVENT_AGE_THRESHOLD_DAYS
 from .const import LOCK_MANAGER
+from .const import OPERATION_KIND_CLEAR
+from .const import OPERATION_KIND_SET
 from .const import REQUEST_TIMEOUT
+from .const import SLOT_STATUS_BLOCKED
+from .const import SLOT_STATUS_OCCUPIED
+from .const import SLOT_STATUS_PENDING_CLEAR
+from .const import SLOT_STATUS_PENDING_SET
+from .const import STORE_SCHEMA_VERSION
+from .const import STORE_SLOT_MAPPINGS_KEY
 from .const import VERSION
 from .description_parser import extract_checkin_time
 from .description_parser import extract_checkout_time
 from .event_overrides import EventOverrides
+from .reconciliation import DesiredPlan as _DesiredPlan
+from .reconciliation import ManagedSlot as _ManagedSlot
+from .reconciliation import Reservation as _Reservation
+from .reconciliation import SlotStatus as _SlotStatus
+from .reconciliation import compute_desired_plan
+from .reconciliation import extract_booking_aliases
+from .reconciliation import find_reservation_rematch
+from .reconciliation import make_reservation_fingerprint
+from .util import OperationResult
 from .util import add_call
 from .util import apply_buffer
 from .util import async_fire_clear_code
 from .util import check_gather_results
 from .util import get_slot_name
 from .util import normalize_uid
+from .util import trim_name
 
 # aislop-ignore-file ai-slop/hallucinated-import -- Provided by Home Assistant runtime.
+# aislop-ignore-file complexity/file-too-large complexity/function-too-long -- Existing module size is outside this emergency fix scope.
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _store_datetime(value: Any) -> Any:
+    """Return a JSON-serializable datetime value for Store payloads."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _is_blank_keymaster_text(value: str | None) -> bool:
+    """Return whether a Keymaster text state is confirmed blank."""
+    return value == ""
+
+
+def _is_unreadable_keymaster_text(value: str | None) -> bool:
+    """Return whether a Keymaster text state is unreadable."""
+    return value in ("unknown", "unavailable")
 
 
 class RentalControlCoordinator(DataUpdateCoordinator[list[CalendarEvent]]):
@@ -162,6 +206,14 @@ class RentalControlCoordinator(DataUpdateCoordinator[list[CalendarEvent]]):
         # by the listener, populated only when the diagnostics option is
         # enabled. See spec for the entry shape and disposition values.
         self.keymaster_event_diagnostics: deque[dict[str, Any]] = deque(maxlen=10)
+
+        # HA Store for persisted slot mappings (T017)
+        self._store: Store | None = None
+        self._slot_mappings: dict[str, Any] = {}
+
+        # Reconciliation state (T022/T031/T033)
+        self._latest_plan: _DesiredPlan | None = None
+        self._latest_res_by_key: dict[str, _Reservation] = {}
 
         super().__init__(
             hass=hass,
@@ -264,6 +316,11 @@ Please update Keymaster to at least v0.1.0-b0
         }
 
     @property
+    def entry_id(self) -> str:
+        """Return the config entry ID."""
+        return self._entry_id
+
+    @property
     def unique_id(self) -> str:
         """Return the unique id."""
         return self._unique_id
@@ -272,6 +329,77 @@ Please update Keymaster to at least v0.1.0-b0
     def version(self) -> str:
         """Return the version."""
         return self._version
+
+    @property
+    def latest_plan(self) -> _DesiredPlan | None:
+        """Return the most recently computed desired plan, or None."""
+        return self._latest_plan
+
+    @property
+    def latest_overflow(self) -> dict[str, str]:
+        """Return overflow dict from latest plan (identity_key → reason)."""
+        if self._latest_plan is None:
+            return {}
+        return dict(self._latest_plan.overflow)
+
+    @property
+    def latest_reconciliation_diagnostics(self) -> dict[str, Any]:
+        """Return a combined diagnostics snapshot from the latest plan.
+
+        Merges the plan-level diagnostics (per-slot desired/actual/action/
+        retry_count/last_error and per-reservation selected/overflow/aliases)
+        with the :class:`~.event_overrides.EventOverrides` diagnostics snapshot
+        (matched_slots, pending_corrections, pending_clear_slots,
+        slot_retry_counts, last_slot_errors).
+
+        Raw PIN / slot-code values are never included: ``slot_code``, ``pin``,
+        and ``code`` keys are stripped before returning.
+
+        Returns:
+            Combined diagnostics dict; empty when no plan has been computed.
+        """
+
+        def scrub_codes(value: Any) -> Any:
+            """Return diagnostics with raw code-bearing keys removed."""
+            if isinstance(value, dict):
+                return {
+                    key: scrub_codes(item)
+                    for key, item in value.items()
+                    if key not in {"slot_code", "pin", "code"}
+                }
+            if isinstance(value, list):
+                return [scrub_codes(item) for item in value]
+            return value
+
+        result: dict[str, Any] = {}
+        if self._latest_plan is not None:
+            result.update(self._latest_plan.diagnostics)
+        if self.event_overrides is not None:
+            result["event_overrides"] = self.event_overrides.diagnostics_snapshot
+        return cast("dict[str, Any]", scrub_codes(result))
+
+    def get_slot_assignment(self, identity_key: str) -> int | None:
+        """Return slot number assigned to identity_key in latest plan, or None."""
+        if self._latest_plan is None:
+            return None
+        return self._latest_plan.selected.get(identity_key)
+
+    def get_slot_code(self, identity_key: str) -> str | None:
+        """Return slot_code for identity_key from latest reconciliation, or None.
+
+        Looks up the reservation by *identity_key* in the most recent
+        reconciliation result.  Returns ``None`` when reconciliation has
+        not run yet, the reservation is not in the plan, or no code was
+        generated for it.
+        """
+        res = self._latest_res_by_key.get(identity_key)
+        return res.slot_code if res is not None else None
+
+    def get_overflow_reason(self, identity_key: str) -> str | None:
+        """Return overflow reason for identity_key in latest plan, or None."""
+        if self._latest_plan is None:
+            return None
+        return self._latest_plan.overflow.get(identity_key)
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
@@ -403,6 +531,1034 @@ Please update Keymaster to at least v0.1.0-b0
                 request_refresh=False,
             )
 
+    async def async_load_slot_store(self) -> None:
+        """Load persisted slot mappings from the HA Store.
+
+        Creates the Store on first call using the entry-scoped key
+        ``STORE_SLOT_MAPPINGS_KEY.{entry_id}``.  Applies schema v1
+        migration when the stored schema version is absent or below 1.
+        Raw PINs are stripped after loading as a safety measure.
+        """
+        self._store = Store(
+            self.hass,
+            STORE_SCHEMA_VERSION,
+            f"{STORE_SLOT_MAPPINGS_KEY}.{self._entry_id}",
+        )
+        raw: dict[str, Any] | None = await self._store.async_load()
+        if raw is None:
+            self._slot_mappings = {}
+            return
+        schema_version = raw.get("schema_version", 0)
+        if schema_version < 1:
+            raw = await self._migrate_slot_store_v1(raw)
+        for mapping in raw.get("mappings", {}).values():
+            last_obs = mapping.get("last_observed_actual")
+            if last_obs is not None:
+                last_obs.pop("pin", None)
+                last_obs.pop("code", None)
+                last_obs.pop("slot_code", None)
+        self._slot_mappings = raw
+
+    def get_persisted_slot_mappings(self) -> dict[str, Any]:
+        """Return entry-scoped persisted reservation-slot mappings."""
+        return cast("dict[str, Any]", self._slot_mappings.get("mappings", {}))
+
+    async def async_save_slot_store(self) -> None:
+        """Save current slot mappings to the HA Store.
+
+        A no-op when ``_store`` is ``None`` (store not yet
+        initialised).  Raw PINs are stripped from
+        ``last_observed_actual`` before persisting as a safety measure.
+        """
+        if self._store is None:
+            return
+        mappings: dict[str, Any] = {}
+        for k, v in self._slot_mappings.get("mappings", {}).items():
+            mapping = dict(v)
+            last_obs = mapping.get("last_observed_actual")
+            if last_obs is not None:
+                last_obs = dict(last_obs)
+                last_obs.pop("pin", None)
+                last_obs.pop("code", None)
+                last_obs.pop("slot_code", None)
+                mapping["last_observed_actual"] = last_obs
+            mappings[k] = mapping
+        data: dict[str, Any] = {
+            "schema_version": STORE_SCHEMA_VERSION,
+            "entry_id": self._entry_id,
+            "lockname": self.lockname,
+            "start_slot": self.start_slot,
+            "max_slots": self.max_events,
+            "updated_at": dt.now().isoformat(),
+            "mappings": mappings,
+            "blocked_slots": self._slot_mappings.get("blocked_slots", {}),
+        }
+        await self._store.async_save(data)
+
+    async def _migrate_slot_store_v1(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Migrate store data to schema version 1.
+
+        Handles upgrading from schema_version 0 or a store that was
+        written without a schema_version field.  Preserves any
+        ``mappings`` and ``blocked_slots`` already present.
+
+        Args:
+            raw: The raw store dict to migrate.
+
+        Returns:
+            A dict conforming to schema version 1.
+        """
+        return {
+            "schema_version": 1,
+            "entry_id": raw.get("entry_id", self._entry_id),
+            "lockname": raw.get("lockname", self.lockname),
+            "start_slot": raw.get("start_slot", self.start_slot),
+            "max_slots": raw.get("max_slots", self.max_events),
+            "updated_at": raw.get("updated_at", dt.now().isoformat()),
+            "mappings": raw.get("mappings", {}),
+            "blocked_slots": raw.get("blocked_slots", {}),
+        }
+
+    async def async_adopt_keymaster_slots(self) -> None:
+        """Adopt populated Keymaster slots on first upgrade.
+
+        Called when the Store is empty (first upgrade from a version
+        that did not persist slot mappings).  Iterates the managed slot
+        range and records each populated slot without modifying any
+        Keymaster state.
+
+        Slots with both a name and a non-empty code are recorded as
+        ``occupied``.  Slots with a name but no code (phantom slots)
+        are recorded as ``pending_clear`` so they are fenced without
+        being wiped immediately.  Empty slots (no name) are skipped.
+        Raw PINs are never stored; only ``has_code: True/False`` is
+        persisted.
+        """
+        if not self.lockname:
+            return
+
+        now_str = dt.now().isoformat()
+        prefix = f"{self.event_prefix} " if self.event_prefix else ""
+        mappings: dict[str, Any] = {}
+
+        for i in range(self.start_slot, self.start_slot + self.max_events):
+            name_state = self.hass.states.get(
+                f"{TEXT}.{self.lockname}_code_slot_{i}_name"
+            )
+            if name_state is None:
+                continue
+            name_value = (
+                ""
+                if name_state.state in ("unknown", "unavailable")
+                else name_state.state
+            )
+            if not name_value:
+                continue
+
+            code_state = self.hass.states.get(
+                f"{TEXT}.{self.lockname}_code_slot_{i}_pin"
+            )
+            has_code = False
+            if code_state is not None:
+                code_value = (
+                    ""
+                    if code_state.state in ("unknown", "unavailable")
+                    else code_state.state
+                )
+                has_code = bool(code_value)
+
+            use_date_range_state = self.hass.states.get(
+                f"{SWITCH}.{self.lockname}_code_slot_{i}_use_date_range_limits"
+            )
+            start_dt_state = self.hass.states.get(
+                f"{DATETIME}.{self.lockname}_code_slot_{i}_date_range_start"
+            )
+            end_dt_state = self.hass.states.get(
+                f"{DATETIME}.{self.lockname}_code_slot_{i}_date_range_end"
+            )
+            date_range_on = (
+                use_date_range_state is not None and use_date_range_state.state == "on"
+            )
+            actual_start: datetime | None = None
+            actual_end: datetime | None = None
+            if date_range_on:
+                if start_dt_state is not None:
+                    actual_start = dt.parse_datetime(start_dt_state.state)
+                if end_dt_state is not None:
+                    actual_end = dt.parse_datetime(end_dt_state.state)
+
+            slot_name = name_value
+            if prefix and slot_name.startswith(prefix):
+                slot_name = slot_name[len(prefix) :]
+
+            status = SLOT_STATUS_OCCUPIED if has_code else SLOT_STATUS_PENDING_CLEAR
+            pending_clear_since: str | None = now_str if not has_code else None
+            identity_key = f"adopted.{self._entry_id}.slot{i}"
+
+            mappings[identity_key] = {
+                "slot": i,
+                "status": status,
+                "operation_id": None,
+                "operation_kind": None,
+                "identity": {
+                    "identity_key": identity_key,
+                    "summary": slot_name,
+                    "slot_name": slot_name,
+                    "start": _store_datetime(actual_start),
+                    "end": _store_datetime(actual_end),
+                    "uid_aliases": [],
+                    "booking_aliases": [],
+                },
+                "missing_count": 0,
+                "pending_set_since": None,
+                "pending_clear_since": pending_clear_since,
+                "fingerprint_history": [],
+                "updated_at": now_str,
+                "last_observed_actual": {
+                    "slot": i,
+                    "classification": "adopted",
+                    "name_state": name_value,
+                    "has_code": has_code,
+                    "start_state": _store_datetime(actual_start),
+                    "end_state": _store_datetime(actual_end),
+                    "use_date_range": date_range_on,
+                    "enabled": None,
+                },
+            }
+
+        if mappings:
+            self._slot_mappings.setdefault("mappings", {}).update(mappings)
+            if "schema_version" not in self._slot_mappings:
+                self._slot_mappings.update(
+                    {
+                        "schema_version": STORE_SCHEMA_VERSION,
+                        "entry_id": self._entry_id,
+                        "lockname": self.lockname,
+                        "start_slot": self.start_slot,
+                        "max_slots": self.max_events,
+                        "updated_at": now_str,
+                        "blocked_slots": {},
+                    }
+                )
+            await self.async_save_slot_store()
+            if self.event_overrides is not None:
+                self.event_overrides.load_persisted_mappings(
+                    self._slot_mappings.get("mappings", {})
+                )
+
+    def _generate_date_based_code(self, start: datetime, end: datetime) -> str:
+        """Generate a date-based door code from reservation start/end times.
+
+        Mirrors the ``date_based`` code generation in
+        :class:`~.sensors.calsensor.RentalControlCalSensor` so that codes
+        produced by the coordinator match what the sensor would generate.
+
+        Args:
+            start: Reservation start datetime.
+            end: Reservation end datetime.
+
+        Returns:
+            A zero-padded date-derived code string of length
+            :attr:`code_length`.
+        """
+        code_length = self.code_length
+        start_day = start.strftime("%d")
+        start_month = start.strftime("%m")
+        start_year = start.strftime("%Y")
+        end_day = end.strftime("%d")
+        end_month = end.strftime("%m")
+        end_year = end.strftime("%Y")
+        code = f"{start_day}{end_day}{start_month}{end_month}{start_year}{end_year}"
+        return (
+            code[:code_length] if len(code) > code_length else code.zfill(code_length)
+        )
+
+    @staticmethod
+    def _extract_last_four(description: str | None) -> str | None:
+        """Extract last-four phone digits from reservation text."""
+        if description is None:
+            return None
+
+        explicit = re.findall(r"""\(?Last 4 Digits\)?:\s+(\d{4})(?!\d)""", description)
+        if explicit:
+            return str(explicit[0])
+
+        phone_last_four = re.findall(
+            r"""Phone\s*\(last\s*4\):\s*(\d{4})(?!\d)""",
+            description,
+            re.I,
+        )
+        if phone_last_four:
+            return str(phone_last_four[0])
+
+        if "Phone" in description:
+            phone_matches = re.findall(
+                r"""Phone(?: Number)?:\s+(\+?[\d\. \-\(\)]{9,})""",
+                description,
+            )
+            if phone_matches:
+                digits = str(phone_matches[0]).replace(" ", "")
+                if len(digits) >= 4:
+                    return digits[-4:]
+
+        return None
+
+    def _generate_slot_code(
+        self,
+        start: datetime,
+        end: datetime,
+        description: str | None,
+        uid: str | None,
+    ) -> str:
+        """Generate a slot code using the configured legacy generator."""
+        generator = self.code_generator
+
+        if description is None and (generator != "static_random" or uid is None):
+            generator = "date_based"
+
+        code: str | None = None
+        if generator == "last_four" and self.code_length == 4:
+            code = self._extract_last_four(description)
+        elif generator == "static_random":
+            seed = uid if uid else description
+            if seed:
+                rng = random.Random(seed)
+                max_range = int("9999".rjust(self.code_length, "9"))
+                code = str(rng.randrange(1, max_range, self.code_length)).zfill(
+                    self.code_length
+                )
+
+        return code if code is not None else self._generate_date_based_code(start, end)
+
+    def _build_reservations(self, calendar: list[CalendarEvent]) -> list[_Reservation]:
+        """Convert parsed CalendarEvent objects to Reservation objects.
+
+        Produces one :class:`~.reconciliation.Reservation` per calendar
+        event that has a usable slot name.  The coordinator's current
+        persisted mappings (``_slot_mappings["mappings"]``) are consulted
+        to populate :attr:`~.reconciliation.Reservation.fingerprint_history`
+        and :attr:`~.reconciliation.Reservation.missing_count`.
+
+        After building reservations from calendar events, ghost Reservation
+        objects are synthesised for occupied persisted mappings that are
+        absent from the current feed (T089).  Their ``missing_count`` is
+        incremented in ``_slot_mappings`` so the planner can apply the
+        two-cycle miss tolerance before generating a CLEAR action.
+
+        Args:
+            calendar: Parsed and sorted calendar events from the current
+                refresh cycle.
+
+        Returns:
+            List of :class:`~.reconciliation.Reservation` objects ready
+            for the planner; includes ghost reservations for absent slots.
+        """
+        # Use _slot_mappings["mappings"] as the live source of truth so that
+        # missing_count updates made by ghost logic in previous cycles are
+        # visible here.  At startup this is identical to what was loaded from
+        # the HA Store; ghost cycles then keep it up to date.
+        persisted: dict[str, Any] = self._slot_mappings.get("mappings", {})
+
+        prefix = f"{self.event_prefix} " if self.event_prefix else ""
+        reservations: list[_Reservation] = []
+        actual_slot_names: dict[int, str] = {}
+        for persisted_mapping in persisted.values():
+            slot_num = persisted_mapping.get("slot")
+            actual_name = (persisted_mapping.get("last_observed_actual", {}) or {}).get(
+                "name_state"
+            )
+            if isinstance(slot_num, int) and isinstance(actual_name, str):
+                actual_slot_names[slot_num] = actual_name
+        current_reservations_for_rematch: list[_Reservation] = []
+        for event in calendar:
+            slot_name = get_slot_name(
+                event.summary,
+                event.description or "",
+                self.event_prefix or "",
+            )
+            if not slot_name:
+                continue
+            rematch_start: datetime = event.start  # type: ignore[assignment]
+            rematch_end: datetime = event.end  # type: ignore[assignment]
+            uid = normalize_uid(getattr(event, "uid", None))
+            if self.trim_names and self.max_name_length > 0:
+                guest_max = self.max_name_length - len(prefix)
+                display_slot_name = f"{prefix}{trim_name(slot_name, guest_max)}"
+            else:
+                display_slot_name = f"{prefix}{slot_name}"
+            try:
+                current_reservations_for_rematch.append(
+                    _Reservation(
+                        identity_key=make_reservation_fingerprint(
+                            self._entry_id, slot_name, rematch_start, rematch_end
+                        ),
+                        start=rematch_start,
+                        end=rematch_end,
+                        buffered_start=rematch_start,
+                        buffered_end=rematch_end,
+                        summary=event.summary,
+                        slot_name=slot_name,
+                        display_slot_name=display_slot_name,
+                        slot_code="",
+                        uid_aliases={uid} if uid else set(),
+                        booking_aliases=extract_booking_aliases(
+                            event.summary, event.description or ""
+                        ),
+                    )
+                )
+            except ValueError:
+                continue
+
+        for event in calendar:
+            slot_name = get_slot_name(
+                event.summary,
+                event.description or "",
+                self.event_prefix or "",
+            )
+            if not slot_name:
+                continue
+
+            start: datetime = event.start  # type: ignore[assignment]
+            end: datetime = event.end  # type: ignore[assignment]
+
+            buffered_start_raw, buffered_end_raw = apply_buffer(
+                start, end, self.code_buffer_before, self.code_buffer_after, self
+            )
+            buffered_start: datetime = (
+                buffered_start_raw
+                if isinstance(buffered_start_raw, datetime)
+                else start
+            )
+            buffered_end: datetime = (
+                buffered_end_raw if isinstance(buffered_end_raw, datetime) else end
+            )
+
+            identity_key = make_reservation_fingerprint(
+                self._entry_id, slot_name, start, end
+            )
+
+            uid_raw = getattr(event, "uid", None)
+            uid = normalize_uid(uid_raw)
+            uid_aliases: set[str] = {uid} if uid else set()
+
+            booking_aliases = extract_booking_aliases(
+                event.summary, event.description or ""
+            )
+            if self.trim_names and self.max_name_length > 0:
+                guest_max = self.max_name_length - len(prefix)
+                display_slot_name = f"{prefix}{trim_name(slot_name, guest_max)}"
+            else:
+                display_slot_name = f"{prefix}{slot_name}"
+
+            provisional = _Reservation(
+                identity_key=identity_key,
+                start=start,
+                end=end,
+                buffered_start=buffered_start,
+                buffered_end=buffered_end,
+                summary=event.summary,
+                slot_name=slot_name,
+                display_slot_name=display_slot_name,
+                slot_code="",
+                uid_aliases=uid_aliases,
+                booking_aliases=booking_aliases,
+            )
+            rematch = find_reservation_rematch(
+                provisional,
+                persisted,
+                current_reservations=current_reservations_for_rematch,
+                actual_slot_names=actual_slot_names,
+            )
+            matched_key = rematch.matched_identity_key
+            if matched_key is not None and matched_key != identity_key:
+                mapping = persisted.pop(matched_key)
+                history = set(mapping.get("fingerprint_history", []))
+                history.add(matched_key)
+                mapping["fingerprint_history"] = sorted(history)
+                identity = mapping.setdefault("identity", {})
+                if isinstance(identity, dict):
+                    identity["identity_key"] = identity_key
+                persisted[identity_key] = mapping
+            else:
+                mapping = persisted.get(identity_key, {})
+                if rematch.kind.value == "ambiguous":
+                    _LOGGER.warning(
+                        "Reservation %s has ambiguous persisted rematch candidates: %s",
+                        identity_key,
+                        rematch.ambiguous_keys,
+                    )
+
+            fingerprint_history: set[str] = set(mapping.get("fingerprint_history", []))
+            missing_count: int = mapping.get("missing_count", 0)
+
+            # Reservation is present in feed – reset any accumulated miss count.
+            if mapping and missing_count != 0:
+                mapping["missing_count"] = 0
+                missing_count = 0
+                _LOGGER.debug(
+                    "Reservation %s reappeared; missing_count reset to 0", identity_key
+                )
+
+            slot_code = ""
+            if self.event_overrides is not None:
+                existing = self.event_overrides.get_slot_with_name(slot_name)
+                if existing and existing.get("slot_code"):
+                    slot_code = str(existing["slot_code"])
+            if not slot_code:
+                slot_code = self._generate_slot_code(start, end, event.description, uid)
+
+            try:
+                res = _Reservation(
+                    identity_key=identity_key,
+                    start=start,
+                    end=end,
+                    buffered_start=buffered_start,
+                    buffered_end=buffered_end,
+                    summary=event.summary,
+                    slot_name=slot_name,
+                    display_slot_name=display_slot_name,
+                    slot_code=slot_code,
+                    uid_aliases=uid_aliases,
+                    booking_aliases=booking_aliases,
+                    fingerprint_history=fingerprint_history,
+                    missing_count=missing_count,
+                )
+                reservations.append(res)
+            except ValueError:
+                _LOGGER.warning(
+                    "Skipping invalid reservation for %s: start=%s >= end=%s",
+                    event.summary,
+                    start,
+                    end,
+                )
+
+        # Build ghost reservations for occupied slots absent from this feed cycle.
+        if self.event_overrides is not None:
+            current_keys: set[str] = {r.identity_key for r in reservations}
+            ghost_list = self._build_ghost_reservations(current_keys, persisted, prefix)
+            reservations.extend(ghost_list)
+
+        return reservations
+
+    def _build_ghost_reservations(
+        self,
+        current_keys: set[str],
+        persisted: dict[str, Any],
+        prefix: str,
+    ) -> list[_Reservation]:
+        """Build synthetic Reservations for assigned slots absent from the feed.
+
+        When a previously-assigned reservation disappears from the calendar
+        feed, this method reconstructs a ghost :class:`~.reconciliation.Reservation`
+        with an incremented ``missing_count``.  The planner includes it so
+        that the slot is retained for up to two consecutive misses (T089);
+        on the third miss the ghost is filtered out by
+        :func:`~.reconciliation._filter_eligible` and the slot becomes
+        clearable.
+
+        Raw PIN values are never stored in the persisted mapping, so the
+        ghost ``slot_code`` is always an empty string.
+
+        Args:
+            current_keys: Identity keys already built from the current
+                calendar feed.  Absent keys are those in *persisted* but
+                not in this set.
+            persisted: Snapshot of ``_slot_mappings["mappings"]`` passed
+                by the caller so that updates made to ``missing_count``
+                here are reflected directly in the coordinator's live
+                store dict.
+            prefix: Computed event-prefix string (e.g. ``"RC "``).
+
+        Returns:
+            List of ghost :class:`~.reconciliation.Reservation` objects
+            for assigned slots missing from the current feed.
+        """
+        ghost_reservations: list[_Reservation] = []
+
+        for key, mapping in persisted.items():
+            if key in current_keys:
+                continue
+            status = mapping.get("status")
+            if status not in (SLOT_STATUS_OCCUPIED, SLOT_STATUS_PENDING_SET):
+                continue
+
+            new_mc = mapping.get("missing_count", 0) + 1
+            mapping["missing_count"] = new_mc
+
+            if status == SLOT_STATUS_PENDING_SET and new_mc >= 3:
+                mapping["status"] = SLOT_STATUS_PENDING_CLEAR
+                mapping["pending_set_since"] = None
+                mapping["pending_clear_since"] = mapping.get(
+                    "pending_clear_since", dt.now().isoformat()
+                )
+                mapping["operation_id"] = None
+                mapping["operation_kind"] = OPERATION_KIND_CLEAR
+                _LOGGER.debug(
+                    "Pending-set ghost %s missed %d cycles; marking pending-clear",
+                    key,
+                    new_mc,
+                )
+                continue
+
+            identity = mapping.get("identity", {})
+            slot_name: str = identity.get("slot_name", "")
+            summary: str = identity.get("summary", "")
+            uid_aliases: set[str] = set(identity.get("uid_aliases", []))
+            booking_aliases: set[str] = set(identity.get("booking_aliases", []))
+            fingerprint_history: set[str] = set(mapping.get("fingerprint_history", []))
+
+            # Recover dates from the last observed Keymaster state.
+            last_actual = mapping.get("last_observed_actual", {})
+            start_raw = last_actual.get("start_state")
+            end_raw = last_actual.get("end_state")
+
+            if not slot_name or start_raw is None or end_raw is None:
+                _LOGGER.debug(
+                    "Ghost reservation %s: missing slot_name or dates; slot remains "
+                    "fenced with missing_count=%d",
+                    key,
+                    new_mc,
+                )
+                continue
+
+            start_dt: datetime | None = (
+                dt.parse_datetime(start_raw)
+                if isinstance(start_raw, str)
+                else start_raw
+            )
+            end_dt: datetime | None = (
+                dt.parse_datetime(end_raw) if isinstance(end_raw, str) else end_raw
+            )
+
+            if start_dt is None or end_dt is None or start_dt >= end_dt:
+                _LOGGER.debug(
+                    "Ghost reservation %s: invalid dates (start=%s end=%s); "
+                    "slot remains fenced with missing_count=%d",
+                    key,
+                    start_raw,
+                    end_raw,
+                    new_mc,
+                )
+                continue
+
+            if self.trim_names and self.max_name_length > 0:
+                guest_max = self.max_name_length - len(prefix)
+                display_slot_name = f"{prefix}{trim_name(slot_name, guest_max)}"
+            else:
+                display_slot_name = f"{prefix}{slot_name}"
+
+            try:
+                ghost = _Reservation(
+                    identity_key=key,
+                    start=start_dt,
+                    end=end_dt,
+                    buffered_start=start_dt,
+                    buffered_end=end_dt,
+                    summary=summary,
+                    slot_name=slot_name,
+                    display_slot_name=display_slot_name,
+                    slot_code="",  # raw PIN is never stored; no code available
+                    uid_aliases=uid_aliases,
+                    booking_aliases=booking_aliases,
+                    fingerprint_history=fingerprint_history,
+                    missing_count=new_mc,
+                )
+                ghost_reservations.append(ghost)
+                _LOGGER.debug(
+                    "Ghost reservation %s created with missing_count=%d", key, new_mc
+                )
+            except ValueError:
+                _LOGGER.debug(
+                    "Ghost reservation %s: invalid Reservation fields; skipping", key
+                )
+
+        return ghost_reservations
+
+    def _sync_slot_store_from_plan(
+        self,
+        plan: _DesiredPlan,
+        res_by_key: dict[str, _Reservation],
+        operation_results: list[OperationResult],
+    ) -> None:
+        """Synchronize persisted mappings with confirmed reconciliation state.
+
+        The HA Store must be updated after each apply-plan pass so the next
+        refresh and future restarts retain the authoritative reservation-to-slot
+        mapping.  Raw PIN values are never written; only ``has_code`` and
+        reservation identity metadata are persisted.
+        """
+        mappings: dict[str, Any] = self._slot_mappings.setdefault("mappings", {})
+        now_str = dt.now().isoformat()
+
+        failed_set_slots = {
+            result.slot
+            for result in operation_results
+            if result.kind == "set" and result.failed
+        }
+        confirmed_clear_slots = {
+            result.slot
+            for result in operation_results
+            if result.kind == "clear" and result.confirmed
+        }
+        unconfirmed_clear_slots = {
+            result.slot
+            for result in operation_results
+            if result.kind == "clear" and not result.confirmed
+        }
+
+        for identity_key, mapping in list(mappings.items()):
+            slot = mapping.get("slot")
+            if slot in confirmed_clear_slots:
+                mappings.pop(identity_key, None)
+            elif slot in unconfirmed_clear_slots:
+                mapping["status"] = SLOT_STATUS_PENDING_CLEAR
+                mapping["pending_clear_since"] = mapping.get(
+                    "pending_clear_since", now_str
+                )
+                if self.event_overrides is not None:
+                    operation_id = self.event_overrides.pending_clear_slots.get(slot)
+                    mapping["operation_id"] = operation_id
+                    mapping["operation_kind"] = OPERATION_KIND_CLEAR
+
+        for identity_key, slot in plan.selected.items():
+            if slot in failed_set_slots:
+                continue
+            if slot in confirmed_clear_slots:
+                continue
+            res = res_by_key.get(identity_key)
+            if res is None:
+                continue
+            if (
+                self.event_overrides is not None
+                and slot in self.event_overrides.pending_clear_slots
+            ):
+                continue
+
+            is_unconfirmed_set = any(
+                result.kind == OPERATION_KIND_SET
+                and result.slot == slot
+                and result.unconfirmed
+                for result in operation_results
+            )
+            existing_mapping = mappings.get(identity_key, {})
+            actual = (
+                self.event_overrides.get_actual_state(slot)
+                if self.event_overrides is not None
+                else None
+            ) or {}
+            for stale_key in [
+                key
+                for key, mapping in mappings.items()
+                if key != identity_key
+                and mapping.get("slot") == slot
+                and mapping.get("status")
+                in (SLOT_STATUS_OCCUPIED, SLOT_STATUS_PENDING_SET)
+            ]:
+                mappings.pop(stale_key, None)
+            mappings[identity_key] = {
+                "slot": slot,
+                "status": (
+                    SLOT_STATUS_PENDING_SET
+                    if is_unconfirmed_set
+                    else SLOT_STATUS_OCCUPIED
+                ),
+                "operation_id": plan.plan_id if is_unconfirmed_set else None,
+                "operation_kind": OPERATION_KIND_SET if is_unconfirmed_set else None,
+                "identity": {
+                    "identity_key": identity_key,
+                    "summary": res.summary,
+                    "slot_name": res.slot_name,
+                    "start": res.start.isoformat(),
+                    "end": res.end.isoformat(),
+                    "uid_aliases": sorted(res.uid_aliases),
+                    "booking_aliases": sorted(res.booking_aliases),
+                },
+                "missing_count": res.missing_count,
+                "pending_set_since": (
+                    existing_mapping.get("pending_set_since", now_str)
+                    if is_unconfirmed_set
+                    else None
+                ),
+                "pending_clear_since": None,
+                "fingerprint_history": sorted(res.fingerprint_history),
+                "updated_at": now_str,
+                "last_observed_actual": {
+                    "slot": slot,
+                    "classification": actual.get("classification", "occupied"),
+                    "name_state": actual.get("name_state") or res.display_slot_name,
+                    "has_code": actual.get("has_code", bool(res.slot_code)),
+                    "start_state": (
+                        _store_datetime(actual.get("start_state"))
+                        or res.buffered_start.isoformat()
+                    ),
+                    "end_state": _store_datetime(actual.get("end_state"))
+                    or res.buffered_end.isoformat(),
+                    "use_date_range": actual.get("use_date_range"),
+                    "enabled": actual.get("enabled"),
+                },
+            }
+
+        self._slot_mappings.update(
+            {
+                "schema_version": STORE_SCHEMA_VERSION,
+                "entry_id": self._entry_id,
+                "lockname": self.lockname,
+                "start_slot": self.start_slot,
+                "max_slots": self.max_events,
+                "updated_at": now_str,
+                "blocked_slots": self._slot_mappings.get("blocked_slots", {}),
+            }
+        )
+
+        if self.event_overrides is not None:
+            self.event_overrides.load_persisted_mappings(mappings)
+
+    def _observe_managed_slots(self) -> list[_ManagedSlot]:
+        """Read Keymaster entity states and build ManagedSlot observations.
+
+        Reads Keymaster text, switch, and datetime entities for every slot
+        in the managed range to determine the current physical state.
+        Persisted fence tokens from :attr:`event_overrides` override the
+        entity-derived classification for ``PENDING_CLEAR`` slots.  The
+        observed state is also written back to the
+        :meth:`~.event_overrides.EventOverrides.update_actual_state`
+        cache for diagnostics.
+
+        Returns:
+            List of :class:`~.reconciliation.ManagedSlot` instances, one
+            per slot in ``start_slot .. start_slot + max_events - 1``.
+        """
+        if not self.lockname or not self.event_overrides:
+            return []
+
+        persisted = self._slot_mappings.get("mappings", {})
+        pending_clear = self.event_overrides.pending_clear_slots
+
+        slot_to_persisted_key: dict[int, str] = {}
+        for key, mapping in persisted.items():
+            slot_num = mapping.get("slot")
+            if slot_num is None:
+                continue
+            current = slot_to_persisted_key.get(slot_num)
+            if current is None:
+                slot_to_persisted_key[slot_num] = key
+            elif mapping.get("status") in (
+                SLOT_STATUS_OCCUPIED,
+                SLOT_STATUS_PENDING_SET,
+            ):
+                slot_to_persisted_key[slot_num] = key
+
+        slots: list[_ManagedSlot] = []
+
+        for i in range(self.start_slot, self.start_slot + self.max_events):
+            name_state = self.hass.states.get(
+                f"{TEXT}.{self.lockname}_code_slot_{i}_name"
+            )
+            code_state = self.hass.states.get(
+                f"{TEXT}.{self.lockname}_code_slot_{i}_pin"
+            )
+
+            if name_state is None or code_state is None:
+                ms = _ManagedSlot(slot=i, managed=True, status=_SlotStatus.UNKNOWN)
+                slots.append(ms)
+                self.event_overrides.update_actual_state(
+                    i,
+                    {
+                        "slot": i,
+                        "classification": _SlotStatus.UNKNOWN.value,
+                        "name_state": None,
+                        "has_code": None,
+                        "start_state": None,
+                        "end_state": None,
+                        "use_date_range": None,
+                        "enabled": None,
+                    },
+                )
+                continue
+
+            name_empty = _is_blank_keymaster_text(name_state.state)
+            code_empty = _is_blank_keymaster_text(code_state.state)
+            physically_empty = name_empty and code_empty
+            unreadable = _is_unreadable_keymaster_text(
+                name_state.state
+            ) or _is_unreadable_keymaster_text(code_state.state)
+
+            if not physically_empty and unreadable:
+                status = (
+                    _SlotStatus.PENDING_CLEAR
+                    if i in pending_clear
+                    else _SlotStatus.UNKNOWN
+                )
+                blocked_reason = "pending_clear" if i in pending_clear else None
+                ms = _ManagedSlot(
+                    slot=i,
+                    managed=True,
+                    status=status,
+                    blocked_reason=blocked_reason,
+                )
+                slots.append(ms)
+                self.event_overrides.update_actual_state(
+                    i,
+                    {
+                        "slot": i,
+                        "classification": status.value,
+                        "name_state": None,
+                        "has_code": None,
+                        "start_state": None,
+                        "end_state": None,
+                        "use_date_range": None,
+                        "enabled": None,
+                    },
+                )
+                continue
+
+            name_value = "" if name_empty else name_state.state
+            code_value = "" if code_empty else code_state.state
+            has_code = bool(code_value)
+
+            use_date_range_state = self.hass.states.get(
+                f"{SWITCH}.{self.lockname}_code_slot_{i}_use_date_range_limits"
+            )
+            enabled_state = self.hass.states.get(
+                f"{SWITCH}.{self.lockname}_code_slot_{i}_enabled"
+            )
+            start_dt_state = self.hass.states.get(
+                f"{DATETIME}.{self.lockname}_code_slot_{i}_date_range_start"
+            )
+            end_dt_state = self.hass.states.get(
+                f"{DATETIME}.{self.lockname}_code_slot_{i}_date_range_end"
+            )
+
+            date_range_on = (
+                use_date_range_state is not None and use_date_range_state.state == "on"
+            )
+            enabled: bool | None = None
+            if enabled_state is not None:
+                enabled = enabled_state.state == "on"
+
+            actual_start: datetime | None = None
+            actual_end: datetime | None = None
+            if date_range_on:
+                if start_dt_state is not None:
+                    actual_start = dt.parse_datetime(start_dt_state.state)
+                if end_dt_state is not None:
+                    actual_end = dt.parse_datetime(end_dt_state.state)
+
+            persisted_key = slot_to_persisted_key.get(i)
+            persisted_mapping = (
+                persisted.get(persisted_key) if persisted_key is not None else None
+            )
+            persisted_status = (
+                persisted_mapping.get("status")
+                if persisted_mapping is not None
+                else None
+            )
+            if physically_empty and i in pending_clear:
+                self.event_overrides.release_pending_clear_slot(i)
+                for key in [
+                    key
+                    for key, mapping in persisted.items()
+                    if mapping.get("slot") == i
+                    and mapping.get("status") == SLOT_STATUS_PENDING_CLEAR
+                ]:
+                    persisted.pop(key, None)
+                pending_clear = self.event_overrides.pending_clear_slots
+                persisted_key = None
+                persisted_mapping = None
+                persisted_status = None
+
+            if i in pending_clear:
+                status = _SlotStatus.PENDING_CLEAR
+                blocked_reason = "pending_clear"
+            elif persisted_status == SLOT_STATUS_BLOCKED:
+                status = _SlotStatus.BLOCKED
+                blocked_reason = SLOT_STATUS_BLOCKED
+            elif name_value and has_code:
+                status = _SlotStatus.OCCUPIED
+                blocked_reason = None
+            elif persisted_status == SLOT_STATUS_PENDING_SET:
+                status = _SlotStatus.BLOCKED
+                blocked_reason = SLOT_STATUS_PENDING_SET
+            elif name_value:
+                status = _SlotStatus.PHANTOM
+                blocked_reason = None
+            else:
+                status = _SlotStatus.FREE
+                blocked_reason = None
+
+            ms = _ManagedSlot(
+                slot=i,
+                managed=True,
+                status=status,
+                actual_name=name_value or None,
+                actual_code_present=has_code,
+                actual_start=actual_start,
+                actual_end=actual_end,
+                date_range_enabled=date_range_on,
+                enabled=enabled,
+                persisted_identity_key=persisted_key,
+                blocked_reason=blocked_reason,
+                last_error=self.event_overrides.get_last_slot_error(i),
+            )
+            slots.append(ms)
+
+            self.event_overrides.update_actual_state(
+                i,
+                {
+                    "slot": i,
+                    "classification": status.value,
+                    "name_state": name_value or None,
+                    "has_code": has_code,
+                    "start_state": actual_start,
+                    "end_state": actual_end,
+                    "use_date_range": date_range_on,
+                    "enabled": enabled,
+                },
+            )
+
+        return slots
+
+    def _apply_checkin_protection(self, reservations: list[_Reservation]) -> None:
+        """Mark active checked-in reservation as protected, if present.
+
+        Reads :class:`~.sensors.checkinsensor.CheckinTrackingSensor` state
+        from ``hass.data`` and sets :attr:`~.reconciliation.Reservation.protected_active`
+        on the matching reservation so that reconciliation never evicts
+        the active guest mid-stay (T043).
+
+        When the sensor state is ``checked_out``, the matching reservation
+        is flagged with :attr:`~.reconciliation.Reservation.checked_out`
+        so the planner can handle graceful post-checkout slot release.
+
+        Args:
+            reservations: Mutable list of reservations for the current
+                refresh cycle.  Modified in-place.
+        """
+        domain_data: dict[str, Any] | None = self.hass.data.get(DOMAIN)
+        entry_data: dict[str, Any] = (
+            domain_data.get(self._entry_id, {}) if domain_data is not None else {}
+        )
+        checkin_sensor = entry_data.get(CHECKIN_SENSOR)
+        if checkin_sensor is None:
+            return
+
+        sensor_state: str = checkin_sensor.state
+        if sensor_state not in (CHECKIN_STATE_CHECKED_IN, CHECKIN_STATE_CHECKED_OUT):
+            return
+
+        attrs: dict[str, Any] = checkin_sensor.extra_state_attributes
+        guest_name: str | None = attrs.get("guest_name")
+        if not guest_name:
+            return
+
+        for res in reservations:
+            if res.slot_name == guest_name:
+                if sensor_state == CHECKIN_STATE_CHECKED_IN:
+                    res.protected_active = True
+                elif sensor_state == CHECKIN_STATE_CHECKED_OUT:
+                    res.checked_out = True
+                break
+
     async def _async_fetch_calendar(self) -> list[CalendarEvent]:
         """Fetch iCalendar data from URL and parse into events."""
         try:
@@ -520,9 +1676,57 @@ Please update Keymaster to at least v0.1.0-b0
                     break
 
         if self.event_overrides:
-            await self.event_overrides.async_check_overrides(
-                self, calendar=new_calendar
-            )
+            try:
+                reservations = self._build_reservations(new_calendar)
+                self.event_overrides.load_persisted_mappings(
+                    self._slot_mappings.get("mappings", {})
+                )
+                managed_slots = self._observe_managed_slots()
+                self._apply_checkin_protection(reservations)
+
+                plan_id = str(uuid.uuid4())
+                plan = compute_desired_plan(
+                    reservations=reservations,
+                    managed_slots=managed_slots,
+                    max_events=self.max_events,
+                    plan_id=plan_id,
+                    generated_at=dt.now(),
+                    entry_id=self._entry_id,
+                    lockname=self.lockname,
+                    start_slot=self.start_slot,
+                )
+
+                violations = plan.validate()
+                for v in violations:
+                    _LOGGER.warning("Plan %s invariant violation: %s", plan_id, v)
+
+                res_by_key: dict[str, _Reservation] = {
+                    r.identity_key: r for r in reservations
+                }
+                operation_results = await self.event_overrides.async_apply_plan(
+                    self, plan, res_by_key
+                )
+                self._sync_slot_store_from_plan(plan, res_by_key, operation_results)
+
+                self._latest_plan = plan
+                self._latest_res_by_key = res_by_key
+
+                _LOGGER.debug(
+                    "Reconciliation for %s: plan=%s selected=%d overflow=%d actions=%d",
+                    self._name,
+                    plan_id,
+                    len(plan.selected),
+                    len(plan.overflow),
+                    len(plan.actions),
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _LOGGER.exception(
+                    "Reconciliation failed for %s; skipping cycle", self._name
+                )
+
+        await self.async_save_slot_store()
 
         # Refresh child lock discovery each cycle
         if self.lockname:
@@ -577,6 +1781,15 @@ Please update Keymaster to at least v0.1.0-b0
             if overrides_stale:
                 self.event_overrides = EventOverrides(self.start_slot, self.max_events)
                 await self.async_setup_keymaster_overrides()
+                persisted = self._slot_mappings.get("mappings", {})
+                if persisted:
+                    try:
+                        self.event_overrides.load_persisted_mappings(persisted)
+                    except ValueError:
+                        _LOGGER.exception(
+                            "Failed to load persisted slot mappings for %s",
+                            self._entry_id,
+                        )
             # Re-discover parent entry and children on lockname change
             if lockname_changed:
                 self._parent_entry_id = self._find_parent_entry_id()

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -20,18 +20,32 @@ from datetime import date
 from datetime import datetime
 from datetime import time
 import logging
+from time import monotonic
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import NamedTuple
 from typing import TypedDict
+import uuid
 
 from homeassistant.util import dt
 
 from .const import DEFAULT_MAX_RETRY_CYCLES
+from .const import SLOT_STATUS_OCCUPIED
+from .const import SLOT_STATUS_PENDING_CLEAR
+from .reconciliation import ActionKind
+from .reconciliation import DesiredPlan
+from .reconciliation import Reservation
+from .reconciliation import SlotAction
 from .util import EventIdentity
+from .util import OperationResult
 from .util import async_fire_clear_code
+from .util import async_fire_set_code
+from .util import async_fire_update_times
 from .util import get_event_identities
 from .util import normalize_uid
 from .util import trim_name
+
+# aislop-ignore-file complexity/file-too-large complexity/function-too-long -- Existing module size is outside this emergency fix scope.
 
 if TYPE_CHECKING:
     from homeassistant.components.calendar import CalendarEvent
@@ -39,6 +53,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 SLOT_MISS_THRESHOLD = 2
+SUPPRESSED_STATE_CHANGE_TTL = 5.0
 
 
 def _to_utc(value: datetime) -> datetime:
@@ -60,6 +75,18 @@ def _to_utc(value: datetime) -> datetime:
         return result
     utc: datetime = dt.as_utc(value)
     return utc
+
+
+def _states_match(expected: str, actual: str) -> bool:
+    """Compare raw HA state strings, normalizing datetimes when possible."""
+    if expected == actual:
+        return True
+
+    expected_dt = dt.parse_datetime(expected)
+    actual_dt = dt.parse_datetime(actual)
+    if expected_dt is not None and actual_dt is not None:
+        return _to_utc(expected_dt) == _to_utc(actual_dt)
+    return False
 
 
 def _strip_prefix(slot_name: str, prefix: str) -> str:
@@ -104,6 +131,25 @@ class EventOverride(TypedDict):
     end_time: datetime
 
 
+class _SlotEvent:
+    """Minimal event adapter for util slot-operation helpers."""
+
+    def __init__(
+        self,
+        slot_name: str,
+        slot_code: str,
+        start: datetime,
+        end: datetime,
+    ) -> None:
+        """Populate the attributes expected by util service helpers."""
+        self.extra_state_attributes: dict[str, Any] = {
+            "slot_name": slot_name,
+            "slot_code": slot_code,
+            "start": start,
+            "end": end,
+        }
+
+
 class EventOverrides:
     """Event Overrides object and methods."""
 
@@ -124,6 +170,20 @@ class EventOverrides:
         self._max_name_length: int = 0
         self._prefix_length: int = 0
 
+        # Store-backed fields (T018)
+        self._persisted_mappings: dict[str, dict[str, Any]] = {}
+        self._pending_clear_slots: dict[int, str] = {}
+        self._pending_fences: dict[int, str] = {}
+        self._actual_state_cache: dict[int, dict[str, Any]] = {}
+        self._reconciliation_active: bool = False
+
+        # Per-slot error tracking for diagnostics (T096)
+        self._last_slot_errors: dict[int, str] = {}
+        # Coordinator-originated state feedback awaiting callback suppression
+        self._suppressed_state_changes: dict[int, dict[str, tuple[str, float]]] = {}
+        # Latest diagnostics snapshot for HA diagnostics collection (T096)
+        self._diagnostics_snapshot: dict[str, Any] = {}
+
     @property
     def max_slots(self) -> int:
         """Return the max_slots known."""
@@ -131,7 +191,16 @@ class EventOverrides:
 
     @property
     def next_slot(self) -> int | None:
-        """Return the next_slot available."""
+        """Return the next available slot index for the greedy path.
+
+        .. deprecated::
+            This property is part of the retired greedy slot-assignment path.
+            The reconciliation coordinator (``compute_desired_plan`` /
+            ``async_apply_plan``) owns slot selection and does not consult
+            ``_next_slot``.  The property is retained as a backward-compatible
+            shim for tests that exercise :meth:`async_reserve_or_get_slot`
+            directly; production code must not read it.
+        """
         return self._next_slot
 
     @property
@@ -179,8 +248,253 @@ class EventOverrides:
         """Set the event prefix length including separator."""
         self._prefix_length = value
 
+    @property
+    def persisted_mappings(self) -> dict[str, dict[str, Any]]:
+        """Return a read-only copy of the persisted slot mappings."""
+        return dict(self._persisted_mappings)
+
+    @property
+    def pending_clear_slots(self) -> dict[int, str]:
+        """Return a read-only copy of the pending-clear slot map."""
+        return dict(self._pending_clear_slots)
+
+    @property
+    def pending_fences(self) -> dict[int, str]:
+        """Return a read-only copy of pending operation fences."""
+        return dict(self._pending_fences)
+
+    @property
+    def reconciliation_active(self) -> bool:
+        """True while async_apply_plan is executing."""
+        return self._reconciliation_active
+
+    def suppress_state_changes(self, slot: int, changes: dict[str, Any]) -> None:
+        """Mark coordinator-originated state changes to ignore in callbacks."""
+        now = monotonic()
+        pending = self._suppressed_state_changes.setdefault(slot, {})
+        for entity_id, value in changes.items():
+            pending[entity_id] = (str(value), now)
+
+    def should_suppress_state_change(
+        self, slot: int, entity_id: str, state: str
+    ) -> bool:
+        """Return True when a callback is feedback from our own service call."""
+        pending = self._suppressed_state_changes.get(slot)
+        if not pending:
+            return False
+
+        now = monotonic()
+        for pending_entity_id, (_, created) in list(pending.items()):
+            if now - created > SUPPRESSED_STATE_CHANGE_TTL:
+                pending.pop(pending_entity_id, None)
+
+        expected = pending.get(entity_id)
+        if expected is None:
+            if not pending:
+                self._suppressed_state_changes.pop(slot, None)
+            return False
+
+        expected_state, _ = expected
+        if _states_match(expected_state, state):
+            pending.pop(entity_id, None)
+            if not pending:
+                self._suppressed_state_changes.pop(slot, None)
+            return True
+        return False
+
+    @property
+    def diagnostics_snapshot(self) -> dict[str, Any]:
+        """Return the latest diagnostics snapshot for HA diagnostics collection.
+
+        The snapshot is built after each :meth:`async_apply_plan` call and
+        captures matched slots, pending corrections, blocked clear reasons,
+        retry counts, and last errors.  Raw slot codes are never included.
+
+        Returns:
+            A shallow copy of the current diagnostics snapshot dict, or an
+            empty dict if no plan has been applied yet.
+        """
+        return dict(self._diagnostics_snapshot)
+
+    def get_last_slot_error(self, slot: int) -> str | None:
+        """Return the last error string for *slot*, or ``None`` if no error.
+
+        Args:
+            slot: Keymaster slot number.
+
+        Returns:
+            The last recorded error string for the slot, or ``None``.
+        """
+        return self._last_slot_errors.get(slot)
+
+    def _record_slot_error(self, slot: int, error: str) -> None:
+        """Record a failed operation error for *slot*.
+
+        Args:
+            slot: Keymaster slot number.
+            error: Human-readable error description.
+        """
+        self._last_slot_errors[slot] = error
+
+    def _clear_slot_error(self, slot: int) -> None:
+        """Clear the recorded error for *slot* on a successful operation.
+
+        Args:
+            slot: Keymaster slot number.
+        """
+        self._last_slot_errors.pop(slot, None)
+
+    def update_diagnostics_snapshot(self, plan: "DesiredPlan") -> None:
+        """Build and store a diagnostics snapshot from the completed plan.
+
+        Called after :meth:`async_apply_plan` completes.  Captures matched
+        slots (those with desired assignments), pending corrections (slots
+        with ``retry_clear`` or ``blocked`` actions), manual drift slots
+        (those with ``overwrite_manual_change`` actions), blocked clear
+        reasons, per-slot retry counts, and last errors.  Raw slot codes
+        are never included.
+
+        Args:
+            plan: The :class:`~.reconciliation.DesiredPlan` that was just applied.
+        """
+        matched: dict[int, dict[str, Any]] = {}
+        pending_corrections: dict[int, dict[str, Any]] = {}
+        manual_drift_slots: dict[int, dict[str, Any]] = {}
+
+        for slot_num, ps in plan.slots.items():
+            if ps.desired_identity_key is not None:
+                matched[slot_num] = {
+                    "identity_key": ps.desired_identity_key,
+                    "action": ps.action.value,
+                }
+            if ps.action.value in (
+                ActionKind.RETRY_CLEAR.value,
+                ActionKind.BLOCKED.value,
+            ):
+                pending_corrections[slot_num] = {
+                    "action": ps.action.value,
+                    "blocked_reason": ps.pending_reason,
+                    "retry_count": ps.retry_count,
+                }
+            if ps.action is ActionKind.OVERWRITE_MANUAL_CHANGE:
+                drift_fields: list[str] = []
+                if ps.pending_reason and ps.pending_reason.startswith(
+                    "drifted fields: "
+                ):
+                    drift_fields = [
+                        f.strip()
+                        for f in ps.pending_reason[len("drifted fields: ") :].split(",")
+                        if f.strip()
+                    ]
+                manual_drift_slots[slot_num] = {
+                    "action": ps.action.value,
+                    "identity_key": ps.desired_identity_key,
+                    "drift_fields": drift_fields,
+                }
+
+        self._diagnostics_snapshot = {
+            "plan_id": plan.plan_id,
+            "generated_at": plan.generated_at.isoformat(),
+            "matched_slots": matched,
+            "pending_corrections": pending_corrections,
+            "manual_drift_slots": manual_drift_slots,
+            "pending_clear_slots": sorted(self._pending_clear_slots.keys()),
+            "slot_retry_counts": {
+                slot: self._retry_counts.get(slot, 0)
+                for slot in range(self._start_slot, self._start_slot + self._max_slots)
+            },
+            "last_slot_errors": dict(self._last_slot_errors),
+        }
+
+    def load_persisted_mappings(self, mappings: dict[str, dict[str, Any]]) -> None:
+        """Load persisted slot mappings from the HA Store.
+
+        Validates that no two mappings both claim the same slot with
+        status ``occupied``; raises ``ValueError`` on conflict.
+
+        Args:
+            mappings: Identity-key → mapping dict from the HA Store.
+
+        Raises:
+            ValueError: If two mappings claim the same slot and both
+                have ``occupied`` status.
+        """
+        slot_owners: dict[int, str] = {}
+        for identity_key, mapping in mappings.items():
+            slot = mapping.get("slot")
+            status = mapping.get("status")
+            if slot is not None and status == SLOT_STATUS_OCCUPIED:
+                if slot in slot_owners:
+                    raise ValueError(
+                        f"Duplicate occupied slot {slot}: claimed by both "
+                        f"{slot_owners[slot]!r} and {identity_key!r}"
+                    )
+                slot_owners[slot] = identity_key
+
+        self._persisted_mappings = {k: dict(v) for k, v in mappings.items()}
+
+        self._pending_clear_slots = {}
+        for identity_key, mapping in mappings.items():
+            if mapping.get("status") == SLOT_STATUS_PENDING_CLEAR:
+                slot = mapping.get("slot")
+                if slot is not None:
+                    operation_id = mapping.get("operation_id")
+                    self._pending_clear_slots[slot] = (
+                        operation_id if operation_id is not None else identity_key
+                    )
+
+    def update_actual_state(self, slot: int, state: dict[str, Any]) -> None:
+        """Store the observed Keymaster state snapshot for a slot.
+
+        Args:
+            slot: Keymaster slot number.
+            state: Dict capturing the observed entity states for the slot.
+        """
+        self._actual_state_cache[slot] = state
+
+    def get_actual_state(self, slot: int) -> dict[str, Any] | None:
+        """Return the cached actual state for a slot, or None.
+
+        Args:
+            slot: Keymaster slot number.
+
+        Returns:
+            The cached state dict, or ``None`` if not yet observed.
+        """
+        return self._actual_state_cache.get(slot)
+
+    def release_pending_clear_slot(self, slot: int) -> None:
+        """Release a pending-clear fence after observing an empty slot.
+
+        Coordinator observations are the authoritative physical state for
+        persisted clear fences.  When both Keymaster name and PIN are
+        observed empty, stale pending-clear bookkeeping must not continue
+        to block future assignments.
+        """
+        self._pending_clear_slots.pop(slot, None)
+        self._pending_fences.pop(slot, None)
+        self._overrides[slot] = None
+        self._slot_uids.pop(slot, None)
+        self._slot_miss_counts.pop(slot, None)
+        self._clear_slot_error(slot)
+
     def __assign_next_slot(self) -> None:
-        """Assign the next slot."""
+        """Recompute ``_next_slot`` for the deprecated greedy path.
+
+        Called only from the greedy-path methods (:meth:`update`,
+        :meth:`async_update`, :meth:`async_reserve_or_get_slot`,
+        :meth:`async_check_overrides`) so that :attr:`next_slot` stays
+        accurate for callers that still use the legacy API.
+
+        Reconciliation methods (:meth:`_apply_clear`, :meth:`_apply_set`,
+        :meth:`_apply_overwrite_manual_change`) do *not* call this helper;
+        slot selection in the reconciliation path is determined by
+        ``compute_desired_plan``, not by ``_next_slot``.
+
+        .. deprecated::
+            Do not call from new code.  Will be removed when the greedy
+            path shims are retired.
+        """
 
         _LOGGER.debug("In EventOverrides.assign_next_slot")
 
@@ -410,10 +724,19 @@ class EventOverrides:
         uid: str | None = None,
         prefix: str | None = None,
     ) -> ReserveResult:
-        """Atomically find existing slot or reserve next available.
+        """Atomically find existing slot or reserve next available (greedy path).
 
         All work is performed under ``_lock`` so concurrent callers
         are serialised.
+
+        .. deprecated::
+            This method is the retired greedy slot-assignment path.  The
+            reconciliation coordinator (``compute_desired_plan`` /
+            ``async_apply_plan``) is now the sole authority for slot
+            assignments and does not call this method.  The method is
+            retained as a backward-compatible shim for tests that exercise
+            the greedy path directly; it must not be called from production
+            coordinator or sensor code.
         """
         async with self._lock:
             if prefix is None:
@@ -539,6 +862,431 @@ class EventOverrides:
         """Reset failure tracking for slot."""
         self._retry_counts[slot] = 0
         self._escalated[slot] = False
+
+    async def async_apply_plan(
+        self,
+        coordinator: Any,
+        plan: DesiredPlan,
+        res_by_key: dict[str, Reservation],
+    ) -> list[OperationResult]:
+        """Apply a desired plan by executing slot actions."""
+        async with self._lock:
+            self._reconciliation_active = True
+
+        results: list[OperationResult] = []
+        try:
+            for action in plan.actions:
+                if action.kind in {ActionKind.NOOP, ActionKind.BLOCKED}:
+                    continue
+
+                slot = action.slot
+                identity_key = action.identity_key
+
+                if action.kind in {ActionKind.CLEAR, ActionKind.RETRY_CLEAR}:
+                    _clear_reason = action.reason
+                    clear_warning = None
+                    if _clear_reason is not None:
+                        clear_warning = {
+                            "duplicate_non_canonical": (
+                                "Duplicate collapse: clearing non-canonical slot %d "
+                                "(duplicate actual assignment)"
+                            ),
+                            "phantom": (
+                                "Phantom recovery: clearing slot %d "
+                                "(name-only state, no usable PIN)"
+                            ),
+                            "stale": (
+                                "Stale correction: clearing slot %d "
+                                "(expired or absent reservation)"
+                            ),
+                            "mis_assigned": (
+                                "Mis-assignment correction: clearing slot %d "
+                                "(wrong reservation in slot)"
+                            ),
+                        }.get(_clear_reason)
+                    if clear_warning is not None:
+                        _LOGGER.warning(
+                            clear_warning,
+                            slot,
+                        )
+                    result = await self._apply_clear(coordinator, slot)
+                elif action.kind is ActionKind.SET:
+                    res = res_by_key.get(identity_key) if identity_key else None
+                    if res is None:
+                        _LOGGER.warning(
+                            "SET action for slot %d has no reservation; skipping", slot
+                        )
+                        continue
+                    result = await self._apply_set(coordinator, slot, res, plan.plan_id)
+                elif action.kind is ActionKind.UPDATE_TIMES:
+                    res = res_by_key.get(identity_key) if identity_key else None
+                    if res is None:
+                        _LOGGER.warning(
+                            "UPDATE_TIMES action for slot %d has no reservation; "
+                            "skipping",
+                            slot,
+                        )
+                        continue
+                    result = await self._apply_update_times(coordinator, slot, res)
+                elif action.kind is ActionKind.OVERWRITE_MANUAL_CHANGE:
+                    res = res_by_key.get(identity_key) if identity_key else None
+                    if res is None:
+                        _LOGGER.warning(
+                            "OVERWRITE_MANUAL_CHANGE action for slot %d has no "
+                            "reservation; skipping",
+                            slot,
+                        )
+                        continue
+                    result = await self._apply_overwrite_manual_change(
+                        coordinator, slot, res, action
+                    )
+                else:
+                    continue
+
+                results.append(result)
+        finally:
+            self.update_diagnostics_snapshot(plan)
+            async with self._lock:
+                self._reconciliation_active = False
+
+        return results
+
+    async def _apply_clear(
+        self,
+        coordinator: Any,
+        slot: int,
+    ) -> OperationResult:
+        """Apply a CLEAR or RETRY_CLEAR action for one slot."""
+        operation_id = str(uuid.uuid4())
+        expected_name: str | None = None
+
+        async with self._lock:
+            self._pending_fences[slot] = operation_id
+            self._pending_clear_slots[slot] = operation_id
+            override = self._overrides.get(slot)
+            if override is not None:
+                expected_name = override.get("slot_name")
+
+        result = await async_fire_clear_code(
+            coordinator, slot, expected_name=expected_name
+        )
+
+        async with self._lock:
+            current_token = self._pending_fences.get(slot)
+            if current_token != operation_id:
+                _LOGGER.warning(
+                    "Stale clear token for slot %d "
+                    "(expected %s, got %s); discarding result",
+                    slot,
+                    operation_id,
+                    current_token,
+                )
+                return OperationResult(kind="clear", slot=slot, unconfirmed=True)
+
+            if result.confirmed:
+                _LOGGER.debug("Clear confirmed for slot %d; marking free", slot)
+                self._pending_fences.pop(slot, None)
+                self._pending_clear_slots.pop(slot, None)
+                self._overrides[slot] = None
+                self._slot_uids.pop(slot, None)
+                self._slot_miss_counts.pop(slot, None)
+                self._clear_slot_error(slot)
+                # NOTE: __assign_next_slot() is intentionally NOT called here.
+                # Slot selection in the reconciliation path is determined by
+                # compute_desired_plan(), not by the deprecated _next_slot field.
+            elif result.failed:
+                _LOGGER.warning(
+                    "Clear failed for slot %d (error: %s); slot remains pending-clear",
+                    slot,
+                    result.error,
+                )
+                self._record_slot_error(slot, result.error or "clear failed")
+            elif result.lingering_name or result.lingering_pin:
+                _LOGGER.warning(
+                    "Clear not fully confirmed for slot %d "
+                    "(lingering_name=%s, lingering_pin=%s); "
+                    "slot remains pending-clear",
+                    slot,
+                    result.lingering_name,
+                    result.lingering_pin,
+                )
+                self._record_slot_error(
+                    slot,
+                    f"lingering state after clear: "
+                    f"name={result.lingering_name} pin={result.lingering_pin}",
+                )
+            else:
+                _LOGGER.debug(
+                    "Clear unconfirmed for slot %d; slot remains pending-clear", slot
+                )
+
+        return result
+
+    async def _apply_set(
+        self,
+        coordinator: Any,
+        slot: int,
+        res: Reservation,
+        plan_id: str,
+    ) -> OperationResult:
+        """Apply a SET action for one slot."""
+        import hashlib as _hashlib
+
+        operation_id = (
+            f"{plan_id}-set-{slot}-"
+            f"{_hashlib.sha256(res.identity_key.encode()).hexdigest()[:8]}"
+        )
+
+        async with self._lock:
+            self._pending_fences[slot] = operation_id
+            self._overrides[slot] = {
+                "slot_name": res.slot_name,
+                "slot_code": res.slot_code,
+                "start_time": res.buffered_start,
+                "end_time": res.buffered_end,
+            }
+            self._slot_miss_counts.pop(slot, None)
+            self.suppress_state_changes(
+                slot,
+                {
+                    f"switch.{coordinator.lockname}_code_slot_"
+                    f"{slot}_use_date_range_limits": "on",
+                    f"text.{coordinator.lockname}_code_slot_{slot}_name": (
+                        res.display_slot_name
+                    ),
+                    f"text.{coordinator.lockname}_code_slot_{slot}_pin": res.slot_code,
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_start": res.buffered_start.isoformat(),
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_end": res.buffered_end.isoformat(),
+                },
+            )
+
+        event = _SlotEvent(
+            slot_name=res.slot_name,
+            slot_code=res.slot_code,
+            start=res.start,
+            end=res.end,
+        )
+        result = await async_fire_set_code(coordinator, event, slot)
+
+        async with self._lock:
+            current_token = self._pending_fences.get(slot)
+            if current_token != operation_id:
+                _LOGGER.warning("Stale set token for slot %d; discarding result", slot)
+                return OperationResult(kind="set", slot=slot, unconfirmed=True)
+
+            if result.confirmed:
+                _LOGGER.debug(
+                    "Set confirmed for slot %d for reservation %s",
+                    slot,
+                    res.identity_key,
+                )
+                self._pending_fences.pop(slot, None)
+                self._clear_slot_error(slot)
+                # NOTE: __assign_next_slot() is intentionally NOT called here.
+                # Slot selection in the reconciliation path is determined by
+                # compute_desired_plan(), not by the deprecated _next_slot field.
+            elif result.failed:
+                _LOGGER.warning(
+                    "Set failed for slot %d (error: %s); reverting pre-assignment",
+                    slot,
+                    result.error,
+                )
+                self._pending_fences.pop(slot, None)
+                self._overrides[slot] = None
+                self._slot_uids.pop(slot, None)
+                self._record_slot_error(slot, result.error or "set failed")
+                # NOTE: __assign_next_slot() is intentionally NOT called here.
+                # Slot selection in the reconciliation path is determined by
+                # compute_desired_plan(), not by the deprecated _next_slot field.
+            else:
+                _LOGGER.debug(
+                    "Set unconfirmed for slot %d; keeping tentative assignment", slot
+                )
+                self._pending_fences.pop(slot, None)
+
+        return result
+
+    async def _apply_update_times(
+        self,
+        coordinator: Any,
+        slot: int,
+        res: Reservation,
+    ) -> OperationResult:
+        """Apply an UPDATE_TIMES action for one slot."""
+        async with self._lock:
+            self.suppress_state_changes(
+                slot,
+                {
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_start": res.buffered_start.isoformat(),
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_end": res.buffered_end.isoformat(),
+                },
+            )
+
+        event = _SlotEvent(
+            slot_name=res.slot_name,
+            slot_code=res.slot_code,
+            start=res.start,
+            end=res.end,
+        )
+        result = await async_fire_update_times(coordinator, event, slot)
+
+        if result.confirmed:
+            async with self._lock:
+                override = self._overrides.get(slot)
+                if override is not None:
+                    override["start_time"] = res.buffered_start
+                    override["end_time"] = res.buffered_end
+                    _LOGGER.debug(
+                        "update_times confirmed for slot %d; in-memory dates updated",
+                        slot,
+                    )
+
+        return result
+
+    async def _apply_overwrite_manual_change(
+        self,
+        coordinator: Any,
+        slot: int,
+        res: Reservation,
+        action: "SlotAction",
+    ) -> OperationResult:
+        """Apply an OVERWRITE_MANUAL_CHANGE action for one slot.
+
+        Logs a warning with all drift details — slot number, changed field
+        names, desired reservation identity, observed name and
+        classification from the actual-state cache — and then restores the
+        desired state via :func:`~.util.async_fire_set_code`.  Raw PIN
+        values are never written to logs; only code *presence* (boolean) is
+        reported.
+
+        Unmanaged slots never trigger this path because
+        :func:`~.reconciliation.compute_desired_plan` iterates only over
+        managed slots.
+
+        Args:
+            coordinator: The active coordinator instance.
+            slot: Keymaster slot number to overwrite.
+            res: Desired :class:`~.reconciliation.Reservation` for this slot.
+            action: The :class:`~.reconciliation.SlotAction` carrying the
+                ``OVERWRITE_MANUAL_CHANGE`` kind and drift reason string.
+
+        Returns:
+            An :class:`~.util.OperationResult` from the underlying
+            :func:`~.util.async_fire_set_code` call.
+        """
+        import hashlib as _hashlib
+
+        drift_fields: list[str] = []
+        if action.reason and action.reason.startswith("drifted fields: "):
+            drift_fields = [
+                f.strip()
+                for f in action.reason[len("drifted fields: ") :].split(",")
+                if f.strip()
+            ]
+
+        # Gather observed state for the log message.  The actual-state cache
+        # is populated by the coordinator before async_apply_plan is called.
+        # Raw PIN values are never stored in the cache; only has_code (bool).
+        actual = self._actual_state_cache.get(slot) or {}
+        observed_name: str = actual.get("name_state") or "(unknown)"
+        observed_classification: str = actual.get("classification") or "(unknown)"
+        observed_has_code: bool | None = actual.get("has_code")
+
+        _LOGGER.warning(
+            "Manual/external drift detected on managed slot %d "
+            "(reservation %s, desired name %r): "
+            "changed fields=%s, "
+            "observed name=%r, observed classification=%s, "
+            "observed has_code=%s; "
+            "restoring desired state.",
+            slot,
+            res.identity_key,
+            res.display_slot_name,
+            drift_fields,
+            observed_name,
+            observed_classification,
+            observed_has_code,
+        )
+
+        operation_id = (
+            f"overwrite-{slot}-"
+            f"{_hashlib.sha256(res.identity_key.encode()).hexdigest()[:8]}"
+        )
+
+        async with self._lock:
+            self._pending_fences[slot] = operation_id
+            self._overrides[slot] = {
+                "slot_name": res.slot_name,
+                "slot_code": res.slot_code,
+                "start_time": res.buffered_start,
+                "end_time": res.buffered_end,
+            }
+            self._slot_miss_counts.pop(slot, None)
+            self.suppress_state_changes(
+                slot,
+                {
+                    f"switch.{coordinator.lockname}_code_slot_"
+                    f"{slot}_use_date_range_limits": "on",
+                    f"text.{coordinator.lockname}_code_slot_{slot}_name": (
+                        res.display_slot_name
+                    ),
+                    f"text.{coordinator.lockname}_code_slot_{slot}_pin": res.slot_code,
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_start": res.buffered_start.isoformat(),
+                    f"datetime.{coordinator.lockname}_code_slot_"
+                    f"{slot}_date_range_end": res.buffered_end.isoformat(),
+                },
+            )
+
+        event = _SlotEvent(
+            slot_name=res.slot_name,
+            slot_code=res.slot_code,
+            start=res.start,
+            end=res.end,
+        )
+        result = await async_fire_set_code(coordinator, event, slot)
+
+        async with self._lock:
+            current_token = self._pending_fences.get(slot)
+            if current_token != operation_id:
+                _LOGGER.warning(
+                    "Stale overwrite token for slot %d; discarding result", slot
+                )
+                return OperationResult(kind="set", slot=slot, unconfirmed=True)
+
+            if result.confirmed:
+                _LOGGER.debug(
+                    "Overwrite confirmed for slot %d; desired state restored "
+                    "for reservation %s.",
+                    slot,
+                    res.identity_key,
+                )
+                self._pending_fences.pop(slot, None)
+                self._clear_slot_error(slot)
+                # NOTE: __assign_next_slot() is intentionally NOT called here.
+                # Slot selection in the reconciliation path is determined by
+                # compute_desired_plan(), not by the deprecated _next_slot field.
+            elif result.failed:
+                _LOGGER.warning(
+                    "Overwrite failed for slot %d (error: %s); "
+                    "slot may remain drifted.",
+                    slot,
+                    result.error,
+                )
+                self._pending_fences.pop(slot, None)
+                self._record_slot_error(slot, result.error or "overwrite failed")
+            else:
+                _LOGGER.debug(
+                    "Overwrite unconfirmed for slot %d; keeping tentative assignment.",
+                    slot,
+                )
+                self._pending_fences.pop(slot, None)
+
+        return result
 
     def _slot_has_matching_event(
         self,
@@ -763,11 +1511,20 @@ class EventOverrides:
         coordinator,
         calendar: list[CalendarEvent] | None = None,
     ) -> None:
-        """Check if overrides need to have a clear_code event fired.
+        """Check overrides and fire clear-code events for stale slots (greedy path).
 
         When called from within _async_update_data, pass the fresh
         calendar list directly because coordinator.data has not been
         updated yet by the DUC framework.
+
+        .. deprecated::
+            This method implements the retired greedy cleanup policy.  Stale
+            slot detection and clearing is now handled entirely by the
+            reconciliation coordinator via ``compute_desired_plan`` /
+            ``async_apply_plan`` (``ActionKind.CLEAR`` / ``RETRY_CLEAR``).
+            The coordinator no longer calls this method.  The method is
+            retained as a backward-compatible shim; production code must
+            not invoke it.
         """
         _LOGGER.debug("In EventOverrides.async_check_overrides")
 
@@ -857,17 +1614,44 @@ class EventOverrides:
                 if clear_code:
                     _LOGGER.debug("Firing clear code for slot %s", slot)
                     try:
-                        await async_fire_clear_code(
+                        result = await async_fire_clear_code(
                             coordinator, slot, expected_name=self.get_slot_name(slot)
                         )
+                    except asyncio.CancelledError:
+                        raise
                     except Exception:
                         _LOGGER.exception(
-                            "Failed to fire clear code for slot %d; "
-                            "freeing slot so new events can be assigned. "
-                            "The stale code may be overwritten when a "
-                            "future event is programmed into this slot.",
+                            "Unexpected error firing clear code for slot %d; "
+                            "slot remains occupied to prevent "
+                            "double-assignment.",
                             slot,
                         )
+                        continue
+
+                    if not isinstance(result, OperationResult):
+                        result = OperationResult(
+                            kind="clear",
+                            slot=slot,
+                            unconfirmed=True,
+                        )
+                    if (
+                        not result.confirmed
+                        or result.failed
+                        or result.lingering_name
+                        or result.lingering_pin
+                    ):
+                        _LOGGER.warning(
+                            "Clear not confirmed for slot %d "
+                            "(failed=%s, unconfirmed=%s, "
+                            "lingering_name=%s, lingering_pin=%s); "
+                            "slot remains occupied.",
+                            slot,
+                            result.failed,
+                            result.unconfirmed,
+                            result.lingering_name,
+                            result.lingering_pin,
+                        )
+                        continue
 
                     self._overrides[slot] = None
                     self._slot_uids.pop(slot, None)

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -979,14 +979,26 @@ def _has_competing_reservation(
     if current_reservations is None:
         return False
     candidate_mapping = persisted_mappings.get(candidate_key, {})
+    include_observed = _is_adopted_mapping(candidate_key, candidate_mapping)
+    candidate_dates_match_this = _mapping_dates_match_reservation(
+        candidate_mapping,
+        this_reservation,
+        include_observed=include_observed,
+    )
     for other in current_reservations:
         if other.identity_key == this_reservation.identity_key:
             continue  # skip self
         if _mapping_name_matches_reservation(
             candidate_mapping,
             other,
-            include_observed=_is_adopted_mapping(candidate_key, candidate_mapping),
+            include_observed=include_observed,
         ):
+            if candidate_dates_match_this and not _mapping_dates_match_reservation(
+                candidate_mapping,
+                other,
+                include_observed=include_observed,
+            ):
+                continue
             return True
     return False
 
@@ -1124,7 +1136,6 @@ def find_reservation_rematch(
         if _mapping_dates_match_reservation(
             mapping,
             reservation,
-            include_observed=_is_adopted_mapping(mapping_key, mapping),
         ):
             name_time_matches.append(mapping_key)
 
@@ -1184,7 +1195,7 @@ def find_reservation_rematch(
         ]
         if len(date_matches) == 1:
             return RematchResult(
-                kind=RematchKind.NAME_TIME,
+                kind=RematchKind.CONTINUITY,
                 matched_identity_key=date_matches[0],
             )
         return RematchResult(

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -1,0 +1,1713 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Slot reconciliation data models for Rental Control.
+
+Provides typed dataclasses, enumerations, and identity-matching helpers
+used by the slot reconciliation system: the deterministic planner that
+assigns RC-managed Keymaster slots to calendar reservations.
+
+Exported names
+--------------
+FINGERPRINT_VERSION
+    Version tag for the v1 primary reservation fingerprint scheme.
+SlotStatus
+    Physical/logical state of a managed Keymaster slot.
+ActionKind
+    Enumeration of reconciliation action types.
+SlotAction
+    A single planned reconciliation action targeting one slot.
+Reservation
+    Normalized calendar stay eligible for slot planning.
+ManagedSlot
+    A numbered Keymaster slot inside the RC-managed range.
+PlannedSlot
+    Desired-vs-actual comparison record for one managed slot.
+DesiredPlan
+    Deterministic refresh result containing the full slot diff.
+StoredIdentity
+    Stable identity fields persisted in the HA Store.
+StoredActual
+    Redacted last-observed Keymaster state persisted in the HA Store.
+SlotMapping
+    Top-level HA Store record for one persisted slot assignment.
+RematchKind
+    Classification of a reservation identity rematch result.
+RematchResult
+    Result of a reservation identity rematch lookup.
+normalize_slot_name_for_fingerprint
+    Return the stable normalized form of a slot name for fingerprinting.
+make_reservation_fingerprint
+    Compute the stable versioned identity fingerprint for a reservation.
+extract_booking_aliases
+    Extract booking/confirmation aliases from event text.
+find_reservation_rematch
+    Find the best identity rematch for a reservation in persisted mappings.
+compute_desired_plan
+    Compute the deterministic desired slot plan for a set of reservations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime
+from datetime import timezone
+from enum import Enum
+import hashlib
+import logging
+import re
+from typing import Any
+
+# aislop-ignore-file complexity/file-too-large complexity/function-too-long -- Existing module size is outside this emergency fix scope.
+
+FINGERPRINT_VERSION = "v1"
+"""Version tag for the primary reservation fingerprint scheme.
+
+If the fingerprint algorithm changes in a future release this tag
+must be bumped (e.g. to ``"v2"``) so that v1 and v2 fingerprints
+occupy separate namespaces and old persisted keys can be preserved
+in :attr:`Reservation.fingerprint_history` for conservative rematch.
+"""
+
+# Airbnb confirmation codes: one uppercase letter followed by nine
+# uppercase alphanumeric characters (e.g. "HMXXXXXXXX").
+_LOGGER = logging.getLogger(__name__)
+
+_AIRBNB_CONF_RE = re.compile(r"(?<![A-Z0-9])([A-Z][A-Z0-9]{9})(?![A-Z0-9])")
+
+
+class SlotStatus(str, Enum):
+    """Physical/logical state of a managed Keymaster slot.
+
+    Values map 1-to-1 to the string literals stored in the HA Store so
+    that serialisation is a no-op cast.
+
+    Lifecycle transitions::
+
+        FREE  ──set──►  OCCUPIED  ──desired gone──►  PENDING_CLEAR
+                                                        │         │
+                                             confirmed  │  failed │
+                                                        ▼         ▼
+                                                      FREE     BLOCKED
+                                                        ▲         │
+                                                        └─confirmed┘
+        *  ──►  PHANTOM : name present, PIN absent/slot disabled
+        *  ──►  UNKNOWN : actual entity state unreadable
+    """
+
+    FREE = "free"
+    OCCUPIED = "occupied"
+    PENDING_CLEAR = "pending_clear"
+    BLOCKED = "blocked"
+    PHANTOM = "phantom"
+    UNKNOWN = "unknown"
+
+
+class ActionKind(str, Enum):
+    """Reconciliation action type for one managed Keymaster slot.
+
+    Used by :class:`SlotAction` and :class:`PlannedSlot` to label the
+    physical operation (or absence of operation) that the planner
+    determined for a slot during a single refresh cycle.
+    """
+
+    NOOP = "noop"
+    """Actual already matches desired; no Keymaster service call needed."""
+
+    SET = "set"
+    """Slot is confirmed free; write name, code, and date range."""
+
+    UPDATE_TIMES = "update_times"
+    """Same reservation and code; only buffered date-range changed."""
+
+    CLEAR = "clear"
+    """Slot contains stale, duplicate, phantom, or expired state."""
+
+    RETRY_CLEAR = "retry_clear"
+    """Prior clear attempt unconfirmed; increment retry count and re-clear."""
+
+    OVERWRITE_MANUAL_CHANGE = "overwrite_manual_change"
+    """Actual state drifted from desired; restore desired and log drift."""
+
+    BLOCKED = "blocked"
+    """Actual state unknown or clear unconfirmed; no assignment allowed."""
+
+
+@dataclass(slots=True)
+class SlotAction:
+    """A single planned reconciliation action for one managed Keymaster slot.
+
+    Instances are collected in :attr:`DesiredPlan.actions` and applied
+    in order by the apply-plan phase.  Each instance couples an
+    :class:`ActionKind` with the target slot and optional identity
+    context so that the apply loop does not need to re-derive
+    per-slot context.
+
+    Attributes:
+        kind: Type of action to perform.
+        slot: Physical Keymaster slot number to act on.
+        identity_key: Identity of the reservation being set or cleared;
+            ``None`` for clears where no reservation is being assigned.
+        reason: Optional human-readable explanation, e.g. overflow
+            cause or drift description.
+    """
+
+    kind: ActionKind
+    slot: int
+    identity_key: str | None = None
+    reason: str | None = None
+
+
+@dataclass(slots=True)
+class Reservation:
+    """Normalized calendar stay eligible for slot planning.
+
+    A ``Reservation`` is constructed from a parsed iCal event and
+    carries all fields required by the planner to decide whether and
+    where to assign a Keymaster slot.
+
+    The ``identity_key`` is a stable fingerprint derived from the
+    normalized slot name, start, end, and entry scope.  It is the
+    primary stable identifier used by the Store and the planner.
+    ``uid_aliases`` and ``booking_aliases`` are *volatile* secondary
+    identifiers that may change between feed refreshes.
+
+    ``slot_code`` is never written to the HA Store; it is an in-memory
+    field used only during the current reconciliation cycle.
+
+    Attributes:
+        identity_key: Versioned stable fingerprint of normalized slot
+            name, start, end, and entry scope.
+        start: Reservation check-in/access start before lock-code
+            buffer.
+        end: Reservation checkout/access end before lock-code buffer.
+        buffered_start: Keymaster date-range start after existing
+            before-buffer.
+        buffered_end: Keymaster date-range end after existing
+            after-buffer.
+        summary: Calendar summary for sensor display.
+        slot_name: Unprefixed, untrimmed guest-facing slot name from
+            existing extraction logic.
+        display_slot_name: Prefixed/trimmed Keymaster name computed at
+            write time.
+        slot_code: Generated or retained code for current planning; not
+            persisted raw in Store.
+        uid_aliases: Volatile iCal UIDs seen for this reservation.
+            Aliases only, not primary identity.
+        booking_aliases: Optional extracted booking or confirmation
+            identifiers when available.
+        fingerprint_history: Prior stable fingerprints for conservative
+            rematch after date or UID changes.
+        eligible: True when current parser/config rules include the
+            reservation.
+        protected_active: True for a currently checked-in guest inside
+            the active stay window.
+        checked_out: True when check-in tracking says the stay has
+            checked out.
+        missing_count: Consecutive refreshes missing from feed while
+            persisted and assigned.  0, 1, or 2 keeps the slot; 3
+            makes the reservation clearable unless protected.
+        desired_slot: Slot selected by the current desired plan.
+        overflow_reason: Why the reservation is not assigned, e.g.
+            ``"capacity"`` or ``"blocked_clear"``.
+    """
+
+    identity_key: str
+    start: datetime
+    end: datetime
+    buffered_start: datetime
+    buffered_end: datetime
+    summary: str
+    slot_name: str
+    display_slot_name: str
+    slot_code: str = field(repr=False)
+    uid_aliases: set[str] = field(default_factory=set)
+    booking_aliases: set[str] = field(default_factory=set)
+    fingerprint_history: set[str] = field(default_factory=set)
+    eligible: bool = True
+    protected_active: bool = False
+    checked_out: bool = False
+    missing_count: int = 0
+    desired_slot: int | None = None
+    overflow_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate Reservation field invariants.
+
+        Raises:
+            ValueError: If ``start`` is not strictly before ``end``,
+                or if ``missing_count`` is negative.
+        """
+        if self.start >= self.end:
+            raise ValueError(
+                f"Reservation start must be strictly before end: "
+                f"{self.start!r} >= {self.end!r}"
+            )
+        if self.missing_count < 0:
+            raise ValueError(
+                f"missing_count must be non-negative, got {self.missing_count}"
+            )
+
+
+@dataclass(slots=True)
+class ManagedSlot:
+    """A numbered Keymaster slot inside the RC-managed range.
+
+    ``ManagedSlot`` holds both the *desired* state from the current
+    :class:`DesiredPlan` and the *observed* state read from Keymaster
+    entities during the most recent refresh.  The planner compares the
+    two to determine which :class:`ActionKind` applies.
+
+    Only slots where :attr:`managed` is ``True`` are ever modified by
+    the reconciliation system.  Slots with
+    ``status in {PENDING_CLEAR, BLOCKED, UNKNOWN}`` cannot receive a
+    different reservation until their status resolves.
+
+    Attributes:
+        slot: Physical Keymaster slot number.
+        managed: True only inside the configured
+            ``start_slot .. start_slot + max_events - 1`` range.
+        status: Current physical/logical state of the slot.
+        actual_name: Observed Keymaster slot name, normalized for
+            unknown/unavailable values.
+        actual_code_present: Whether the PIN text entity contains a
+            usable code.  ``None`` means the state was unreadable.
+        actual_start: Observed Keymaster date-range start.
+        actual_end: Observed Keymaster date-range end.
+        date_range_enabled: Observed Keymaster use-date-range switch
+            state.
+        enabled: Observed Keymaster slot enabled switch state.
+        desired_identity_key: Desired reservation for this slot in the
+            current plan.
+        persisted_identity_key: Previously stored reservation for this
+            slot.
+        blocked_reason: Reason the slot cannot be reused.
+        retry_count: Consecutive failed physical operations for this
+            slot.
+        last_operation_id: Reconcile operation token used to classify
+            callback echoes.
+        dirty_during_operation: True when a callback observed state
+            while an operation token was pending.
+        last_error: Description of the most recent failed operation for
+            this slot, if any.  Populated by the apply-plan phase and
+            carried forward to the next refresh cycle for diagnostics.
+            Not persisted in the HA Store.
+    """
+
+    slot: int
+    managed: bool
+    status: SlotStatus = SlotStatus.UNKNOWN
+    actual_name: str | None = None
+    actual_code_present: bool | None = None
+    actual_start: datetime | None = None
+    actual_end: datetime | None = None
+    date_range_enabled: bool | None = None
+    enabled: bool | None = None
+    desired_identity_key: str | None = None
+    persisted_identity_key: str | None = None
+    blocked_reason: str | None = None
+    retry_count: int = 0
+    last_operation_id: str | None = None
+    dirty_during_operation: bool = False
+    last_error: str | None = None
+
+
+@dataclass(slots=True)
+class PlannedSlot:
+    """Desired-vs-actual comparison record for one managed slot.
+
+    One ``PlannedSlot`` is produced per managed slot during each
+    refresh and stored in :attr:`DesiredPlan.slots`.  It captures the
+    planner's side-by-side view of what is desired versus what was
+    actually observed so that diagnostics can explain every decision.
+
+    Attributes:
+        slot: Physical Keymaster slot number.
+        desired_identity_key: Identity key the planner wants in this
+            slot, or ``None`` if the slot should be empty.
+        actual_classification: Observed slot classification string from
+            the Keymaster entity read (e.g. ``"free"``,
+            ``"occupied"``, ``"phantom"``).
+        action: Reconciliation action the planner determined for this
+            slot.
+        pending_reason: Human-readable explanation when the action is
+            ``ActionKind.BLOCKED`` or ``ActionKind.RETRY_CLEAR``.
+        retry_count: Copy of :attr:`ManagedSlot.retry_count` at plan
+            time, included for diagnostics.
+        last_error: Description of the most recent failed operation for
+            this slot, if any.
+    """
+
+    slot: int
+    desired_identity_key: str | None
+    actual_classification: str
+    action: ActionKind
+    pending_reason: str | None = None
+    retry_count: int = 0
+    last_error: str | None = None
+
+
+@dataclass(slots=True)
+class DesiredPlan:
+    """Deterministic refresh result containing the full slot diff.
+
+    Produced once per coordinator refresh cycle, ``DesiredPlan``
+    records every decision made by the planner for the current set of
+    eligible reservations and managed slots.  It is the single source
+    of truth consumed by the apply-plan phase.
+
+    Invariants:
+        - ``len(selected) <= max_events`` unless protected active
+          reservations exceed capacity; capacity violations are
+          diagnostic-only.
+        - Each selected identity appears exactly once.
+        - Each selected slot appears exactly once.
+        - No selected reservation is assigned behind a farther
+          unprotected reservation once physical operations are
+          confirmed.
+
+    Attributes:
+        plan_id: Refresh-scoped identifier for logging and operation
+            tokens.
+        generated_at: Time the plan was computed.
+        selected: Mapping from reservation identity key to desired
+            slot number.
+        protected: Set of selected identity keys protected by
+            checked-in state.
+        overflow: Mapping from unassigned eligible identity keys to
+            human-readable overflow reasons.
+        slots: Per-slot desired-vs-actual comparison keyed by slot
+            number.
+        actions: Ordered list of actions to apply during apply-plan.
+        diagnostics: Freeform capture of desired-vs-actual state for
+            support diagnostics.
+    """
+
+    plan_id: str
+    generated_at: datetime
+    selected: dict[str, int] = field(default_factory=dict)
+    protected: set[str] = field(default_factory=set)
+    overflow: dict[str, str] = field(default_factory=dict)
+    slots: dict[int, PlannedSlot] = field(default_factory=dict)
+    actions: list[SlotAction] = field(default_factory=list)
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> list[str]:
+        """Return a list of invariant violations found in this plan.
+
+        Checks that each selected identity key appears exactly once and
+        that each selected slot number appears exactly once.  Returns
+        an empty list when all invariants hold.  Callers may raise on a
+        non-empty result or record the violations as diagnostics.
+
+        Returns:
+            List of human-readable violation messages; empty when the
+            plan is internally consistent.
+        """
+        violations: list[str] = []
+        seen_identities: set[str] = set()
+        seen_slots: set[int] = set()
+        for identity_key, slot in self.selected.items():
+            if identity_key in seen_identities:
+                violations.append(
+                    f"Identity key {identity_key!r} appears more than once in selected."
+                )
+            seen_identities.add(identity_key)
+            if slot in seen_slots:
+                violations.append(
+                    f"Slot {slot} is claimed by more than one reservation in selected."
+                )
+            seen_slots.add(slot)
+        return violations
+
+
+@dataclass(slots=True)
+class StoredIdentity:
+    """Stable identity fields persisted in the HA Store.
+
+    ``StoredIdentity`` captures the subset of :class:`Reservation`
+    fields written to persistent storage.  These fields are sufficient
+    to re-identify a reservation after a Home Assistant restart without
+    re-fetching the calendar feed.
+
+    Note that ``uid_aliases`` and ``booking_aliases`` use ``list``
+    (JSON-serializable) rather than the ``set`` used in
+    :class:`Reservation`; the ordering is not significant.
+
+    Attributes:
+        identity_key: Primary stable fingerprint.
+        summary: Calendar summary for sensor display.
+        slot_name: Unprefixed, untrimmed guest-facing slot name.
+        start: Optional ISO-8601 reservation start used for NAME_TIME rematch.
+        end: Optional ISO-8601 reservation end used for NAME_TIME rematch.
+        uid_aliases: Volatile iCal UIDs seen for this reservation.
+        booking_aliases: Optional extracted booking/confirmation IDs.
+    """
+
+    identity_key: str
+    summary: str
+    slot_name: str
+    start: str | None = None
+    end: str | None = None
+    uid_aliases: list[str] = field(default_factory=list)
+    booking_aliases: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class StoredActual:
+    """Redacted last-observed Keymaster state persisted in the HA Store.
+
+    Raw PIN values are **never** stored.  This record holds only
+    redacted or non-sensitive fields sufficient for drift detection
+    and migration diagnostics.
+
+    Attributes:
+        slot: Slot number.
+        classification: Last observed slot classification, e.g.
+            ``"free"``, ``"occupied"``, or ``"phantom"``.
+        name_state: Last observed name entity state after
+            unknown/unavailable normalization.
+        has_code: Whether the PIN entity contained a usable code at
+            last observation.  The raw PIN value is never stored.
+        start_state: Last observed Keymaster date-range start.
+        end_state: Last observed Keymaster date-range end.
+        use_date_range: Last observed use-date-range switch state.
+        enabled: Last observed slot-enabled switch state.
+    """
+
+    slot: int
+    classification: str
+    name_state: str | None = None
+    has_code: bool | None = None
+    start_state: datetime | None = None
+    end_state: datetime | None = None
+    use_date_range: bool | None = None
+    enabled: bool | None = None
+
+
+@dataclass(slots=True)
+class SlotMapping:
+    """Top-level HA Store record for one persisted slot assignment.
+
+    One ``SlotMapping`` is written per managed slot assignment and
+    survives Home Assistant restarts.  The Store layer enforces the
+    invariant that no two mappings may claim the same slot with
+    ``status == "occupied"`` simultaneously.
+
+    Store invariants (enforced by the persistence layer):
+        - No two mappings may claim the same slot unless at most one
+          is ``"occupied"`` and the other is historical/overflow
+          diagnostic state.
+        - ``"pending_set"`` and ``"pending_clear"`` slots are fenced
+          after restart until a refresh verifies the physical state.
+        - Raw PIN values are not stored; only
+          :attr:`StoredActual.has_code` for drift detection.
+
+    Attributes:
+        schema_version: Store schema version.  Starts at ``1``.
+        entry_id: Config entry scope.
+        identity_key: Primary Reservation identity.
+        slot: Persisted desired/last confirmed slot.
+        status: Mapping status string: ``"occupied"``,
+            ``"pending_set"``, ``"pending_clear"``, ``"blocked"``,
+            or ``"overflow"``.
+        identity: Stable fields and aliases for the reservation.
+        last_observed_actual: Redacted last actual state for
+            diagnostics and migration.
+        updated_at: Last Store update time.
+        fingerprint_history: Prior fingerprints for conservative
+            rematch after date shifts.
+        missing_count: Consecutive feed misses while persisted.
+        lockname: Keymaster lock scope for migration checks.
+        start_slot: Managed range start at time of record creation.
+        max_slots: Managed range length at time of record creation.
+        operation_id: Persisted fence token for an in-flight set or
+            clear.
+        operation_kind: ``"set"`` or ``"clear"`` while an operation
+            is pending.
+        pending_set_since: When a set became in-flight and not yet
+            verified.
+        pending_clear_since: When clear became unconfirmed.
+    """
+
+    schema_version: int
+    entry_id: str
+    identity_key: str
+    slot: int
+    status: str
+    identity: StoredIdentity
+    last_observed_actual: StoredActual
+    updated_at: datetime
+    fingerprint_history: list[str] = field(default_factory=list)
+    missing_count: int = 0
+    lockname: str | None = None
+    start_slot: int = 0
+    max_slots: int = 0
+    operation_id: str | None = None
+    operation_kind: str | None = None
+    pending_set_since: datetime | None = None
+    pending_clear_since: datetime | None = None
+
+    def __post_init__(self) -> None:
+        """Validate SlotMapping field invariants.
+
+        Raises:
+            ValueError: If ``missing_count`` is negative, or if
+                ``schema_version`` is less than 1.
+        """
+        if self.schema_version < 1:
+            raise ValueError(f"schema_version must be >= 1, got {self.schema_version}")
+        if self.missing_count < 0:
+            raise ValueError(
+                f"missing_count must be non-negative, got {self.missing_count}"
+            )
+
+
+def normalize_slot_name_for_fingerprint(slot_name: str) -> str:
+    """Return the stable normalized form of a slot name for fingerprinting.
+
+    Strips leading/trailing whitespace and applies Unicode-aware
+    ``casefold()`` so names that differ only in case or surrounding
+    whitespace produce identical fingerprints.
+
+    Args:
+        slot_name: Unprefixed, untrimmed guest-facing slot name.
+
+    Returns:
+        Casefold-normalized, stripped slot name.
+    """
+    return slot_name.strip().casefold()
+
+
+def _dt_to_utc_iso(dt: datetime) -> str:
+    """Convert *dt* to a UTC ISO-8601 string for fingerprint computation.
+
+    Naive datetimes are treated as UTC.  The output format is always
+    ``YYYY-MM-DDTHH:MM:SS+00:00`` to ensure a single canonical
+    representation regardless of the original timezone offset.
+
+    Args:
+        dt: Input datetime, timezone-aware or naive.
+
+    Returns:
+        Fixed-format UTC ISO-8601 string.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+def make_reservation_fingerprint(
+    entry_id: str,
+    slot_name: str,
+    start: datetime,
+    end: datetime,
+) -> str:
+    """Compute the stable versioned identity fingerprint for a reservation.
+
+    The fingerprint is a 64-character lowercase SHA-256 hexdigest of a
+    canonical string built from:
+
+    - :data:`FINGERPRINT_VERSION` prefix (``"v1"``),
+    - *entry_id* (config-entry scope),
+    - normalized, casefold-stripped *slot_name*,
+    - UTC ISO-8601 *start*, and
+    - UTC ISO-8601 *end*.
+
+    The fingerprint deliberately excludes volatile calendar UIDs so that
+    platform UID churn does not change the primary identity key.
+
+    Args:
+        entry_id: Config entry ID that scopes this fingerprint to one
+            integration instance.
+        slot_name: Unprefixed, untrimmed guest-facing slot name.  Will
+            be normalized via :func:`normalize_slot_name_for_fingerprint`.
+        start: Reservation start datetime (any timezone; converted to
+            UTC before hashing).
+        end: Reservation end datetime (any timezone; converted to UTC
+            before hashing).
+
+    Returns:
+        64-character lowercase SHA-256 hexdigest string.
+    """
+    normalized_name = normalize_slot_name_for_fingerprint(slot_name)
+    start_utc = _dt_to_utc_iso(start)
+    end_utc = _dt_to_utc_iso(end)
+    canonical = (
+        f"{FINGERPRINT_VERSION}:{entry_id}:{normalized_name}:{start_utc}:{end_utc}"
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def extract_booking_aliases(summary: str, description: str) -> set[str]:
+    """Extract booking/confirmation aliases from an event's text fields.
+
+    Searches the combined *summary* and *description* text for known
+    booking-platform confirmation codes.  Currently extracts:
+
+    - **Airbnb** confirmation codes: one uppercase letter followed by
+      nine uppercase alphanumeric characters (e.g. ``HMXXXXXXXX``).
+
+    The extracted aliases are stored as :attr:`Reservation.booking_aliases`
+    and used as secondary signals in :func:`find_reservation_rematch`.
+
+    Args:
+        summary: Raw iCal SUMMARY field value.
+        description: Raw iCal DESCRIPTION field value; may be empty or
+            ``None``-like (empty string is safe).
+
+    Returns:
+        Set of extracted booking identifier strings; empty when none
+        are detected.
+    """
+    aliases: set[str] = set()
+    text = f"{summary} {description or ''}"
+    for m in _AIRBNB_CONF_RE.finditer(text):
+        aliases.add(m.group(1))
+    return aliases
+
+
+class RematchKind(str, Enum):
+    """Classification of a reservation identity rematch result.
+
+    Values follow the six-rule matching hierarchy from R-002 in
+    ``specs/012-slot-reconciliation/research.md``.  Lower-numbered rules
+    take precedence: :func:`find_reservation_rematch` returns the *first*
+    matching rule for each candidate reservation.
+    """
+
+    EXACT = "exact"
+    """Rule 1: primary fingerprint found unchanged in persisted mappings."""
+
+    UID_ALIAS = "uid_alias"
+    """Rule 2: a volatile UID alias overlaps; name also matches.
+
+    :attr:`RematchResult.date_shifted` is always ``True`` when this
+    kind is returned, because if the dates had not changed the primary
+    fingerprint would have matched under rule 1 instead.
+    """
+
+    BOOKING_ALIAS = "booking_alias"
+    """Rule 3: a booking/confirmation alias overlaps; name also matches."""
+
+    NAME_TIME = "name_time"
+    """Rule 4: normalized name plus exact UTC start/end match.
+
+    Triggered when no alias evidence is available but the persisted
+    identity dict's ``slot_name``, ``start``, and ``end`` match the
+    incoming reservation exactly.  Acts as a migration safety net.
+    """
+
+    CONTINUITY = "continuity"
+    """Rule 5: conservative continuity rematch.
+
+    Exactly one persisted mapping is compatible based on fingerprint
+    history, booking aliases, or normalized name with actual-slot
+    evidence, and no other current reservation competes for it.
+    """
+
+    AMBIGUOUS = "ambiguous"
+    """Two or more candidates are equally compatible; no rematch is made.
+
+    Can arise from rule 2 (multiple UID alias matches), rule 3 (multiple
+    booking alias matches), or rule 5 (multiple continuity-compatible
+    mappings).  :attr:`RematchResult.ambiguous_keys` lists all
+    compatible candidates for diagnostic capture.
+    """
+
+    NO_MATCH = "no_match"
+    """No compatible persisted mapping was found under any rule."""
+
+
+@dataclass(slots=True)
+class RematchResult:
+    """Result of a reservation identity rematch lookup.
+
+    Produced by :func:`find_reservation_rematch` and consumed by the
+    coordinator's identity-resolution step to decide whether and how
+    to update the persisted slot mapping.
+
+    Attributes:
+        kind: Classification of the match found.
+        matched_identity_key: Primary identity key of the persisted
+            mapping that matched.  ``None`` for ``AMBIGUOUS`` and
+            ``NO_MATCH`` results.
+        date_shifted: ``True`` when the match was established via a UID
+            alias but the incoming reservation's dates differ from the
+            persisted fingerprint.  Always ``False`` for non-UID-alias
+            matches.  When ``True`` and ``should_update_code`` is also
+            ``True`` in the coordinator config, the coordinator should
+            regenerate the access code alongside the date update.
+        ambiguous_keys: Identity keys of all compatible candidates when
+            *kind* is ``AMBIGUOUS``; empty otherwise.
+    """
+
+    kind: RematchKind
+    matched_identity_key: str | None
+    date_shifted: bool = False
+    ambiguous_keys: list[str] = field(default_factory=list)
+
+
+def _get_nested(d: dict[str, Any], *keys: str) -> Any:
+    """Safely navigate nested dict keys; return ``None`` on any miss."""
+    current: Any = d
+    for k in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(k)
+    return current
+
+
+def _normalized_name_forms(reservation: Reservation) -> set[str]:
+    """Return normalized reservation names that may appear in Keymaster."""
+    forms = {normalize_slot_name_for_fingerprint(reservation.slot_name)}
+    if reservation.display_slot_name:
+        forms.add(normalize_slot_name_for_fingerprint(reservation.display_slot_name))
+    return {form for form in forms if form}
+
+
+def _mapping_name_forms(
+    mapping: dict[str, Any],
+    actual_slot_names: dict[int, str] | None,
+    *,
+    include_observed: bool = False,
+) -> set[str]:
+    """Return normalized persisted and observed names for a mapping."""
+    forms: set[str] = set()
+    persisted_name = _get_nested(mapping, "identity", "slot_name")
+    if persisted_name:
+        forms.add(normalize_slot_name_for_fingerprint(str(persisted_name)))
+
+    if include_observed:
+        last_observed_name = _get_nested(mapping, "last_observed_actual", "name_state")
+        if last_observed_name:
+            forms.add(normalize_slot_name_for_fingerprint(str(last_observed_name)))
+
+    if include_observed and actual_slot_names is not None:
+        slot_num: int | None = mapping.get("slot")
+        if slot_num is not None:
+            actual_name = actual_slot_names.get(slot_num)
+            if actual_name:
+                forms.add(normalize_slot_name_for_fingerprint(actual_name))
+
+    return {form for form in forms if form}
+
+
+def _mapping_name_matches_reservation(
+    mapping: dict[str, Any],
+    reservation: Reservation,
+    actual_slot_names: dict[int, str] | None = None,
+    *,
+    include_observed: bool = False,
+) -> bool:
+    """Return whether a mapping name matches a reservation name form.
+
+    Adopted slots often only have the observed Keymaster display name,
+    which may be prefixed or trimmed compared with the full calendar feed
+    name.  Compare all persisted/observed forms against both the full
+    slot name and the display name the coordinator would write.
+    """
+    return bool(
+        _mapping_name_forms(
+            mapping, actual_slot_names, include_observed=include_observed
+        )
+        & _normalized_name_forms(reservation)
+    )
+
+
+def _is_adopted_mapping(mapping_key: str, mapping: dict[str, Any]) -> bool:
+    """Return whether a persisted mapping was created by first-upgrade adoption."""
+    identity_key = _get_nested(mapping, "identity", "identity_key")
+    return mapping_key.startswith("adopted.") or (
+        isinstance(identity_key, str) and identity_key.startswith("adopted.")
+    )
+
+
+def _as_utc_datetime(value: Any) -> datetime | None:
+    """Parse a stored datetime value and normalize it to UTC."""
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    else:
+        return None
+
+    return (
+        parsed.astimezone(timezone.utc)
+        if parsed.tzinfo
+        else parsed.replace(tzinfo=timezone.utc)
+    )
+
+
+def _mapping_dates_match_reservation(
+    mapping: dict[str, Any],
+    reservation: Reservation,
+    *,
+    include_observed: bool = False,
+) -> bool:
+    """Return whether stored identity or observed dates match a reservation."""
+    reservation_start = _as_utc_datetime(reservation.start)
+    reservation_end = _as_utc_datetime(reservation.end)
+    identity_start = _as_utc_datetime(_get_nested(mapping, "identity", "start"))
+    identity_end = _as_utc_datetime(_get_nested(mapping, "identity", "end"))
+    if (
+        identity_start is not None
+        and identity_end is not None
+        and reservation_start == identity_start
+        and reservation_end == identity_end
+    ):
+        return True
+
+    if not include_observed:
+        return False
+
+    buffered_start = _as_utc_datetime(reservation.buffered_start)
+    buffered_end = _as_utc_datetime(reservation.buffered_end)
+    observed_start = _as_utc_datetime(
+        _get_nested(mapping, "last_observed_actual", "start_state")
+    )
+    observed_end = _as_utc_datetime(
+        _get_nested(mapping, "last_observed_actual", "end_state")
+    )
+    return (
+        observed_start is not None
+        and observed_end is not None
+        and buffered_start == observed_start
+        and buffered_end == observed_end
+    )
+
+
+def _is_continuity_compatible(
+    reservation: Reservation,
+    mapping_key: str,
+    mapping: dict[str, Any],
+    actual_slot_names: dict[int, str] | None,
+) -> bool:
+    """Return ``True`` if *mapping* is continuity-compatible with *reservation*.
+
+    A mapping is continuity-compatible when:
+
+    1. Normalized names match (required baseline).
+    2. At least one of the following weak signals is present:
+
+       a. The reservation's current identity key appears in the mapping's
+          ``fingerprint_history`` (a prior fingerprint for this mapping).
+       b. The mapping's primary ``identity_key`` appears in the
+          reservation's :attr:`Reservation.fingerprint_history`.
+       c. A booking alias overlaps between the two records.
+       d. The actual Keymaster slot name for the mapping's slot matches
+          one of the reservation's normalized name forms.
+
+    Args:
+        reservation: The incoming reservation candidate.
+        mapping_key: Identity key of the persisted mapping being tested.
+        mapping: Raw Store mapping dict.
+        actual_slot_names: Optional mapping of slot number → current
+            Keymaster slot name for actual-slot continuity checks.
+
+    Returns:
+        ``True`` if the mapping is continuity-compatible with the
+        reservation; ``False`` otherwise.
+    """
+    if not _mapping_name_matches_reservation(
+        mapping,
+        reservation,
+        actual_slot_names,
+        include_observed=_is_adopted_mapping(mapping_key, mapping),
+    ):
+        return False
+
+    # Signal (a): reservation's current fingerprint in mapping's history
+    fp_history: list[str] = mapping.get("fingerprint_history") or []
+    if reservation.identity_key in fp_history:
+        return True
+
+    # Signal (b): persisted key in reservation's fingerprint history
+    if mapping_key in reservation.fingerprint_history:
+        return True
+
+    # Signal (c): booking alias overlap
+    persisted_booking: set[str] = set(
+        _get_nested(mapping, "identity", "booking_aliases") or []
+    )
+    if persisted_booking & reservation.booking_aliases:
+        return True
+
+    # Signal (d): actual Keymaster slot name matches
+    if actual_slot_names is not None:
+        slot_num: int | None = mapping.get("slot")
+        if slot_num is not None:
+            actual_name = actual_slot_names.get(slot_num)
+            if actual_name is not None:
+                if normalize_slot_name_for_fingerprint(
+                    actual_name
+                ) in _normalized_name_forms(reservation):
+                    return True
+
+    return False
+
+
+def _has_competing_reservation(
+    candidate_key: str,
+    persisted_mappings: dict[str, dict[str, Any]],
+    current_reservations: list[Reservation] | None,
+    this_reservation: Reservation,
+) -> bool:
+    """Return ``True`` if another current reservation also matches *candidate_key*.
+
+    Used by :func:`find_reservation_rematch` to verify that a single
+    continuity candidate is not also claimed by another current
+    reservation (which would make the rematch ambiguous even though
+    only one persisted mapping is compatible).
+
+    Args:
+        candidate_key: Identity key of the single compatible mapping.
+        persisted_mappings: Full raw Store mapping dict.
+        current_reservations: All current reservations being reconciled.
+        this_reservation: The reservation being matched (excluded from
+            the competition check).
+
+    Returns:
+        ``True`` if at least one other current reservation competes for
+        the candidate mapping by normalized name; ``False`` otherwise.
+    """
+    if current_reservations is None:
+        return False
+    candidate_mapping = persisted_mappings.get(candidate_key, {})
+    for other in current_reservations:
+        if other.identity_key == this_reservation.identity_key:
+            continue  # skip self
+        if _mapping_name_matches_reservation(
+            candidate_mapping,
+            other,
+            include_observed=_is_adopted_mapping(candidate_key, candidate_mapping),
+        ):
+            return True
+    return False
+
+
+def find_reservation_rematch(
+    reservation: Reservation,
+    persisted_mappings: dict[str, dict[str, Any]],
+    current_reservations: list[Reservation] | None = None,
+    actual_slot_names: dict[int, str] | None = None,
+) -> RematchResult:
+    """Find the best identity rematch for *reservation* in *persisted_mappings*.
+
+    Implements the six-rule matching hierarchy described in R-002 of
+    ``specs/012-slot-reconciliation/research.md``:
+
+    1. **Exact fingerprint**: if the reservation's ``identity_key`` is
+       already a key in *persisted_mappings*, return
+       :attr:`RematchKind.EXACT`.
+    2. **UID alias + name**: if any volatile UID alias in the incoming
+       reservation overlaps with a persisted mapping's ``uid_aliases``
+       *and* the normalized names match, return
+       :attr:`RematchKind.UID_ALIAS` with ``date_shifted=True`` (because
+       the fingerprint would have matched under rule 1 if dates were
+       unchanged).  If multiple mappings match, return AMBIGUOUS.
+    3. **Booking alias + name**: if any booking/confirmation alias
+       overlaps *and* names match, return
+       :attr:`RematchKind.BOOKING_ALIAS`.  If multiple mappings match
+       the same alias, return AMBIGUOUS.
+    4. **Name + exact start/end**: compare the normalized name and exact
+       UTC start/end stored in the persisted mapping's ``identity`` dict.
+       Returns :attr:`RematchKind.NAME_TIME` when both match.  Serves
+       as a migration safety net.
+    5. **Conservative continuity**: collect all continuity-compatible
+       candidates (see :func:`_is_continuity_compatible`).  If exactly
+       one is found and no other current reservation competes for it,
+       return :attr:`RematchKind.CONTINUITY`.  If multiple candidates
+       are compatible, return :attr:`RematchKind.AMBIGUOUS` with all
+       keys for diagnostic capture.
+    6. **No match**: return :attr:`RematchKind.NO_MATCH`.
+
+    Args:
+        reservation: The incoming reservation to resolve against stored
+            mappings.
+        persisted_mappings: Raw Store mapping dicts keyed by identity
+            key (as loaded by
+            :meth:`~rental_control.event_overrides.EventOverrides.load_persisted_mappings`).
+        current_reservations: All current reservations being reconciled
+            in this refresh cycle.  Used for competition checking in
+            the conservative continuity rematch.  Optional.
+        actual_slot_names: Mapping of Keymaster slot number to the
+            currently observed slot name entity state.  Provides the
+            actual-slot continuity signal in rule 5.  Optional.
+
+    Returns:
+        A :class:`RematchResult` describing the best match found.
+    """
+    # Rule 1: exact primary fingerprint match
+    if reservation.identity_key in persisted_mappings:
+        return RematchResult(
+            kind=RematchKind.EXACT,
+            matched_identity_key=reservation.identity_key,
+        )
+
+    # Rule 2: UID alias + normalized name match
+    # If a UID alias matches but rule 1 did not fire, the fingerprint must
+    # differ.  Given that the fingerprint encodes entry_id + name + start +
+    # end, and entry_id is constant per instance, different fingerprint with
+    # matching name means the dates shifted → date_shifted=True always.
+    uid_matches: list[str] = []
+    for mapping_key, mapping in persisted_mappings.items():
+        persisted_uids: set[str] = set(
+            _get_nested(mapping, "identity", "uid_aliases") or []
+        )
+        if persisted_uids & reservation.uid_aliases:
+            if _mapping_name_matches_reservation(
+                mapping,
+                reservation,
+                actual_slot_names,
+                include_observed=_is_adopted_mapping(mapping_key, mapping),
+            ):
+                uid_matches.append(mapping_key)
+
+    if len(uid_matches) == 1:
+        return RematchResult(
+            kind=RematchKind.UID_ALIAS,
+            matched_identity_key=uid_matches[0],
+            date_shifted=True,
+        )
+    if len(uid_matches) > 1:
+        return RematchResult(
+            kind=RematchKind.AMBIGUOUS,
+            matched_identity_key=None,
+            ambiguous_keys=uid_matches,
+        )
+
+    # Rule 3: booking alias + normalized name match
+    # Collect all matches to detect ambiguous scenarios (e.g. duplicate
+    # booking codes across two persisted mappings).
+    booking_matches: list[str] = []
+    for mapping_key, mapping in persisted_mappings.items():
+        persisted_booking: set[str] = set(
+            _get_nested(mapping, "identity", "booking_aliases") or []
+        )
+        if persisted_booking & reservation.booking_aliases:
+            if _mapping_name_matches_reservation(
+                mapping,
+                reservation,
+                actual_slot_names,
+                include_observed=_is_adopted_mapping(mapping_key, mapping),
+            ):
+                booking_matches.append(mapping_key)
+
+    if len(booking_matches) == 1:
+        return RematchResult(
+            kind=RematchKind.BOOKING_ALIAS,
+            matched_identity_key=booking_matches[0],
+        )
+    if len(booking_matches) > 1:
+        return RematchResult(
+            kind=RematchKind.AMBIGUOUS,
+            matched_identity_key=None,
+            ambiguous_keys=booking_matches,
+        )
+
+    # Rule 4: name + exact start/end stored in identity dict
+    name_time_matches: list[str] = []
+    for mapping_key, mapping in persisted_mappings.items():
+        if not _mapping_name_matches_reservation(
+            mapping,
+            reservation,
+            actual_slot_names,
+            include_observed=_is_adopted_mapping(mapping_key, mapping),
+        ):
+            continue
+        if _mapping_dates_match_reservation(
+            mapping,
+            reservation,
+            include_observed=_is_adopted_mapping(mapping_key, mapping),
+        ):
+            name_time_matches.append(mapping_key)
+
+    if len(name_time_matches) == 1:
+        return RematchResult(
+            kind=RematchKind.NAME_TIME,
+            matched_identity_key=name_time_matches[0],
+        )
+    if len(name_time_matches) > 1:
+        return RematchResult(
+            kind=RematchKind.AMBIGUOUS,
+            matched_identity_key=None,
+            ambiguous_keys=name_time_matches,
+        )
+
+    # Rule 5: conservative continuity rematch
+    candidates: list[str] = [
+        mapping_key
+        for mapping_key, mapping in persisted_mappings.items()
+        if _is_continuity_compatible(
+            reservation,
+            mapping_key,
+            mapping,
+            actual_slot_names,
+        )
+    ]
+
+    if len(candidates) == 1:
+        if not _has_competing_reservation(
+            candidates[0],
+            persisted_mappings,
+            current_reservations,
+            reservation,
+        ):
+            return RematchResult(
+                kind=RematchKind.CONTINUITY,
+                matched_identity_key=candidates[0],
+            )
+        # Competition found → treat as ambiguous even with one candidate
+        return RematchResult(
+            kind=RematchKind.AMBIGUOUS,
+            matched_identity_key=None,
+            ambiguous_keys=list(candidates),
+        )
+
+    if len(candidates) > 1:
+        date_matches = [
+            candidate
+            for candidate in candidates
+            if _mapping_dates_match_reservation(
+                persisted_mappings[candidate],
+                reservation,
+                include_observed=_is_adopted_mapping(
+                    candidate, persisted_mappings[candidate]
+                ),
+            )
+        ]
+        if len(date_matches) == 1:
+            return RematchResult(
+                kind=RematchKind.NAME_TIME,
+                matched_identity_key=date_matches[0],
+            )
+        return RematchResult(
+            kind=RematchKind.AMBIGUOUS,
+            matched_identity_key=None,
+            ambiguous_keys=list(candidates),
+        )
+
+    return RematchResult(kind=RematchKind.NO_MATCH, matched_identity_key=None)
+
+
+def _find_persisted_slot_for_reservation(
+    managed_slots: list[ManagedSlot], identity_key: str
+) -> ManagedSlot | None:
+    """Return the managed slot that has *identity_key* as its persisted assignment.
+
+    Scans only slots where :attr:`ManagedSlot.managed` is ``True``.
+    Returns ``None`` if no such slot is found.
+
+    Args:
+        managed_slots: Full list of managed and unmanaged slots.
+        identity_key: Reservation identity key to look up.
+
+    Returns:
+        The first managed slot whose :attr:`ManagedSlot.persisted_identity_key`
+        matches *identity_key*, or ``None``.
+    """
+    for ms in managed_slots:
+        if ms.managed and ms.persisted_identity_key == identity_key:
+            return ms
+    return None
+
+
+def _is_slot_assignable(ms: ManagedSlot) -> bool:
+    """Return ``True`` when *ms* can receive a new desired assignment.
+
+    Slots with :attr:`SlotStatus.PENDING_CLEAR`, :attr:`SlotStatus.BLOCKED`,
+    or :attr:`SlotStatus.UNKNOWN` status cannot receive a different reservation
+    until their status resolves.  All other statuses (FREE, OCCUPIED, PHANTOM)
+    are considered assignable by the planner.
+
+    Args:
+        ms: Managed slot to evaluate.
+
+    Returns:
+        ``True`` if the slot may be included in a desired assignment;
+        ``False`` if the slot must be skipped.
+    """
+    return ms.status not in {
+        SlotStatus.PENDING_CLEAR,
+        SlotStatus.BLOCKED,
+        SlotStatus.UNKNOWN,
+    }
+
+
+def _compute_drift_fields(ms: ManagedSlot, res: Reservation) -> list[str]:
+    """Return the list of field names that differ between actual and desired state.
+
+    Compares the observed :class:`ManagedSlot` fields against the desired
+    :class:`Reservation` to detect manual or external changes to a managed
+    Keymaster slot.  Only fields where an observed value is available are
+    checked; ``None`` observations are skipped rather than treated as drift.
+
+    Raw PIN values are never compared or returned; only code *presence* is
+    checked via :attr:`ManagedSlot.actual_code_present`.
+
+    Fields checked:
+
+    - **name**: :attr:`~ManagedSlot.actual_name` vs
+      :attr:`~Reservation.display_slot_name`.
+    - **code**: :attr:`~ManagedSlot.actual_code_present` is ``False`` when
+      a code should be present (i.e., the slot is occupied).
+    - **start**: :attr:`~ManagedSlot.actual_start` vs
+      :attr:`~Reservation.buffered_start`.
+    - **end**: :attr:`~ManagedSlot.actual_end` vs
+      :attr:`~Reservation.buffered_end`.
+    - **date_range_enabled**: :attr:`~ManagedSlot.date_range_enabled` is
+      ``False`` when dates are configured, indicating the switch was turned
+      off manually.
+
+    Args:
+        ms: The managed slot with observed Keymaster state.
+        res: The desired reservation whose fields represent the expected state.
+
+    Returns:
+        Sorted list of field name strings that differ; empty when no drift is
+        detected.
+    """
+    fields: list[str] = []
+
+    # Name drift: actual Keymaster display name differs from desired
+    if ms.actual_name is not None and ms.actual_name != res.display_slot_name:
+        fields.append("name")
+
+    # Code presence drift: slot should have a code but one was removed
+    if ms.actual_code_present is False:
+        fields.append("code")
+
+    if ms.actual_start is not None and ms.actual_start != res.buffered_start:
+        fields.append("start")
+
+    if ms.actual_end is not None and ms.actual_end != res.buffered_end:
+        fields.append("end")
+
+    # Date-range switch drift: switch should be enabled for date-ranged slots
+    if ms.date_range_enabled is False:
+        fields.append("date_range_enabled")
+
+    return fields
+
+
+def _filter_eligible(reservations: list[Reservation]) -> list[Reservation]:
+    """Return the subset of *reservations* eligible for slot planning.
+
+    Excludes ineligible, checked-out, and feed-missed reservations.
+    Protected active reservations bypass the missing-count filter because
+    an active guest must stay assigned regardless of feed gaps.
+
+    Args:
+        reservations: Full list of current reservations.
+
+    Returns:
+        Filtered list containing only candidates that may be selected.
+    """
+    result: list[Reservation] = []
+    for res in reservations:
+        if not res.eligible or res.checked_out:
+            continue
+        if res.missing_count >= 3 and not res.protected_active:
+            continue
+        result.append(res)
+    return result
+
+
+def _select_candidates(
+    eligible: list[Reservation],
+    max_events: int,
+) -> tuple[list[Reservation], list[Reservation], list[Reservation], int]:
+    """Partition *eligible* into protected, selected-non-protected, and overflow.
+
+    Protected active reservations are always selected first and count against
+    ``max_events``.  The remaining capacity is filled by the soonest
+    non-protected reservations sorted by ``(start, identity_key)``.
+
+    Args:
+        eligible: Pre-filtered list of eligible reservations.
+        max_events: Maximum total assignments allowed.
+
+    Returns:
+        A four-tuple of
+        ``(protected, selected_np, overflow_list, remaining_capacity)``
+        where *remaining_capacity* is ``max(0, max_events - len(protected))``.
+    """
+    protected = [r for r in eligible if r.protected_active]
+    non_protected = [r for r in eligible if not r.protected_active]
+    non_protected.sort(key=lambda r: (r.start, r.identity_key))
+    remaining_capacity = max(0, max_events - len(protected))
+    return (
+        protected,
+        non_protected[:remaining_capacity],
+        non_protected[remaining_capacity:],
+        remaining_capacity,
+    )
+
+
+def _build_slot_action(
+    ms: ManagedSlot,
+    desired_key: str | None,
+    res_by_key: dict[str, "Reservation"],
+) -> tuple[ActionKind, str | None]:
+    """Determine the reconciliation action for one managed slot.
+
+    Compares the desired assignment against the slot's current observed
+    state to produce the appropriate :class:`ActionKind` and an optional
+    human-readable reason string.
+
+    Args:
+        ms: The managed slot being evaluated.
+        desired_key: Identity key of the reservation the planner wants in
+            this slot, or ``None`` if the slot should be empty.
+        res_by_key: Mapping of identity key → :class:`Reservation` for
+            date comparison.
+
+    Returns:
+        A two-tuple ``(action, pending_reason)``.
+    """
+    if ms.status is SlotStatus.PENDING_CLEAR:
+        return ActionKind.RETRY_CLEAR, ms.blocked_reason or "pending_clear"
+
+    if ms.status in {SlotStatus.BLOCKED, SlotStatus.UNKNOWN}:
+        return ActionKind.BLOCKED, ms.blocked_reason or ms.status.value
+
+    if desired_key is None:
+        if ms.status is SlotStatus.FREE:
+            return ActionKind.NOOP, None
+        if (
+            ms.status is SlotStatus.OCCUPIED
+            and ms.persisted_identity_key is not None
+            and ms.persisted_identity_key.startswith("adopted.")
+        ):
+            return ActionKind.BLOCKED, "adopted_unmatched"
+        return ActionKind.CLEAR, None
+
+    desired_res = res_by_key.get(desired_key)
+    if ms.status is SlotStatus.FREE:
+        return ActionKind.SET, None
+
+    if ms.status is SlotStatus.OCCUPIED:
+        if ms.persisted_identity_key != desired_key:
+            return ActionKind.CLEAR, None
+
+        # Detect non-date drift (manual/external name, code, or switch change).
+        # Date-only drift is handled below as UPDATE_TIMES to preserve the
+        # churn-minimisation invariant.  Unmanaged slots never reach this path
+        # because compute_desired_plan iterates only managed == True slots.
+        if desired_res is not None:
+            drift_fields = _compute_drift_fields(ms, desired_res)
+            non_date_drift = [f for f in drift_fields if f not in ("start", "end")]
+            if non_date_drift:
+                # Include all drifted fields (including dates if also wrong) in
+                # the reason so diagnostics capture the full picture.
+                reason = "drifted fields: " + ", ".join(drift_fields)
+                return ActionKind.OVERWRITE_MANUAL_CHANGE, reason
+
+        if desired_res is not None and (
+            ms.actual_start is not None or ms.actual_end is not None
+        ):
+            dates_match = (
+                ms.actual_start == desired_res.buffered_start
+                and ms.actual_end == desired_res.buffered_end
+            )
+            return (ActionKind.NOOP if dates_match else ActionKind.UPDATE_TIMES), None
+        return ActionKind.NOOP, None
+
+    return ActionKind.CLEAR, None
+
+
+def _build_plan_diagnostics_snapshot(
+    plan: DesiredPlan,
+    reservations: list[Reservation],
+    max_events: int,
+    *,
+    entry_id: str | None = None,
+    lockname: str | None = None,
+    start_slot: int | None = None,
+) -> dict[str, Any]:
+    """Build a comprehensive diagnostics snapshot for *plan*.
+
+    Produces a dict capturing plan metadata, per-slot desired/actual/action/
+    blocked_reason/retry_count/last_error, and per-reservation
+    selected/protected/overflow/missing_count/assigned_slot/uid_aliases/
+    booking_aliases.  Raw slot codes are deliberately excluded.
+
+    Called once per refresh at the end of :func:`compute_desired_plan`
+    after ``plan.slots`` and ``plan.actions`` are fully populated.
+
+    Args:
+        plan: The partially-built :class:`DesiredPlan` whose
+            :attr:`~DesiredPlan.slots`, :attr:`~DesiredPlan.selected`,
+            :attr:`~DesiredPlan.protected`, and :attr:`~DesiredPlan.overflow`
+            are already set.
+        reservations: All current reservations (eligible and ineligible).
+        max_events: Maximum number of reservations that can be assigned.
+        entry_id: Optional config-entry scope for diagnostics context.
+        lockname: Optional Keymaster lock name for diagnostics context.
+        start_slot: Optional managed-range start for diagnostics context.
+
+    Returns:
+        Populated diagnostics dict suitable for
+        :attr:`DesiredPlan.diagnostics`.
+    """
+    existing_diag: dict[str, Any] = dict(plan.diagnostics)
+
+    diag: dict[str, Any] = {
+        "plan_id": plan.plan_id,
+        "generated_at": plan.generated_at.isoformat(),
+        "max_slots": max_events,
+    }
+    if entry_id is not None:
+        diag["entry_id"] = entry_id
+    if lockname is not None:
+        diag["lockname"] = lockname
+    if start_slot is not None:
+        diag["start_slot"] = start_slot
+
+    # Per-slot diagnostics (no raw codes)
+    slots_diag: dict[int, dict[str, Any]] = {}
+    for slot_num, ps in plan.slots.items():
+        slot_entry: dict[str, Any] = {
+            "desired_identity_key": ps.desired_identity_key,
+            "actual_classification": ps.actual_classification,
+            "action": ps.action.value,
+            "blocked_reason": ps.pending_reason,
+            "retry_count": ps.retry_count,
+            "last_error": ps.last_error,
+        }
+        # Include parsed drift fields for OVERWRITE_MANUAL_CHANGE actions so
+        # diagnostics consumers can enumerate exactly which fields were wrong.
+        if ps.action is ActionKind.OVERWRITE_MANUAL_CHANGE and ps.pending_reason:
+            prefix = "drifted fields: "
+            if ps.pending_reason.startswith(prefix):
+                slot_entry["drift_fields"] = [
+                    f.strip()
+                    for f in ps.pending_reason[len(prefix) :].split(",")
+                    if f.strip()
+                ]
+        slots_diag[slot_num] = slot_entry
+    diag["slots"] = slots_diag
+
+    # Per-reservation diagnostics (slot_code intentionally excluded)
+    res_diag: dict[str, dict[str, Any]] = {}
+    for res in reservations:
+        ikey = res.identity_key
+        res_diag[ikey] = {
+            "selected": ikey in plan.selected,
+            "protected": ikey in plan.protected,
+            "overflow_reason": plan.overflow.get(ikey),
+            "missing_count": res.missing_count,
+            "assigned_slot": plan.selected.get(ikey),
+            "uid_aliases": sorted(res.uid_aliases),
+            "booking_aliases": sorted(res.booking_aliases),
+            "slot_name": res.slot_name,
+            "summary": res.summary,
+            "eligible": res.eligible,
+            "protected_active": res.protected_active,
+            "checked_out": res.checked_out,
+        }
+    diag["reservations"] = res_diag
+
+    # Carry over pre-existing diagnostics keys not overwritten above.
+    for k, v in existing_diag.items():
+        diag.setdefault(k, v)
+
+    return diag
+
+
+def compute_desired_plan(
+    reservations: list[Reservation],
+    managed_slots: list[ManagedSlot],
+    max_events: int,
+    plan_id: str,
+    generated_at: datetime,
+    *,
+    entry_id: str | None = None,
+    lockname: str | None = None,
+    start_slot: int | None = None,
+) -> DesiredPlan:
+    """Compute the deterministic desired slot plan for the current set of reservations.
+
+    **Selection**: eligible candidates are filtered, protected active reservations
+    are always selected first (counting against ``max_events``), and remaining
+    capacity is filled by soonest non-protected sorted by ``(start, identity_key)``.
+    Overflow reservations receive reason ``"capacity"`` with per-entry rank.
+
+    **Slot assignment**: protected and selected reservations retain their persisted
+    slot when it is assignable; otherwise the lowest free managed slot is used.
+    ``PENDING_CLEAR``, ``BLOCKED``, and ``UNKNOWN`` slots are never assigned.
+
+    **Action generation**: ``SET`` for a free slot, ``UPDATE_TIMES`` when dates
+    differ, ``NOOP`` when already correct, ``CLEAR`` for stale/phantom/wrong
+    occupants, ``RETRY_CLEAR`` for pending clears, and ``BLOCKED`` for locked
+    slots.  ``NOOP`` actions are excluded from :attr:`DesiredPlan.actions`.
+
+    **Diagnostics**: a comprehensive snapshot is stored in
+    :attr:`DesiredPlan.diagnostics` capturing ``plan_id``, ``generated_at``,
+    per-slot desired/actual/action/blocked_reason/retry_count/last_error, and
+    per-reservation selected/protected/overflow/missing_count/assigned_slot/
+    uid_aliases/booking_aliases.  Raw slot codes are never included.
+
+    Args:
+        reservations: All current reservations (eligible and ineligible).
+        managed_slots: All managed slots with their current observed and
+            persisted state.
+        max_events: Maximum number of reservations that can be assigned.
+        plan_id: Refresh-scoped identifier for logging and operation tokens.
+        generated_at: Time at which the plan was computed.
+        entry_id: Optional config-entry scope for diagnostics context.
+        lockname: Optional Keymaster lock name for diagnostics context.
+        start_slot: Optional managed-range start for diagnostics context.
+
+    Returns:
+        A fully populated :class:`DesiredPlan` with :attr:`~DesiredPlan.selected`,
+        :attr:`~DesiredPlan.protected`, :attr:`~DesiredPlan.overflow`,
+        :attr:`~DesiredPlan.slots`, :attr:`~DesiredPlan.actions`, and
+        :attr:`~DesiredPlan.diagnostics` populated.
+    """
+    plan = DesiredPlan(plan_id=plan_id, generated_at=generated_at)
+
+    eligible = _filter_eligible(reservations)
+    protected, selected_np, overflow_list, remaining_capacity = _select_candidates(
+        eligible, max_events
+    )
+    plan.protected = {r.identity_key for r in protected}
+
+    assigned: dict[int, str] = {}
+    free_slot_numbers: list[int] = sorted(
+        ms.slot for ms in managed_slots if ms.managed and ms.status is SlotStatus.FREE
+    )
+
+    def _try_assign(res: Reservation) -> bool:
+        """Try to assign *res* to its persisted slot or the lowest free slot."""
+        persisted = _find_persisted_slot_for_reservation(
+            managed_slots, res.identity_key
+        )
+        if (
+            persisted is not None
+            and _is_slot_assignable(persisted)
+            and persisted.slot not in assigned
+        ):
+            assigned[persisted.slot] = res.identity_key
+            if persisted.slot in free_slot_numbers:
+                free_slot_numbers.remove(persisted.slot)
+            return True
+        if free_slot_numbers:
+            assigned[free_slot_numbers.pop(0)] = res.identity_key
+            return True
+        return False
+
+    for res in protected:
+        if not _try_assign(res):
+            plan.diagnostics.setdefault("protected_capacity_violations", []).append(
+                res.identity_key
+            )
+
+    for res in selected_np:
+        if not _try_assign(res):
+            plan.overflow[res.identity_key] = "no_free_slot"
+            _LOGGER.warning(
+                "Overflow: reservation %s selected but no free managed slot available",
+                res.identity_key,
+            )
+
+    for slot_num, ikey in assigned.items():
+        plan.selected[ikey] = slot_num
+
+    for rank_offset, res in enumerate(overflow_list):
+        plan.overflow[res.identity_key] = "capacity"
+        plan.diagnostics.setdefault("overflow_details", {})[res.identity_key] = {
+            "rank": remaining_capacity + rank_offset + 1,
+            "reason": "capacity",
+            "start": res.start.isoformat(),
+            "identity_key": res.identity_key,
+        }
+
+    slot_to_identity: dict[int, str] = {v: k for k, v in plan.selected.items()}
+    res_by_key: dict[str, Reservation] = {r.identity_key: r for r in reservations}
+
+    # Detect duplicate persisted assignments: same identity key in multiple OCCUPIED
+    # managed slots.  The canonical slot is the lowest-numbered one.  All others are
+    # non-canonical and will be cleared.
+    _persisted_to_slots: dict[str, list[int]] = {}
+    for _ms in managed_slots:
+        if (
+            _ms.managed
+            and _ms.persisted_identity_key is not None
+            and _ms.status is SlotStatus.OCCUPIED
+        ):
+            _persisted_to_slots.setdefault(_ms.persisted_identity_key, []).append(
+                _ms.slot
+            )
+    _non_canonical_slots: set[int] = set()
+    for _dup_key, _dup_slots in _persisted_to_slots.items():
+        if len(_dup_slots) > 1:
+            _canonical = min(_dup_slots)
+            _non_canonical = [s for s in _dup_slots if s != _canonical]
+            _non_canonical_slots.update(_non_canonical)
+            _LOGGER.warning(
+                "Duplicate assignment: identity %s found in slots %s; "
+                "slot %d is canonical, slots %s will be cleared (duplicate collapse)",
+                _dup_key,
+                sorted(_dup_slots),
+                _canonical,
+                sorted(_non_canonical),
+            )
+
+    for ms in sorted(managed_slots, key=lambda m: m.slot):
+        if not ms.managed:
+            continue
+        desired_key = slot_to_identity.get(ms.slot)
+        action, pending_reason = _build_slot_action(ms, desired_key, res_by_key)
+        if (
+            action is ActionKind.RETRY_CLEAR
+            and ms.persisted_identity_key in plan.protected
+        ):
+            action = ActionKind.BLOCKED
+            pending_reason = "protected_active_pending_clear"
+        ms.desired_identity_key = desired_key
+        plan.slots[ms.slot] = PlannedSlot(
+            slot=ms.slot,
+            desired_identity_key=desired_key,
+            actual_classification=ms.status.value,
+            action=action,
+            pending_reason=pending_reason,
+            retry_count=ms.retry_count,
+            last_error=ms.last_error,
+        )
+        if action is not ActionKind.NOOP:
+            clear_reason: str | None = pending_reason
+            if action is ActionKind.CLEAR:
+                if ms.slot in _non_canonical_slots:
+                    clear_reason = "duplicate_non_canonical"
+                elif ms.status is SlotStatus.PHANTOM:
+                    clear_reason = "phantom"
+                elif ms.status is SlotStatus.OCCUPIED and desired_key is None:
+                    clear_reason = "stale"
+                elif ms.status is SlotStatus.OCCUPIED and desired_key is not None:
+                    clear_reason = "mis_assigned"
+            plan.actions.append(
+                SlotAction(
+                    kind=action,
+                    slot=ms.slot,
+                    identity_key=desired_key,
+                    reason=clear_reason,
+                )
+            )
+
+    plan.diagnostics = _build_plan_diagnostics_snapshot(
+        plan,
+        reservations,
+        max_events,
+        entry_id=entry_id,
+        lockname=lockname,
+        start_slot=start_slot,
+    )
+
+    return plan

--- a/custom_components/rental_control/sensors/calsensor.py
+++ b/custom_components/rental_control/sensors/calsensor.py
@@ -22,12 +22,9 @@ from ..const import ICON
 from ..const import NAME
 from ..const import SECONDS_PER_HOUR
 from ..const import SECONDS_PER_MINUTE
-from ..util import async_fire_clear_code
-from ..util import async_fire_set_code
-from ..util import async_fire_update_times
+from ..reconciliation import make_reservation_fingerprint
 from ..util import gen_uuid
 from ..util import get_slot_name
-from ..util import normalize_uid
 
 if TYPE_CHECKING:
     from ..coordinator import RentalControlCoordinator
@@ -416,19 +413,27 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
             )
             self._event_attributes["slot_name"] = slot_name
 
-            slot_code = self._generate_door_code()
-            self._event_attributes["slot_number"] = None
+            # Read slot assignment and code from coordinator reconciliation
+            # state.  The coordinator owns all slot mutations; the sensor is
+            # purely read-only.  Fall back to a locally generated code when
+            # reconciliation has not yet produced a result (e.g. no lock
+            # configured, or first refresh before reconciliation ran).
+            slot_number: int | None = None
+            slot_code: str | None = None
+            if self.coordinator.event_overrides is not None and slot_name is not None:
+                identity_key = make_reservation_fingerprint(
+                    self.coordinator.entry_id,
+                    slot_name,
+                    event.start,
+                    event.end,
+                )
+                slot_number = self.coordinator.get_slot_assignment(identity_key)
+                slot_code = self.coordinator.get_slot_code(identity_key)
 
-            # Read-only lookup for display: show existing override code
-            # immediately rather than the generated fallback.  This is
-            # safe because it is not used for slot-assignment decisions.
-            overrides = self.coordinator.event_overrides
-            if overrides and slot_name is not None:
-                existing = overrides.get_slot_with_name(slot_name)
-                if existing and existing["slot_code"]:
-                    slot_code = str(existing["slot_code"])
-                slot_key = overrides.get_slot_key_by_name(slot_name)
-                self._event_attributes["slot_number"] = slot_key if slot_key else None
+            if slot_code is None:
+                slot_code = self._generate_door_code()
+
+            self._event_attributes["slot_number"] = slot_number
             self._event_attributes["slot_code"] = slot_code
 
             # attributes parsed from description
@@ -466,27 +471,6 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
                     parsed_attributes[key] = value
 
             self._parsed_attributes = parsed_attributes
-
-            # Schedule atomic slot assignment with a snapshot of
-            # event data so the async task is immune to subsequent
-            # coordinator updates mutating self._event_attributes.
-            # Gate on overrides.ready to avoid spurious overflow
-            # warnings during bootstrap when _next_slot is still None.
-            if overrides and overrides.ready and slot_name is not None:
-                event_uid: str | None = normalize_uid(
-                    event.uid if hasattr(event, "uid") else None
-                )
-                self.hass.async_create_task(
-                    self._async_handle_slot_assignment(
-                        slot_name=slot_name,
-                        slot_code=slot_code,
-                        start_time=event.start,
-                        end_time=event.end,
-                        uid=event_uid,
-                        prefix=self.coordinator.event_prefix or "",
-                        eta_days=eta_days,
-                    )
-                )
 
         else:
             # No reservations
@@ -529,78 +513,24 @@ class RentalControlCalSensor(CoordinatorEntity["RentalControlCoordinator"]):
         prefix: str,
         eta_days: int | None,
     ) -> None:
-        """Atomically reserve or locate an existing slot for the current event.
+        """No-op backward-compatible shim; slot assignment is owned by the coordinator.
 
-        All event data is captured at call-time so the coroutine is
-        immune to subsequent coordinator updates that could mutate
-        ``self._event_attributes`` before execution.
+        The per-event slot-assignment scheduling path — where
+        ``_handle_coordinator_update`` would call this method to invoke
+        :meth:`~..event_overrides.EventOverrides.async_reserve_or_get_slot`
+        or fire set-code / clear-code / update-times events — has been
+        removed.  All slot mutation is now performed exclusively by
+        :class:`~..coordinator.RentalControlCoordinator` through the
+        reconciliation cycle (``compute_desired_plan`` / ``async_apply_plan``).
 
-        Uses ``async_reserve_or_get_slot`` to eliminate the
-        check-then-act race that previously existed between
-        ``get_slot_with_name`` and ``next_slot`` reads.
+        This shim is retained so that any external call sites produce a
+        harmless no-op rather than an ``AttributeError``.  It is verified
+        by ``test_async_handle_slot_assignment_is_noop`` as a regression
+        guard.  The method must never be called or scheduled from
+        :meth:`_handle_coordinator_update`.
+
+        .. deprecated::
+            The per-event scheduling and mutation fallback path has been
+            retired.  This shim will be removed in a future release once
+            all external references are eliminated.
         """
-        overrides = self.coordinator.event_overrides
-        if overrides is None:
-            return
-
-        result = await overrides.async_reserve_or_get_slot(
-            slot_name=slot_name,
-            slot_code=slot_code,
-            start_time=start_time,
-            end_time=end_time,
-            uid=uid,
-            prefix=prefix,
-        )
-
-        if result.slot is None:
-            return
-
-        # Staleness guard: a subsequent coordinator update may have
-        # changed this sensor to a different event.  The reservation
-        # itself is still valid, but Keymaster side effects must not
-        # fire for a stale event.
-        current_attrs = self._event_attributes
-        current_uid = normalize_uid(
-            str(current_attrs["uid"]) if current_attrs.get("uid") is not None else None
-        )
-        if (
-            current_attrs.get("slot_name") != slot_name
-            or current_attrs.get("start") != start_time
-            or current_attrs.get("end") != end_time
-            or current_uid != uid
-        ):
-            _LOGGER.debug(
-                "Slot assignment for '%s' is stale, skipping "
-                "Keymaster side effects for sensor %s",
-                slot_name,
-                self.name,
-            )
-            return
-
-        self._event_attributes["slot_number"] = result.slot
-
-        if result.is_new:
-            await async_fire_set_code(self.coordinator, self, result.slot)
-            return
-
-        # Existing slot — update displayed code from the override
-        override = overrides.overrides.get(result.slot)
-        if override and override["slot_code"]:
-            self._event_attributes["slot_code"] = str(override["slot_code"])
-            self.async_write_ha_state()
-
-        if result.times_updated:
-            if (
-                self.coordinator.code_generator == "date_based"
-                and self.coordinator.should_update_code
-                and eta_days
-                and eta_days > 0
-            ):
-                _LOGGER.debug(
-                    "Clearing slot %s for sensor %s due to date shift",
-                    result.slot,
-                    self.name,
-                )
-                await async_fire_clear_code(self.coordinator, result.slot)
-            else:
-                await async_fire_update_times(self.coordinator, self, result.slot)

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -18,12 +18,14 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Coroutine
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import date
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
 from datetime import tzinfo
 import hashlib
+import inspect
 import logging
 from pathlib import Path
 import re
@@ -57,6 +59,27 @@ from .const import EARLY_CHECKOUT_GRACE_MINUTES
 from .const import NAME
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class OperationResult:
+    """Result of a physical Keymaster slot service operation.
+
+    Returned by ``async_fire_clear_code()``, ``async_fire_set_code()``,
+    and ``async_fire_update_times()``. Successful helper paths set one
+    of ``confirmed``, ``unconfirmed``, or ``failed`` to ``True``.
+    ``lingering_name`` and ``lingering_pin`` are supplementary flags for
+    clear operations. Raw PIN values are never stored.
+    """
+
+    kind: str
+    slot: int
+    confirmed: bool = False
+    unconfirmed: bool = False
+    failed: bool = False
+    lingering_name: bool = False
+    lingering_pin: bool = False
+    error: str | None = None
 
 
 def get_entry_data(hass: HomeAssistant, entry_id: str) -> dict[str, Any] | None:
@@ -172,7 +195,7 @@ def delete_folder(absolute_path: str | Path, *relative_paths: str) -> None:
 
 async def async_fire_clear_code(
     coordinator, slot: int, expected_name: str | None = None
-) -> None:
+) -> OperationResult:
     """Fire a clear_code signal."""
     _LOGGER.debug(
         "In async_fire_clear_code - slot: %s, name: %s", slot, coordinator.name
@@ -181,7 +204,7 @@ async def async_fire_clear_code(
     reset_entity = f"{BUTTON}.{coordinator.lockname}_code_slot_{slot}_reset"
 
     if not coordinator.lockname:
-        return
+        return OperationResult(kind="clear", slot=slot, unconfirmed=True)
 
     if (
         expected_name is not None
@@ -192,7 +215,7 @@ async def async_fire_clear_code(
             slot,
             expected_name,
         )
-        return
+        return OperationResult(kind="clear", slot=slot, unconfirmed=True)
 
     try:
         # Reset the slot
@@ -202,7 +225,9 @@ async def async_fire_clear_code(
             target={"entity_id": reset_entity},
             blocking=True,
         )
-    except Exception:
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
         escalated = coordinator.event_overrides.record_retry_failure(slot)
         if escalated:
             pn_create(
@@ -212,19 +237,26 @@ async def async_fire_clear_code(
                 title="Rental Control: Lock Command Failure",
                 notification_id=f"rental_control_slot_{slot}_clear_failure",
             )
-        raise
+        return OperationResult(
+            kind="clear",
+            slot=slot,
+            failed=True,
+            error=str(exc),
+        )
 
     # Give Keymaster time to propagate the state change
     await asyncio.sleep(0.5)
 
-    # Verify the slot name was actually cleared
+    unconfirmed = False
+    lingering_name = False
+    lingering_pin = False
     name_entity = f"{TEXT}.{coordinator.lockname}_code_slot_{slot}_name"
+    pin_entity = f"{TEXT}.{coordinator.lockname}_code_slot_{slot}_pin"
+
     name_state = hass.states.get(name_entity)
-    if name_state is not None and name_state.state not in (
-        "",
-        "unknown",
-        "unavailable",
-    ):
+    if name_state is None:
+        unconfirmed = True
+    elif name_state.state not in ("", "unknown", "unavailable"):
         _LOGGER.warning(
             "Slot %d name '%s' persisted after reset; "
             "forcing name clear via text.set_value",
@@ -239,11 +271,35 @@ async def async_fire_clear_code(
                 service_data={"value": ""},
                 blocking=True,
             )
+        except asyncio.CancelledError:
+            raise
         except Exception:
             _LOGGER.exception(
                 "Failed to force-clear name for slot %d",
                 slot,
             )
+        name_state = hass.states.get(name_entity)
+        if name_state is None:
+            unconfirmed = True
+        elif name_state.state not in ("", "unknown", "unavailable"):
+            lingering_name = True
+
+    pin_state = hass.states.get(pin_entity)
+    if pin_state is None:
+        unconfirmed = True
+    elif pin_state.state not in ("", "unknown", "unavailable"):
+        lingering_pin = True
+
+    if lingering_name or lingering_pin:
+        return OperationResult(
+            kind="clear",
+            slot=slot,
+            unconfirmed=True,
+            lingering_name=lingering_name,
+            lingering_pin=lingering_pin,
+        )
+    if unconfirmed:
+        return OperationResult(kind="clear", slot=slot, unconfirmed=True)
 
     was_escalated = coordinator.event_overrides._escalated.get(slot, False)
     coordinator.event_overrides.record_retry_success(slot)
@@ -252,6 +308,7 @@ async def async_fire_clear_code(
             hass,
             notification_id=f"rental_control_slot_{slot}_clear_failure",
         )
+    return OperationResult(kind="clear", slot=slot, confirmed=True)
 
 
 def trim_name(name: str, max_length: int) -> str:
@@ -321,7 +378,7 @@ def apply_buffer(
     return dt_start, dt_end
 
 
-async def async_fire_set_code(coordinator, event, slot: int) -> None:
+async def async_fire_set_code(coordinator, event, slot: int) -> OperationResult:
     """Set codes into a slot."""
     _LOGGER.debug("In async_fire_set_code - slot: %s", slot)
     _LOGGER.debug("Event: %s", event)
@@ -331,7 +388,7 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
     coro: list[Coroutine] = []
 
     if not lockname:
-        return
+        return OperationResult(kind="set", slot=slot, unconfirmed=True)
 
     if coordinator.event_prefix:
         prefix = f"{coordinator.event_prefix} "
@@ -352,7 +409,7 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
             slot,
             expected_name,
         )
-        return
+        return OperationResult(kind="set", slot=slot, unconfirmed=True)
 
     try:
         # Disable the slot, this should help avoid notices from Keymaster
@@ -447,7 +504,9 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
         results = await asyncio.gather(*coro, return_exceptions=True)
         check_gather_results(results, "Lock slot operation")
         _raise_first_gather_exception(results)
-    except Exception:
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
         escalated = coordinator.event_overrides.record_retry_failure(slot)
         if escalated:
             pn_create(
@@ -457,18 +516,35 @@ async def async_fire_set_code(coordinator, event, slot: int) -> None:
                 title="Rental Control: Lock Command Failure",
                 notification_id=f"rental_control_slot_{slot}_failure",
             )
-        raise
-
-    was_escalated = coordinator.event_overrides._escalated.get(slot, False)
-    coordinator.event_overrides.record_retry_success(slot)
-    if was_escalated:
-        pn_dismiss(
-            coordinator.hass,
-            notification_id=f"rental_control_slot_{slot}_failure",
+        return OperationResult(
+            kind="set",
+            slot=slot,
+            failed=True,
+            error=str(exc),
         )
 
+    name_entity = f"{TEXT}.{lockname}_code_slot_{slot}_name"
+    block_till_done = getattr(coordinator.hass, "async_block_till_done", None)
+    if block_till_done is not None:
+        done_result = block_till_done()
+        if inspect.isawaitable(done_result):
+            await done_result
+    name_state = coordinator.hass.states.get(name_entity)
+    if name_state is None:
+        return OperationResult(kind="set", slot=slot, unconfirmed=True)
+    if name_state.state == slot_name:
+        was_escalated = coordinator.event_overrides._escalated.get(slot, False)
+        coordinator.event_overrides.record_retry_success(slot)
+        if was_escalated:
+            pn_dismiss(
+                coordinator.hass,
+                notification_id=f"rental_control_slot_{slot}_failure",
+            )
+        return OperationResult(kind="set", slot=slot, confirmed=True)
+    return OperationResult(kind="set", slot=slot, unconfirmed=True)
 
-async def async_fire_update_times(coordinator, event, slot: int) -> None:
+
+async def async_fire_update_times(coordinator, event, slot: int) -> OperationResult:
     """Update times on slot."""
 
     lockname: str = coordinator.lockname
@@ -476,7 +552,7 @@ async def async_fire_update_times(coordinator, event, slot: int) -> None:
     slot_name: str = event.extra_state_attributes["slot_name"]
 
     if not slot or not lockname:
-        return
+        return OperationResult(kind="update_times", slot=slot, unconfirmed=True)
 
     if not coordinator.event_overrides.verify_slot_ownership(slot, slot_name):
         _LOGGER.warning(
@@ -484,7 +560,7 @@ async def async_fire_update_times(coordinator, event, slot: int) -> None:
             slot,
             slot_name,
         )
-        return
+        return OperationResult(kind="update_times", slot=slot, unconfirmed=True)
 
     # Compute buffered validity window for Keymaster
     buffered_start, buffered_end = apply_buffer(
@@ -514,6 +590,18 @@ async def async_fire_update_times(coordinator, event, slot: int) -> None:
     )
     results = await asyncio.gather(*coro, return_exceptions=True)
     check_gather_results(results, "Lock slot operation")
+    try:
+        _raise_first_gather_exception(results)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        return OperationResult(
+            kind="update_times",
+            slot=slot,
+            failed=True,
+            error=str(exc),
+        )
+    return OperationResult(kind="update_times", slot=slot, confirmed=True)
 
 
 def _ensure_datetime(value: date | datetime, rc) -> datetime:
@@ -693,6 +781,11 @@ async def handle_state_change(
     await asyncio.sleep(0.1)
 
     entity_id = event.data["entity_id"]
+    event_new_state = event.data.get("new_state")
+    event_new_value = (
+        getattr(event_new_state, "state", None) if event_new_state is not None else None
+    )
+    event_has_new_value = event_new_value is not None
 
     _LOGGER.debug(
         "Handling state change for %s in %s with event: %s",
@@ -706,6 +799,9 @@ async def handle_state_change(
         _LOGGER.warning("Could not extract slot number from entity_id: %s", entity_id)
         return
     slot_num = int(slot_match.group(1))
+    existing_override: dict[str, Any] | None = None
+    if event_has_new_value and coordinator.event_overrides:
+        existing_override = coordinator.event_overrides.overrides.get(slot_num)
 
     if "_reset" in entity_id:
         _LOGGER.debug("Resetting overrides %s for %s.", slot_num, lockname)
@@ -714,12 +810,29 @@ async def handle_state_change(
         )
         return
 
+    if event_has_new_value and coordinator.event_overrides.should_suppress_state_change(
+        slot_num, entity_id, event_new_value
+    ):
+        _LOGGER.debug(
+            "Ignoring coordinator feedback for %s slot %s.",
+            lockname,
+            slot_num,
+        )
+        return
+
     slot_state = hass.states.get(f"switch.{lockname}_code_slot_{slot_num}_enabled")
     _LOGGER.debug("Slot %s state: %s", slot_num, slot_state)
     if slot_state is None:
         return
 
-    if slot_state.state != "on":
+    slot_enabled_entity_id = f"switch.{lockname}_code_slot_{slot_num}_enabled"
+    slot_enabled_state = (
+        event_new_value
+        if event_has_new_value and entity_id == slot_enabled_entity_id
+        else slot_state.state
+    )
+
+    if slot_enabled_state != "on":
         _LOGGER.debug(
             "Slot %s is not enabled, skipping update for %s.",
             slot_num,
@@ -727,47 +840,86 @@ async def handle_state_change(
         )
         return
 
-    slot_code = hass.states.get(f"text.{lockname}_code_slot_{slot_num}_pin")
-    slot_name = hass.states.get(f"text.{lockname}_code_slot_{slot_num}_name")
+    slot_code_entity_id = f"text.{lockname}_code_slot_{slot_num}_pin"
+    slot_name_entity_id = f"text.{lockname}_code_slot_{slot_num}_name"
+    slot_code = hass.states.get(slot_code_entity_id)
+    slot_name = hass.states.get(slot_name_entity_id)
 
-    use_date_range = hass.states.get(
+    use_date_range_entity_id = (
         f"switch.{lockname}_code_slot_{slot_num}_use_date_range_limits"
     )
+    use_date_range = hass.states.get(use_date_range_entity_id)
     _LOGGER.debug("Use Date Range: %s", use_date_range)
-    if use_date_range and use_date_range.state == "on":
-        g_start_time = hass.states.get(
+    use_date_range_state = (
+        event_new_value
+        if event_has_new_value and entity_id == use_date_range_entity_id
+        else use_date_range.state
+        if use_date_range
+        else None
+    )
+    if use_date_range_state == "on":
+        start_time_entity_id = (
             f"datetime.{lockname}_code_slot_{slot_num}_date_range_start"
         )
-        g_end_time = hass.states.get(
-            f"datetime.{lockname}_code_slot_{slot_num}_date_range_end"
-        )
+        end_time_entity_id = f"datetime.{lockname}_code_slot_{slot_num}_date_range_end"
+        g_start_time = hass.states.get(start_time_entity_id)
+        g_end_time = hass.states.get(end_time_entity_id)
     else:
+        start_time_entity_id = ""
+        end_time_entity_id = ""
         g_start_time = None
         g_end_time = None
 
     if slot_code is None:
         return
-    slot_code_value = (
-        "" if slot_code.state in ("unknown", "unavailable") else slot_code.state
-    )
+    if event_has_new_value and entity_id == slot_code_entity_id:
+        slot_code_value = (
+            "" if event_new_value in ("unknown", "unavailable") else event_new_value
+        )
+    elif event_has_new_value and existing_override is not None:
+        slot_code_value = str(existing_override["slot_code"])
+    else:
+        slot_code_value = (
+            "" if slot_code.state in ("unknown", "unavailable") else slot_code.state
+        )
     if slot_name is None:
         return
-    slot_name_value = (
-        "" if slot_name.state in ("unknown", "unavailable") else slot_name.state
-    )
+    if event_has_new_value and entity_id == slot_name_entity_id:
+        slot_name_value = (
+            "" if event_new_value in ("unknown", "unavailable") else event_new_value
+        )
+    elif event_has_new_value and existing_override is not None:
+        slot_name_value = str(existing_override["slot_name"])
+    else:
+        slot_name_value = (
+            "" if slot_name.state in ("unknown", "unavailable") else slot_name.state
+        )
 
     start_time = dt.start_of_local_day()
     end_time = dt.start_of_local_day()
+    if event_has_new_value and existing_override is not None:
+        start_time = existing_override["start_time"]
+        end_time = existing_override["end_time"]
 
     if g_start_time is not None:
-        p_start_time = dt.parse_datetime(g_start_time.state)
-        if p_start_time:
-            start_time = p_start_time
+        if event_has_new_value and entity_id == start_time_entity_id:
+            p_start_time = dt.parse_datetime(event_new_value)
+            if p_start_time:
+                start_time = p_start_time
+        elif not (event_has_new_value and existing_override is not None):
+            p_start_time = dt.parse_datetime(g_start_time.state)
+            if p_start_time:
+                start_time = p_start_time
 
     if g_end_time is not None:
-        p_end_time = dt.parse_datetime(g_end_time.state)
-        if p_end_time:
-            end_time = p_end_time
+        if event_has_new_value and entity_id == end_time_entity_id:
+            p_end_time = dt.parse_datetime(event_new_value)
+            if p_end_time:
+                end_time = p_end_time
+        elif not (event_has_new_value and existing_override is not None):
+            p_end_time = dt.parse_datetime(g_end_time.state)
+            if p_end_time:
+                end_time = p_end_time
 
     _LOGGER.debug(
         "updating overrides for %s slot %s. "
@@ -813,8 +965,8 @@ async def handle_state_change(
         start_time,
         end_time,
     )
-
-    await coordinator.event_overrides.async_check_overrides(coordinator)
+    # Reconciliation runs exclusively from coordinator apply_plan (R-007);
+    # callbacks must not launch reconciliation.
 
 
 async def async_reload_package_platforms(hass: HomeAssistant) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,21 @@
 from __future__ import annotations
 
 from datetime import time
+import inspect
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from unittest.mock import MagicMock
 
+from aiohttp import hdrs
+from aiohttp.client_reqrep import ClientResponse
+from aiohttp.client_reqrep import RequestInfo
+from aiohttp.helpers import TimerNoop
 from aioresponses import aioresponses
+import aioresponses.core as aioresponses_core
+from multidict import CIMultiDict
+from multidict import CIMultiDictProxy
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -28,6 +37,88 @@ if TYPE_CHECKING:
 
 # Enable custom components for testing
 pytest_plugins = ("pytest_homeassistant_custom_component",)
+
+
+def _aioresponses_build_response_aiohttp313(  # noqa: PLR0913
+    self,
+    url,
+    method=hdrs.METH_GET,
+    request_headers=None,
+    status=200,
+    body="",
+    content_type="application/json",
+    payload=None,
+    headers=None,
+    response_class=None,
+    reason=None,
+):
+    """Build a mock ClientResponse compatible with aiohttp >= 3.13.
+
+    aiohttp 3.13 added a required ``stream_writer`` keyword-only
+    argument to ``ClientResponse.__init__``.  This replacement for
+    ``aioresponses.core.RequestMatch._build_response`` injects the
+    extra argument so that ``aioresponses``-based coordinator tests
+    pass without modification.
+    """
+    if response_class is None:
+        response_class = ClientResponse
+    if payload is not None:
+        body = json.dumps(payload)
+    if not isinstance(body, bytes):
+        body = str.encode(body)
+    if request_headers is None:
+        request_headers = {}
+    loop = MagicMock()
+    loop.get_debug.return_value = True
+    kwargs: dict[str, Any] = {}
+    kwargs["request_info"] = RequestInfo(
+        url=url,
+        method=method,
+        headers=CIMultiDictProxy(CIMultiDict(**request_headers)),
+        real_url=url,
+    )
+    kwargs["writer"] = None
+    kwargs["continue100"] = None
+    kwargs["timer"] = TimerNoop()
+    kwargs["traces"] = []
+    kwargs["loop"] = loop
+    kwargs["session"] = None
+    kwargs["stream_writer"] = MagicMock(output_size=0)
+
+    _headers = CIMultiDict({hdrs.CONTENT_TYPE: content_type})
+    if headers:
+        _headers.update(headers)
+    raw_headers = self._build_raw_headers(_headers)
+    resp = response_class(method, url, **kwargs)
+
+    for header in _headers.getall(hdrs.SET_COOKIE, ()):
+        resp.cookies.load(header)
+
+    resp._headers = _headers
+    resp._raw_headers = raw_headers
+    resp.status = status
+    resp.reason = reason
+    resp.content = aioresponses_core.stream_reader_factory(loop)
+    resp.content.feed_data(body)
+    resp.content.feed_eof()
+    return resp
+
+
+def _patch_aioresponses_for_aiohttp_313() -> None:
+    """Apply aioresponses patch when running with aiohttp >= 3.13."""
+    if "stream_writer" not in inspect.signature(ClientResponse).parameters:
+        return  # pragma: no cover
+    if (
+        "stream_writer"
+        in inspect.signature(aioresponses_core.RequestMatch._build_response).parameters
+    ):
+        return  # pragma: no cover
+    aioresponses_core.RequestMatch._build_response = (  # type: ignore[method-assign]
+        _aioresponses_build_response_aiohttp313
+    )
+
+
+_patch_aioresponses_for_aiohttp_313()
 
 _TESTS_ROOT = Path(__file__).parent
 

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -10,8 +10,12 @@ door-code generation, and independent multi-entry updates.
 
 from __future__ import annotations
 
+from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from aioresponses import aioresponses
@@ -423,3 +427,2856 @@ async def test_concurrent_calendar_updates(
     assert coord_b.data is not None
     assert coord_a.event.summary == "Reserved: Guest A"
     assert coord_b.event.summary == "Reserved: Guest B"
+
+
+class TestClearFailureSlotNotReused:
+    """Verify failed clear prevents slot reuse."""
+
+    async def test_clear_failure_slot_not_reused(self) -> None:
+        """A slot that fails to clear is not assigned to a new reservation."""
+        from datetime import datetime
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import SlotAction
+        from custom_components.rental_control.util import OperationResult
+
+        eo = EventOverrides(start_slot=1, max_slots=2)
+        now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        eo.update(1, "c1", "OldGuest", now, now)
+        eo.update(2, "c2", "Slot2", now, now)
+
+        plan = DesiredPlan(plan_id="test-t063", generated_at=now)
+        plan.actions = [SlotAction(kind=ActionKind.CLEAR, slot=1, identity_key=None)]
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        failed_result = OperationResult(
+            kind="clear",
+            slot=1,
+            failed=True,
+            error="lock offline",
+        )
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=failed_result,
+        ):
+            await eo.async_apply_plan(coordinator, plan, {})
+
+        assert eo.overrides[1] is not None
+        assert eo.overrides[1]["slot_name"] == "OldGuest"
+        assert 1 in eo.pending_fences
+
+    async def test_no_double_assignment_after_failed_clear(self) -> None:
+        """A slot with failed clear is not available for new assignment."""
+        from datetime import datetime
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotAction
+        from custom_components.rental_control.util import OperationResult
+
+        eo = EventOverrides(start_slot=1, max_slots=2)
+        now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        eo.update(1, "c1", "OldGuest", now, now)
+        eo.update(2, "", "", now, now)
+
+        start = datetime(2026, 8, 1, 14, tzinfo=timezone.utc)
+        end = datetime(2026, 8, 8, 11, tzinfo=timezone.utc)
+        new_res = Reservation(
+            identity_key="new-res",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="RC New Guest",
+            slot_code="1234",
+        )
+
+        plan = DesiredPlan(plan_id="t063-no-double", generated_at=now)
+        plan.actions = [
+            SlotAction(kind=ActionKind.CLEAR, slot=1, identity_key=None),
+            SlotAction(kind=ActionKind.SET, slot=2, identity_key="new-res"),
+        ]
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides = eo
+        name_state = MagicMock()
+        name_state.state = "New Guest"
+        coordinator.hass.states.get.return_value = name_state
+
+        failed_result = OperationResult(
+            kind="clear",
+            slot=1,
+            failed=True,
+            error="lock offline",
+        )
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=failed_result,
+        ):
+            await eo.async_apply_plan(coordinator, plan, {"new-res": new_res})
+
+        assert eo.overrides[1] is not None
+        assert eo.overrides[1]["slot_name"] == "OldGuest"
+        assert eo.overrides[2] is not None
+        assert eo.overrides[2]["slot_name"] == "New Guest"
+
+
+# ---------------------------------------------------------------------------
+# T093 – Diagnostics desired-vs-actual completeness scenario
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsDesiredVsActual:
+    """T093: Integration scenario proving diagnostics capture all significant
+    slot states: matched slot, overflow reservation, manual drift, and
+    pending clear.
+
+    Uses focused mock-based integration (same pattern as TestClearFailureSlotNotReused)
+    so no HA infrastructure is required.
+    """
+
+    async def test_diagnostics_captures_all_states(self) -> None:
+        """Diagnostics snapshot covers matched, overflow, drift, and pending clear.
+
+        Scenario:
+          - Slot 1 occupied by matching reservation r-match (NOOP action)
+          - Slot 2 pending_clear from a previous failed clear (RETRY_CLEAR)
+          - Reservation r-overflow exceeds capacity and lands in plan.overflow
+          - plan.diagnostics contains per-slot and per-reservation detail
+          - No raw PIN codes appear anywhere in diagnostics
+        """
+        from datetime import datetime
+        from datetime import timezone
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import PlannedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = timezone.utc
+
+        def _mk(key: str, day: int) -> Reservation:
+            """Build a minimal August Reservation with *key* starting on *day*."""
+            from datetime import timedelta
+
+            s = datetime(2026, 8, day, 14, tzinfo=_TZ)
+            e = s + timedelta(days=7)
+            return Reservation(
+                identity_key=key,
+                start=s,
+                end=e,
+                buffered_start=s,
+                buffered_end=e,
+                summary=f"Guest {key}",
+                slot_name=f"Guest {key}",
+                display_slot_name=f"RC Guest {key}",
+                slot_code="SECRETCODE",
+            )
+
+        r_match = _mk("r-match", 1)
+        r_overflow = _mk("r-overflow", 8)
+
+        # Slot 1: occupied by r-match (persisted_identity_key matches)
+        # Slot 2: pending_clear from a prior failed attempt
+        ms1 = ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest r-match",
+            actual_code_present=True,
+            persisted_identity_key="r-match",
+            last_error=None,
+        )
+        ms2 = ManagedSlot(
+            slot=2,
+            managed=True,
+            status=SlotStatus.PENDING_CLEAR,
+            actual_name="OldGuest",
+            actual_code_present=True,
+            retry_count=1,
+            last_error="prior clear failed",
+            blocked_reason="prior clear unconfirmed",
+        )
+
+        generated = datetime(2026, 8, 1, tzinfo=_TZ)
+        plan = compute_desired_plan(
+            [r_match, r_overflow],
+            [ms1, ms2],
+            max_events=1,  # capacity=1 → r_overflow overflows
+            plan_id="t093-diag",
+            generated_at=generated,
+            entry_id="entry-t093",
+            lockname="test_lock",
+            start_slot=1,
+        )
+
+        diag = plan.diagnostics
+
+        # --- Plan metadata present ---
+        assert diag["plan_id"] == "t093-diag"
+        assert diag["entry_id"] == "entry-t093"
+        assert diag["lockname"] == "test_lock"
+        assert diag["start_slot"] == 1
+
+        # --- Matched slot: r-match in slot 1 ---
+        assert "r-match" in plan.selected
+        assert diag["reservations"]["r-match"]["selected"] is True
+        assert diag["reservations"]["r-match"]["assigned_slot"] == 1
+
+        # --- Overflow reservation: r-overflow ---
+        assert "r-overflow" in plan.overflow
+        assert diag["reservations"]["r-overflow"]["selected"] is False
+        assert diag["reservations"]["r-overflow"]["overflow_reason"] is not None
+
+        # --- Pending clear: slot 2 has RETRY_CLEAR action ---
+        assert diag["slots"][2]["action"] == ActionKind.RETRY_CLEAR.value
+        assert diag["slots"][2]["retry_count"] == 1
+        assert diag["slots"][2]["last_error"] == "prior clear failed"
+
+        # --- EventOverrides snapshot also captures this ---
+        eo = EventOverrides(start_slot=1, max_slots=2)
+        eo._pending_clear_slots[2] = "op-token"
+        eo._record_slot_error(2, "prior clear failed")
+
+        # Build a matching plan for the snapshot
+        snap_plan = DesiredPlan(plan_id="t093-snap", generated_at=generated)
+        snap_plan.slots[1] = PlannedSlot(
+            slot=1,
+            desired_identity_key="r-match",
+            actual_classification="occupied",
+            action=ActionKind.NOOP,
+        )
+        snap_plan.slots[2] = PlannedSlot(
+            slot=2,
+            desired_identity_key=None,
+            actual_classification="pending_clear",
+            action=ActionKind.RETRY_CLEAR,
+            pending_reason="prior clear unconfirmed",
+            retry_count=1,
+        )
+
+        eo.update_diagnostics_snapshot(snap_plan)
+        snap = eo.diagnostics_snapshot
+
+        assert 1 in snap["matched_slots"]
+        assert snap["matched_slots"][1]["identity_key"] == "r-match"
+        assert 2 in snap["pending_corrections"]
+        assert 2 in snap["pending_clear_slots"]
+        assert snap["last_slot_errors"][2] == "prior clear failed"
+
+        # --- No raw codes anywhere ---
+        assert "SECRETCODE" not in str(diag)
+        assert "SECRETCODE" not in str(snap)
+        assert "slot_code" not in str(diag)
+        assert "slot_code" not in str(snap)
+
+    async def test_diagnostics_manual_drift_detected(self) -> None:
+        """Manual drift (OVERWRITE_MANUAL_CHANGE) shows in per-slot diagnostics."""
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = timezone.utc
+
+        s = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        r = Reservation(
+            identity_key="r-drift",
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary="Guest Drift",
+            slot_name="Guest Drift",
+            display_slot_name="RC Guest Drift",
+            slot_code="DRIFT_CODE",
+        )
+
+        # Slot occupied with DIFFERENT persisted key → planner will CLEAR then SET
+        # (not OVERWRITE_MANUAL_CHANGE since that happens in apply, but the CLEAR
+        # action + wrong persisted key is visible in diagnostics)
+        ms = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="WrongGuest",
+            actual_code_present=True,
+            persisted_identity_key="r-wrong",  # different from r-drift
+        )
+
+        plan = compute_desired_plan(
+            [r],
+            [ms],
+            max_events=3,
+            plan_id="t093-drift",
+            generated_at=s,
+        )
+
+        slot_diag = plan.diagnostics["slots"][5]
+        # CLEAR because persisted key doesn't match desired key
+        assert slot_diag["action"] == "clear"
+        assert slot_diag["actual_classification"] == "occupied"
+        assert "DRIFT_CODE" not in str(plan.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# T072 / T073: Manual drift correction and unmanaged-slot ignore scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestManualDriftCorrection:
+    """T072 + T073: Integration scenarios for manual/external slot drift.
+
+    T072 verifies that when a managed slot's actual state drifts from the
+    desired plan (name changed), async_apply_plan issues a WARNING log
+    containing the slot number, changed field names, and desired identity —
+    without exposing the raw PIN — and then restores the desired state via
+    async_fire_set_code.
+
+    T073 verifies that edits to unmanaged (out-of-range) slots produce no
+    OVERWRITE_MANUAL_CHANGE action because compute_desired_plan iterates
+    only managed == True slots.
+
+    Uses a focused mock-based approach (no HA infrastructure) mirroring
+    TestClearFailureSlotNotReused.
+    """
+
+    async def test_manual_edit_corrected_and_caplog(self, caplog) -> None:
+        """T072: Name-drifted managed slot is corrected and WARNING logged.
+
+        Scenario:
+          - Reservation r-drift-t072 is assigned to slot 5.
+          - Actual Keymaster name is 'WRONG NAME' (manual drift).
+          - compute_desired_plan generates OVERWRITE_MANUAL_CHANGE for slot 5.
+          - async_apply_plan calls async_fire_set_code and emits WARNING with:
+              slot number, changed field names, desired identity_key.
+          - Raw PIN value never appears in logs.
+          - diagnostics snapshot captures manual_drift_slots entry.
+        """
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+        import logging
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        _TZ = timezone.utc
+        s = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        r = Reservation(
+            identity_key="r-drift-t072",
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary="Guest Drift",
+            slot_name="Guest Drift",
+            display_slot_name="RC Guest Drift",
+            slot_code="SECRETPIN72",
+        )
+
+        ms = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="WRONG NAME",  # manual drift
+            actual_code_present=True,
+            persisted_identity_key="r-drift-t072",
+        )
+
+        plan = compute_desired_plan(
+            [r],
+            [ms],
+            max_events=3,
+            plan_id="t072-drift",
+            generated_at=s,
+        )
+
+        overwrite_actions = [
+            a for a in plan.actions if a.kind is ActionKind.OVERWRITE_MANUAL_CHANGE
+        ]
+        assert len(overwrite_actions) == 1
+        assert overwrite_actions[0].slot == 5
+
+        eo = EventOverrides(start_slot=5, max_slots=1)
+        eo.update(5, "SECRETPIN72", "Guest Drift", s, e)
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ) as mock_set,
+        ):
+            await eo.async_apply_plan(coordinator, plan, {"r-drift-t072": r})
+
+        # async_fire_set_code was called to restore desired state
+        assert mock_set.called
+
+        # WARNING log contains slot number, field names, and identity
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "slot 5" in log_text
+        assert "name" in log_text
+        assert "r-drift-t072" in log_text
+
+        # Raw PIN never appears in WARNING (or above) log records
+        for record in (r for r in caplog.records if r.levelno >= logging.WARNING):
+            assert "SECRETPIN72" not in record.message
+
+        # Diagnostics snapshot captures the drift entry
+        snap = eo.diagnostics_snapshot
+        assert "manual_drift_slots" in snap
+        assert 5 in snap["manual_drift_slots"]
+        drift_info = snap["manual_drift_slots"][5]
+        assert drift_info["identity_key"] == "r-drift-t072"
+        assert "name" in drift_info["drift_fields"]
+        # No raw codes in snapshot
+        assert "SECRETPIN72" not in str(snap)
+
+    async def test_unmanaged_slot_manual_edit_ignored(self) -> None:
+        """T073: Manual edits to unmanaged slots produce no OVERWRITE action.
+
+        Scenario:
+          - Slot 3 is outside the RC-managed range (managed=False).
+          - Its actual_name differs — any drift would normally trigger
+            OVERWRITE_MANUAL_CHANGE, but unmanaged slots are invisible to
+            compute_desired_plan.
+          - Slot 5 is managed and free; the reservation lands there via SET.
+        """
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = timezone.utc
+        s = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        r = Reservation(
+            identity_key="r-unmanaged-t073",
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary="Guest Unmanaged",
+            slot_name="Guest Unmanaged",
+            display_slot_name="RC Guest Unmanaged",
+            slot_code="SECRETPIN73",
+        )
+
+        # Slot 3: unmanaged, heavily drifted — must be completely ignored
+        unmanaged = ManagedSlot(
+            slot=3,
+            managed=False,
+            status=SlotStatus.OCCUPIED,
+            actual_name="EDITED BY OWNER",
+            actual_code_present=True,
+            persisted_identity_key="r-unmanaged-t073",
+        )
+        # Slot 5: managed and free
+        managed_free = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [r],
+            [unmanaged, managed_free],
+            max_events=3,
+            plan_id="t073-unmanaged",
+            generated_at=s,
+        )
+
+        # Unmanaged slot 3 must not appear in slots or actions
+        assert 3 not in plan.slots
+        assert not any(a.slot == 3 for a in plan.actions)
+
+        # No OVERWRITE_MANUAL_CHANGE actions at all
+        overwrite_actions = [
+            a for a in plan.actions if a.kind is ActionKind.OVERWRITE_MANUAL_CHANGE
+        ]
+        assert len(overwrite_actions) == 0
+
+        # Reservation assigned to managed slot 5 via SET
+        set_actions = [a for a in plan.actions if a.kind is ActionKind.SET]
+        assert len(set_actions) == 1
+        assert set_actions[0].slot == 5
+
+
+# ---------------------------------------------------------------------------
+# T047 – #589 triple-assignment duplicate-collapse regression
+# ---------------------------------------------------------------------------
+
+
+class TestTripleAssignmentCollapse:
+    """T047: Regression for #589 — triple duplicate assignment collapses.
+
+    In issue #589, the same reservation ended up programmed into three slots
+    simultaneously.  The reconciliation system must detect this and clear
+    the two non-canonical slots, converging the state in one or two
+    normal refreshes.
+    """
+
+    async def test_triple_assignment_converges_one_refresh(self) -> None:
+        """Three copies of same reservation collapse to one in a single refresh.
+
+        Setup:
+          - Slots 3, 4, 5 all OCCUPIED with persisted_identity_key='r-589'
+          - One active reservation 'r-589'
+          - max_events=3 (only 1 reservation, so slots 4 and 5 must be cleared)
+
+        After one refresh with confirmed clears, slots 4 and 5 are free and
+        slot 3 is the canonical owner.
+        """
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        _TZ = timezone.utc
+        s = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        res = Reservation(
+            identity_key="r-589",
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary="Guest 589",
+            slot_name="Guest 589",
+            display_slot_name="RC Guest 589",
+            slot_code="PIN589",
+        )
+
+        # Corrupt starting state: same reservation in 3 slots
+        slot3 = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="RC Guest 589",
+            actual_code_present=True,
+            persisted_identity_key="r-589",
+            actual_start=s,
+            actual_end=e,
+        )
+        slot4 = ManagedSlot(
+            slot=4,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest 589",
+            actual_code_present=True,
+            persisted_identity_key="r-589",
+        )
+        slot5 = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest 589",
+            actual_code_present=True,
+            persisted_identity_key="r-589",
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3, slot4, slot5],
+            max_events=3,
+            plan_id="t047-triple",
+            generated_at=s,
+        )
+
+        # Canonical slot 3 should keep the reservation
+        assert plan.selected.get("r-589") == 3
+        # Slots 4 and 5 must be cleared
+        clear_slots = {a.slot for a in plan.actions if a.kind is ActionKind.CLEAR}
+        assert 4 in clear_slots
+        assert 5 in clear_slots
+
+        # Apply plan with confirmed clears
+        eo = EventOverrides(start_slot=3, max_slots=3)
+        eo.update(3, "PIN589", "Guest 589", s, e)
+        eo.update(4, "PIN589", "Guest 589", s, e)
+        eo.update(5, "PIN589", "Guest 589", s, e)
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        async def mock_clear(coord, slot, **kwargs):
+            """Return a confirmed clear result for the given slot."""
+            return OperationResult(kind="clear", slot=slot, confirmed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            side_effect=mock_clear,
+        ):
+            await eo.async_apply_plan(coordinator, plan, {"r-589": res})
+
+        # After confirmed clears: slots 4 and 5 freed, slot 3 still occupied
+        assert eo.overrides.get(4) is None
+        assert eo.overrides.get(5) is None
+        assert eo.overrides.get(3) is not None
+
+
+# ---------------------------------------------------------------------------
+# T048 – #521 phantom name-only slot pending-clear then reuse
+# ---------------------------------------------------------------------------
+
+
+class TestPhantomNameOnlySlot:
+    """T048: Regression for #521 — phantom slot becomes pending-clear then reusable.
+
+    In issue #521, a slot had a guest name but no PIN (phantom state).
+    Rental Control must classify it as PHANTOM, issue a CLEAR, and only
+    reuse the slot after a confirmed clear.
+    """
+
+    async def test_phantom_slot_pending_clear_then_free_then_reuse(self) -> None:
+        """PHANTOM slot is cleared then becomes free and reusable.
+
+        Refresh 1: slot has PHANTOM state → CLEAR action issued.
+        After clear confirmed: slot is FREE.
+        Refresh 2: a waiting reservation is assigned (SET) to the now-free slot.
+        """
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        _TZ = timezone.utc
+        s = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        res = Reservation(
+            identity_key="r-521",
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary="Guest 521",
+            slot_name="Guest 521",
+            display_slot_name="RC Guest 521",
+            slot_code="PIN521",
+        )
+
+        # Corrupt starting state: slot 5 is PHANTOM (name only, no PIN)
+        slot5_phantom = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.PHANTOM,
+            actual_name="OldPhantomGuest",
+            actual_code_present=False,
+        )
+
+        # Refresh 1: phantom slot must receive CLEAR, reservation overflows
+        plan1 = compute_desired_plan(
+            [res],
+            [slot5_phantom],
+            max_events=3,
+            plan_id="t048-r1",
+            generated_at=s,
+        )
+
+        assert plan1.slots[5].action is ActionKind.CLEAR
+        assert plan1.slots[5].action.value == "clear"
+
+        # Apply plan 1: confirmed clear
+        eo = EventOverrides(start_slot=5, max_slots=1)
+        eo.update(5, "", "OldPhantomGuest", s, e)
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed_clear = OperationResult(kind="clear", slot=5, confirmed=True)
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=confirmed_clear,
+        ):
+            await eo.async_apply_plan(coordinator, plan1, {})
+
+        # After clear: slot 5 should be free (override cleared)
+        assert eo.overrides.get(5) is None
+        assert 5 not in eo.pending_fences
+
+        # Refresh 2: slot 5 is now FREE → reservation gets SET
+        slot5_free = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.FREE,
+        )
+
+        plan2 = compute_desired_plan(
+            [res],
+            [slot5_free],
+            max_events=3,
+            plan_id="t048-r2",
+            generated_at=s,
+        )
+
+        assert "r-521" in plan2.selected
+        set_actions = [a for a in plan2.actions if a.kind is ActionKind.SET]
+        assert len(set_actions) == 1
+        assert set_actions[0].slot == 5
+
+
+# ---------------------------------------------------------------------------
+# T049 – stale expired assignment self-heal without restart/reload
+# ---------------------------------------------------------------------------
+
+
+class TestStaleExpiredAssignment:
+    """T049: Stale expired assignment self-heals on the next normal refresh.
+
+    A slot occupied by a reservation that is no longer in the calendar feed
+    (expired or cancelled) must be cleared and made available, all within
+    a normal coordinator refresh — no restart or reload required.
+    """
+
+    async def test_stale_assignment_cleared_on_next_refresh(self) -> None:
+        """Stale occupied slot receives CLEAR; slot is freed for a new reservation.
+
+        Setup:
+          - Slot 5 OCCUPIED with r-expired (NOT in current reservations)
+          - r-new needs assignment
+        Refresh 1: slot 5 gets CLEAR; r-new overflows (no free slot).
+        After clear confirmed: slot 5 is FREE.
+        Refresh 2: r-new gets SET to slot 5.
+        """
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        _TZ = timezone.utc
+        s = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+
+        r_new = Reservation(
+            identity_key="r-new-t049",
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="RC New Guest",
+            slot_code="PIN049",
+        )
+
+        # Slot 5 occupied by expired reservation (not in current list)
+        slot5_stale = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="OldExpiredGuest",
+            actual_code_present=True,
+            persisted_identity_key="r-expired-t049",
+        )
+
+        # Refresh 1: r-new needs slot, slot 5 is stale → CLEAR; r-new overflows
+        plan1 = compute_desired_plan(
+            [r_new],  # r-expired NOT in list
+            [slot5_stale],
+            max_events=3,
+            plan_id="t049-r1",
+            generated_at=s,
+        )
+
+        # Slot 5 gets CLEAR (stale)
+        assert plan1.slots[5].action is ActionKind.CLEAR
+        # r-new overflows (no free slot available)
+        assert "r-new-t049" in plan1.overflow
+
+        # Apply plan 1: confirmed clear
+        eo = EventOverrides(start_slot=5, max_slots=1)
+        eo.update(5, "PIN-EXPIRED", "OldExpiredGuest", s, e)
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed_clear = OperationResult(kind="clear", slot=5, confirmed=True)
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=confirmed_clear,
+        ):
+            await eo.async_apply_plan(coordinator, plan1, {})
+
+        assert eo.overrides.get(5) is None
+
+        # Refresh 2: slot 5 now FREE → r-new gets SET
+        slot5_free = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+
+        plan2 = compute_desired_plan(
+            [r_new],
+            [slot5_free],
+            max_events=3,
+            plan_id="t049-r2",
+            generated_at=s,
+        )
+
+        assert "r-new-t049" in plan2.selected
+        set_actions = [a for a in plan2.actions if a.kind is ActionKind.SET]
+        assert any(a.slot == 5 for a in set_actions)
+
+
+# ---------------------------------------------------------------------------
+# T050 – stale mis-assigned slot replaced with desired reservation
+# ---------------------------------------------------------------------------
+
+
+class TestStaleMisassignedSlot:
+    """T050: Stale mis-assigned slot self-heals by clearing and reassigning.
+
+    A slot occupied by reservation A (stale) is cleared so that reservation
+    B (the desired, currently-active reservation) can take the slot on the
+    next refresh cycle.
+    """
+
+    async def test_misassigned_slot_replaced_with_desired_two_refreshes(
+        self,
+    ) -> None:
+        """Mis-assigned slot is cleared on refresh 1; desired reservation SET on refresh 2.
+
+        Setup:
+          - Slot 3 OCCUPIED with r-wrong (NOT in current reservations)
+          - Slot 5 FREE
+          - r-desired is the active reservation
+
+        Refresh 1:
+          - r-desired gets slot 5 (SET — free slot available)
+          - Slot 3 gets CLEAR (stale occupant)
+
+        After clear: slot 3 is FREE (slot 5 already has r-desired).
+        Convergence happens in 1 refresh (r-desired gets a slot immediately).
+        """
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        _TZ = timezone.utc
+        s = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+
+        r_desired = Reservation(
+            identity_key="r-desired-t050",
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary="Desired Guest",
+            slot_name="Desired Guest",
+            display_slot_name="RC Desired Guest",
+            slot_code="PIN050",
+        )
+
+        slot3_wrong = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="WrongGuest",
+            actual_code_present=True,
+            persisted_identity_key="r-wrong-t050",  # NOT in current list
+        )
+        slot5_free = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [r_desired],
+            [slot3_wrong, slot5_free],
+            max_events=3,
+            plan_id="t050-misassign",
+            generated_at=s,
+        )
+
+        # r-desired gets the free slot 5 (SET)
+        assert plan.selected.get("r-desired-t050") == 5
+        set_actions = [a for a in plan.actions if a.kind is ActionKind.SET]
+        assert any(a.slot == 5 for a in set_actions)
+
+        # Slot 3 gets CLEAR (stale r-wrong)
+        clear_actions = [a for a in plan.actions if a.kind is ActionKind.CLEAR]
+        assert any(a.slot == 3 for a in clear_actions)
+
+        # Apply plan with confirmed clears and set
+        eo = EventOverrides(start_slot=3, max_slots=3)
+        eo.update(3, "WRONGPIN", "WrongGuest", s, e)
+        eo.update(4, "", "", s, e)
+        eo.update(5, "", "", s, e)
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_prefix = ""
+        name_state = MagicMock()
+        name_state.state = "Desired Guest"
+        coordinator.hass.states.get.return_value = name_state
+
+        async def mock_clear(coord, slot, **kwargs):
+            """Return a confirmed clear result for the given slot."""
+            return OperationResult(kind="clear", slot=slot, confirmed=True)
+
+        async def mock_set(coord, event, slot):
+            """Return a confirmed set result for the given slot."""
+            return OperationResult(kind="set", slot=slot, confirmed=True)
+
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                side_effect=mock_clear,
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                side_effect=mock_set,
+            ),
+        ):
+            await eo.async_apply_plan(coordinator, plan, {"r-desired-t050": r_desired})
+
+        # Slot 3 cleared (stale removed)
+        assert eo.overrides.get(3) is None
+        # Slot 5 has r-desired
+        assert eo.overrides.get(5) is not None
+
+
+# ---------------------------------------------------------------------------
+# T051 – #535 nearer-not-programmed-when-full corrupt starting state
+# ---------------------------------------------------------------------------
+
+
+class TestNearerNotProgrammedWhenFull:
+    """T051: Regression for #535 — nearer reservation not programmed when all
+    slots are occupied by farther reservations.
+
+    When all managed slots are occupied by later-starting reservations and a
+    nearer reservation arrives, the reconciliation system must:
+    1. Overflow the farthest reservation.
+    2. Clear the farthest slot.
+    3. Assign the nearer reservation to the newly freed slot (may take 2 refreshes
+       if the clear is confirmed after the planning pass).
+    """
+
+    async def test_nearer_programmed_after_farther_cleared(self) -> None:
+        """Nearer reservation wins a slot within 2 refresh cycles.
+
+        Setup (corrupt starting state):
+          - Slot 3: OCCUPIED r-far1 (Aug 15)
+          - Slot 4: OCCUPIED r-far2 (Aug 20)
+          - r-near (Aug 1) arrives — must be assigned within 2 refreshes
+
+        Refresh 1:
+          - r-near selected (soonest); r-far2 overflows (farther, capacity=2)
+          - Slot 4 gets CLEAR (r-far2 not in plan)
+          - r-near overflows (no_free_slot — both slots still OCCUPIED)
+
+        After clear of slot 4: slot 4 FREE.
+        Refresh 2: r-near gets SET to slot 4.
+        """
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        _TZ = timezone.utc
+
+        def _r(key: str, day: int) -> Reservation:
+            """Build a minimal August 2026 Reservation with *key* starting on *day*."""
+            s = datetime(2026, 8, day, 14, tzinfo=_TZ)
+            e = s + timedelta(days=7)
+            return Reservation(
+                identity_key=key,
+                start=s,
+                end=e,
+                buffered_start=s,
+                buffered_end=e,
+                summary=f"Guest {key}",
+                slot_name=f"Guest {key}",
+                display_slot_name=f"RC Guest {key}",
+                slot_code=f"PIN{key}",
+            )
+
+        r_near = _r("r-near-535", 1)
+        r_far1 = _r("r-far1-535", 15)
+        r_far2 = _r("r-far2-535", 20)
+
+        # Corrupt starting state: farther reservations occupy all slots
+        slot3 = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="RC Guest r-far1-535",
+            actual_code_present=True,
+            persisted_identity_key="r-far1-535",
+            actual_start=r_far1.buffered_start,
+            actual_end=r_far1.buffered_end,
+        )
+        slot4 = ManagedSlot(
+            slot=4,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest r-far2-535",
+            actual_code_present=True,
+            persisted_identity_key="r-far2-535",
+            actual_start=r_far2.buffered_start,
+            actual_end=r_far2.buffered_end,
+        )
+
+        # Refresh 1
+        plan1 = compute_desired_plan(
+            [r_near, r_far1, r_far2],
+            [slot3, slot4],
+            max_events=2,
+            plan_id="t051-r1",
+            generated_at=datetime(2026, 8, 1, tzinfo=_TZ),
+        )
+
+        # r-far2 must overflow (farther than r-near and r-far1)
+        assert "r-far2-535" in plan1.overflow
+        # Slot 4 must get CLEAR (r-far2 overflows; its slot has no desired occupant)
+        clear_slot4 = [
+            a for a in plan1.actions if a.kind is ActionKind.CLEAR and a.slot == 4
+        ]
+        assert len(clear_slot4) == 1
+
+        # Apply refresh 1: confirm clear of slot 4
+        eo = EventOverrides(start_slot=3, max_slots=2)
+        eo.update(
+            3,
+            "PINr-far1-535",
+            "Guest r-far1-535",
+            r_far1.buffered_start,
+            r_far1.buffered_end,
+        )
+        eo.update(
+            4,
+            "PINr-far2-535",
+            "Guest r-far2-535",
+            r_far2.buffered_start,
+            r_far2.buffered_end,
+        )
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        async def mock_clear(coord, slot, **kwargs):
+            """Return a confirmed clear result for the given slot."""
+            return OperationResult(kind="clear", slot=slot, confirmed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            side_effect=mock_clear,
+        ):
+            await eo.async_apply_plan(
+                coordinator, plan1, {"r-far1-535": r_far1, "r-near-535": r_near}
+            )
+
+        # Slot 4 freed after confirmed clear
+        assert eo.overrides.get(4) is None
+
+        # Refresh 2: slot 4 now FREE → r-near gets SET
+        slot3_r2 = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest r-far1-535",
+            actual_code_present=True,
+            persisted_identity_key="r-far1-535",
+            actual_start=r_far1.buffered_start,
+            actual_end=r_far1.buffered_end,
+        )
+        slot4_r2 = ManagedSlot(slot=4, managed=True, status=SlotStatus.FREE)
+
+        plan2 = compute_desired_plan(
+            [r_near, r_far1, r_far2],
+            [slot3_r2, slot4_r2],
+            max_events=2,
+            plan_id="t051-r2",
+            generated_at=datetime(2026, 8, 1, tzinfo=_TZ),
+        )
+
+        # r-near must be assigned in refresh 2
+        assert "r-near-535" in plan2.selected
+        set_actions = [a for a in plan2.actions if a.kind is ActionKind.SET]
+        assert any(a.slot == 4 for a in set_actions)
+
+
+# ---------------------------------------------------------------------------
+# T052 – #546 farther-evicts-nearer corrupt starting state
+# ---------------------------------------------------------------------------
+
+
+class TestFartherEvictsNearer:
+    """T052: Regression for #546 — farther reservation evicted a nearer one.
+
+    In issue #546, a farther reservation was programmed into a slot while the
+    nearer reservation (which should have priority) was left unassigned.
+    The reconciliation system must detect and correct this within 1-2 refreshes.
+    """
+
+    async def test_farther_evicted_nearer_corrected_within_two_refreshes(
+        self,
+    ) -> None:
+        """Farther-evicts-nearer corrupt state corrected in ≤2 refresh cycles.
+
+        Setup (corrupt starting state):
+          - Slot 3 OCCUPIED by r-far (Aug 15) — farther has a slot it shouldn't
+          - r-near (Aug 1) — nearer, should have priority but has no slot
+
+        Desired plan (max_events=1):
+          - r-near selected (nearer start time, capacity=1)
+          - r-far overflows (farther, capacity exceeded)
+          - Slot 3: desired_key=None (r-far overflows) → CLEAR
+          - r-near: no free slot (slot 3 occupied) → no_free_slot overflow
+
+        Refresh 1: CLEAR slot 3; r-near overflows.
+        After clear: slot 3 FREE.
+        Refresh 2: r-near gets SET to slot 3.
+        """
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        _TZ = timezone.utc
+
+        def _r(key: str, day: int) -> Reservation:
+            """Build a minimal August 2026 Reservation with *key* starting on *day*."""
+            s = datetime(2026, 8, day, 14, tzinfo=_TZ)
+            e = s + timedelta(days=7)
+            return Reservation(
+                identity_key=key,
+                start=s,
+                end=e,
+                buffered_start=s,
+                buffered_end=e,
+                summary=f"Guest {key}",
+                slot_name=f"Guest {key}",
+                display_slot_name=f"RC Guest {key}",
+                slot_code=f"PIN{key}",
+            )
+
+        r_near = _r("r-near-546", 1)
+        r_far = _r("r-far-546", 15)
+
+        # Corrupt starting state: far has the slot, near is unassigned
+        slot3_far = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest r-far-546",
+            actual_code_present=True,
+            persisted_identity_key="r-far-546",
+            actual_start=r_far.buffered_start,
+            actual_end=r_far.buffered_end,
+        )
+
+        # Refresh 1: r-near selected (nearer), r-far overflows (farther)
+        # slot 3 has r-far but r-far is overflow → slot 3 gets CLEAR
+        # r-near has no persisted slot and no free slot → no_free_slot overflow
+        plan1 = compute_desired_plan(
+            [r_near, r_far],
+            [slot3_far],
+            max_events=1,
+            plan_id="t052-r1",
+            generated_at=datetime(2026, 8, 1, tzinfo=_TZ),
+        )
+
+        # r-far must overflow (farther, capacity=1)
+        assert "r-far-546" in plan1.overflow
+        # Slot 3 gets CLEAR (r-far is overflow, no desired occupant)
+        clear_slot3 = [
+            a for a in plan1.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_slot3) == 1
+
+        # Apply refresh 1: confirm clear of slot 3
+        eo = EventOverrides(start_slot=3, max_slots=1)
+        eo.update(
+            3,
+            "PINr-far-546",
+            "Guest r-far-546",
+            r_far.buffered_start,
+            r_far.buffered_end,
+        )
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        async def mock_clear(coord, slot, **kwargs):
+            """Return a confirmed clear result for the given slot."""
+            return OperationResult(kind="clear", slot=slot, confirmed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            side_effect=mock_clear,
+        ):
+            await eo.async_apply_plan(coordinator, plan1, {})
+
+        # Slot 3 freed
+        assert eo.overrides.get(3) is None
+
+        # Refresh 2: slot 3 FREE → r-near gets SET
+        slot3_free = ManagedSlot(slot=3, managed=True, status=SlotStatus.FREE)
+
+        plan2 = compute_desired_plan(
+            [r_near, r_far],
+            [slot3_free],
+            max_events=1,
+            plan_id="t052-r2",
+            generated_at=datetime(2026, 8, 1, tzinfo=_TZ),
+        )
+
+        assert "r-near-546" in plan2.selected
+        assert plan2.selected["r-near-546"] == 3
+        set_actions = [a for a in plan2.actions if a.kind is ActionKind.SET]
+        assert any(a.slot == 3 for a in set_actions)
+
+
+# ---------------------------------------------------------------------------
+# T083 – restart with persisted Store mapping and UID churn
+# ---------------------------------------------------------------------------
+
+
+class TestRestartWithPersistedMappingAndUidChurn:
+    """T083: Coordinator rehydrates persisted slot mappings after a restart
+    even when the calendar platform reissues a new volatile UID for the
+    same reservation.
+
+    The fingerprint is computed from entry_id + slot_name + dates (not UID)
+    so UID churn does not change the identity key.  After restart the
+    coordinator's _build_reservations() must:
+      1. Find the persisted mapping by fingerprint.
+      2. Load missing_count=0 (no misses) for the recognised reservation.
+      3. Not treat the reservation as absent (no ghost with incremented count).
+    """
+
+    def _make_entry(self, entry_id: str = "rc-restart-t083") -> "MockConfigEntry":
+        """Build a minimal config entry scoped to the restart/UID-churn scenario."""
+        from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Restart Rental",
+            version=10,
+            unique_id=f"restart-{entry_id}",
+            data={
+                "name": "Restart Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "UTC",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 2,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "keymaster_entry_id": "test_lock",
+                "code_buffer_before": 0,
+                "code_buffer_after": 0,
+            },
+            entry_id=entry_id,
+        )
+
+    async def test_uid_churn_does_not_change_identity_key(self) -> None:
+        """T083-1: Same name/dates with new UID produce the same fingerprint.
+
+        This is the fundamental guarantee: UID churn cannot create a new
+        identity so the slot mapping survives platform UID reissuance.
+        """
+        from datetime import timezone
+
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        _TZ = timezone.utc
+        entry_id = "rc-restart-t083"
+        name = "Alice Guest"
+        start = datetime(2026, 7, 1, 16, 0, 0, tzinfo=_TZ)
+        end = datetime(2026, 7, 8, 11, 0, 0, tzinfo=_TZ)
+
+        fp_first_run = make_reservation_fingerprint(entry_id, name, start, end)
+        fp_second_run = make_reservation_fingerprint(entry_id, name, start, end)
+
+        assert fp_first_run == fp_second_run, (
+            "Fingerprint changed between runs — UID churn broke identity stability"
+        )
+
+    async def test_restart_with_persisted_mapping_recognises_reservation(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T083-2: After restart, _build_reservations recognises persisted mapping.
+
+        Simulates:
+          - Store has a mapping for Alice Guest in slot 10 (missing_count=0).
+          - Calendar returns Alice Guest with a NEW volatile UID (churn).
+          - _build_reservations() must find the mapping by fingerprint.
+          - The Reservation built has missing_count=0 (not treated as absent).
+        """
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        _TZ = timezone.utc
+        entry = self._make_entry()
+        entry.add_to_hass(hass)
+
+        frozen_time = datetime(2026, 7, 10, 12, 0, 0, tzinfo=_TZ)
+        start_dt = datetime(2026, 7, 15, 16, 0, 0, tzinfo=_TZ)
+        end_dt = datetime(2026, 7, 22, 11, 0, 0, tzinfo=_TZ)
+        fp = make_reservation_fingerprint(
+            "rc-restart-t083", "Alice Guest", start_dt, end_dt
+        )
+
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "rc-restart-t083",
+            "mappings": {
+                fp: {
+                    "slot": 10,
+                    "status": "occupied",
+                    "operation_id": None,
+                    "operation_kind": None,
+                    "identity": {
+                        "identity_key": fp,
+                        "summary": "Alice Guest",
+                        "slot_name": "Alice Guest",
+                        "uid_aliases": ["uid-alice-old"],
+                        "booking_aliases": [],
+                    },
+                    "missing_count": 0,
+                    "pending_set_since": None,
+                    "pending_clear_since": None,
+                    "fingerprint_history": [],
+                    "updated_at": "2026-07-01T00:00:00+00:00",
+                    "last_observed_actual": {
+                        "slot": 10,
+                        "classification": "occupied",
+                        "name_state": "Alice Guest",
+                        "has_code": True,
+                        "start_state": start_dt.isoformat(),
+                        "end_state": end_dt.isoformat(),
+                        "use_date_range": True,
+                        "enabled": True,
+                    },
+                }
+            },
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        # Inject persisted state (simulating post-restart Store load).
+        coordinator._slot_mappings = store_data
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        # Calendar returns Alice Guest with a NEW UID (churn).
+        ics_body = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\n"
+            "BEGIN:VEVENT\r\n"
+            "DTSTART;VALUE=DATE:20260715\r\n"
+            "DTEND;VALUE=DATE:20260722\r\n"
+            "SUMMARY:Alice Guest\r\nUID:uid-alice-NEW-after-churn\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+
+        mock_plan = MagicMock()
+        mock_plan.plan_id = "t083-restart"
+        mock_plan.selected = {}
+        mock_plan.overflow = {}
+        mock_plan.actions = []
+        mock_plan.diagnostics = {}
+        mock_plan.validate.return_value = []
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ) as mock_compute,
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=ics_body)
+            await coordinator._async_update_data()
+
+        reservations = mock_compute.call_args.kwargs["reservations"]
+        # Exactly one live reservation built from the calendar event.
+        live = [r for r in reservations if r.identity_key == fp]
+        assert len(live) == 1, "Persisted reservation not recognised after UID churn"
+        # Not treated as absent → missing_count stays 0.
+        assert live[0].missing_count == 0
+
+    async def test_restart_uid_churn_no_ghost_created(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T083-3: Recognised reservation does not also generate a ghost entry.
+
+        When the live reservation is found by fingerprint, _build_ghost_reservations
+        must not also create a ghost with incremented missing_count.
+        """
+        from datetime import timezone
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        _TZ = timezone.utc
+        entry = self._make_entry("rc-restart-t083-ghost")
+        entry.add_to_hass(hass)
+
+        frozen_time = datetime(2026, 7, 10, 12, 0, 0, tzinfo=_TZ)
+        start_dt = datetime(2026, 7, 15, 16, 0, 0, tzinfo=_TZ)
+        end_dt = datetime(2026, 7, 22, 11, 0, 0, tzinfo=_TZ)
+        fp = make_reservation_fingerprint(
+            "rc-restart-t083-ghost", "Alice Guest", start_dt, end_dt
+        )
+
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "rc-restart-t083-ghost",
+            "mappings": {
+                fp: {
+                    "slot": 10,
+                    "status": "occupied",
+                    "operation_id": None,
+                    "operation_kind": None,
+                    "identity": {
+                        "identity_key": fp,
+                        "summary": "Alice Guest",
+                        "slot_name": "Alice Guest",
+                        "uid_aliases": [],
+                        "booking_aliases": [],
+                    },
+                    "missing_count": 0,
+                    "pending_set_since": None,
+                    "pending_clear_since": None,
+                    "fingerprint_history": [],
+                    "updated_at": "2026-07-01T00:00:00+00:00",
+                    "last_observed_actual": {
+                        "slot": 10,
+                        "classification": "occupied",
+                        "name_state": "Alice Guest",
+                        "has_code": True,
+                        "start_state": start_dt.isoformat(),
+                        "end_state": end_dt.isoformat(),
+                        "use_date_range": True,
+                        "enabled": True,
+                    },
+                }
+            },
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = store_data
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        # Same reservation with new UID.
+        ics_body = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\n"
+            "BEGIN:VEVENT\r\n"
+            "DTSTART;VALUE=DATE:20260715\r\n"
+            "DTEND;VALUE=DATE:20260722\r\n"
+            "SUMMARY:Alice Guest\r\nUID:uid-alice-brand-new\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+
+        mock_plan = MagicMock()
+        mock_plan.plan_id = "t083-no-ghost"
+        mock_plan.selected = {}
+        mock_plan.overflow = {}
+        mock_plan.actions = []
+        mock_plan.diagnostics = {}
+        mock_plan.validate.return_value = []
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ) as mock_compute,
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=ics_body)
+            await coordinator._async_update_data()
+
+        reservations = mock_compute.call_args.kwargs["reservations"]
+        # Exactly one entry for this fingerprint — no duplicate ghost
+        matching = [r for r in reservations if r.identity_key == fp]
+        assert len(matching) == 1, (
+            f"Expected exactly 1 reservation for fp, got {len(matching)}"
+        )
+        # missing_count must remain 0 — not incremented by ghost logic
+        assert matching[0].missing_count == 0
+
+
+# ---------------------------------------------------------------------------
+# T084 – first-upgrade migration does-not-wipe-working-slots
+# ---------------------------------------------------------------------------
+
+
+class TestFirstUpgradeMigrationNoWipe:
+    """T084: First-upgrade slot adoption leaves working Keymaster slots intact.
+
+    When the HA Store is empty (first upgrade from a version without slot
+    persistence), async_adopt_keymaster_slots() records existing populated
+    slots as 'occupied' without issuing any clear_code service calls.
+
+    This is the integration-level version of T010-2 (unit test).
+    """
+
+    def _make_entry(
+        self,
+        entry_id: str = "rc-upgrade-t084",
+        lockname: str = "upgrade_lock",
+        start_slot: int = 10,
+        max_events: int = 3,
+    ) -> MockConfigEntry:
+        """Build a minimal config entry for the first-upgrade scenario."""
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Upgrade Rental",
+            version=10,
+            unique_id=f"upgrade-{entry_id}",
+            data={
+                "name": "Upgrade Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "UTC",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": start_slot,
+                "max_events": max_events,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "keymaster_entry_id": lockname,
+                "code_buffer_before": 0,
+                "code_buffer_after": 0,
+            },
+            entry_id=entry_id,
+        )
+
+    async def test_adoption_does_not_wipe_codes_scenario(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T084-1: async_adopt_keymaster_slots reads slot state but issues no writes.
+
+        Scenario: first-time setup with two occupied Keymaster slots.
+          - Slot 10: Guest A with PIN 1234
+          - Slot 11: Guest B with PIN 5678
+          - Slot 12: empty
+
+        After adoption, PINs must still be 1234 and 5678 (no wipes).
+        Mappings for slots 10 and 11 must be recorded as occupied.
+        """
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_entry()
+        entry.add_to_hass(hass)
+
+        hass.states.async_set("text.upgrade_lock_code_slot_10_name", "Guest A")
+        hass.states.async_set("text.upgrade_lock_code_slot_10_pin", "1234")
+        hass.states.async_set("text.upgrade_lock_code_slot_11_name", "Guest B")
+        hass.states.async_set("text.upgrade_lock_code_slot_11_pin", "5678")
+        hass.states.async_set("text.upgrade_lock_code_slot_12_name", "")
+        hass.states.async_set("text.upgrade_lock_code_slot_12_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        # Store is empty → first-upgrade path
+        coordinator._slot_mappings = {}
+        await coordinator.async_adopt_keymaster_slots()
+
+        # PINs must not be wiped
+        pin10 = hass.states.get("text.upgrade_lock_code_slot_10_pin")
+        assert pin10 is not None and pin10.state == "1234"
+        pin11 = hass.states.get("text.upgrade_lock_code_slot_11_pin")
+        assert pin11 is not None and pin11.state == "5678"
+
+        # Occupied mappings recorded
+        mappings = coordinator._slot_mappings.get("mappings", {})
+        occupied_slots = {
+            v["slot"] for v in mappings.values() if v["status"] == "occupied"
+        }
+        assert 10 in occupied_slots
+        assert 11 in occupied_slots
+        assert 12 not in occupied_slots
+
+    async def test_adoption_no_raw_pin_in_mappings(self, hass: "HomeAssistant") -> None:
+        """T084-2: Adopted slot mappings contain no raw PIN values.
+
+        The no-raw-PIN invariant must hold for adopted mappings so
+        that the Store never persists sensitive access codes.
+        """
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_entry("rc-upgrade-t084-pin")
+        entry.add_to_hass(hass)
+
+        hass.states.async_set("text.upgrade_lock_code_slot_10_name", "Guest C")
+        hass.states.async_set("text.upgrade_lock_code_slot_10_pin", "9999")
+        hass.states.async_set("text.upgrade_lock_code_slot_11_name", "")
+        hass.states.async_set("text.upgrade_lock_code_slot_11_pin", "")
+        hass.states.async_set("text.upgrade_lock_code_slot_12_name", "")
+        hass.states.async_set("text.upgrade_lock_code_slot_12_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {}
+        await coordinator.async_adopt_keymaster_slots()
+
+        for _key, v in coordinator._slot_mappings.get("mappings", {}).items():
+            last_obs = v.get("last_observed_actual", {})
+            assert "pin" not in last_obs
+            assert "code" not in last_obs
+            assert "slot_code" not in last_obs
+            assert "has_code" in last_obs
+
+
+# ---------------------------------------------------------------------------
+# T085 – two-cycle transient miss tolerance and third-miss clearable
+# ---------------------------------------------------------------------------
+
+
+class TestTwoCycleTransientMissTolerance:
+    """T085: Reservations absent from the feed for 1 or 2 cycles keep their
+    slot; on the third consecutive miss the slot becomes clearable.
+
+    Uses compute_desired_plan directly with Reservations that have the
+    appropriate missing_count pre-set (mirrors what _build_ghost_reservations
+    produces after N missed cycles).
+    """
+
+    def _mk(self, key: str, day: int = 1, *, missing_count: int = 0):  # type: ignore[return]
+        """Build a minimal August 2026 ghost Reservation for miss-tolerance tests."""
+        from datetime import timezone as _tz
+
+        from custom_components.rental_control.reconciliation import Reservation
+
+        _TZ = _tz.utc
+        s = datetime(2026, 8, day, 14, 0, 0, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        return Reservation(
+            identity_key=key,
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary=f"Ghost {key}",
+            slot_name=f"Ghost {key}",
+            display_slot_name=f"RC Ghost {key}",
+            slot_code="",
+            missing_count=missing_count,
+        )
+
+    def _occupied(self, slot: int, key: str, day: int = 1):  # type: ignore[return]
+        """Build an OCCUPIED ManagedSlot for the given slot and identity key."""
+        from datetime import timezone as _tz
+
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+
+        _TZ = _tz.utc
+        s = datetime(2026, 8, day, 14, 0, 0, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        return ManagedSlot(
+            slot=slot,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name=f"RC Ghost {key}",
+            actual_code_present=True,
+            persisted_identity_key=key,
+            actual_start=s,
+            actual_end=e,
+        )
+
+    async def test_miss_cycle_1_slot_retained(self) -> None:
+        """T085-1: After one miss (missing_count=1) the slot is retained.
+
+        The planner still sees the reservation as eligible (count < 3)
+        and keeps NOOP on its slot.
+        """
+        from datetime import timezone as _tz
+
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = _tz.utc
+        res = self._mk("r-t085-miss1", missing_count=1)
+        slot = self._occupied(3, "r-t085-miss1")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot],
+            max_events=1,
+            plan_id="t085-c1",
+            generated_at=datetime(2026, 8, 1, tzinfo=_TZ),
+        )
+
+        assert "r-t085-miss1" in plan.selected
+        clear_actions = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_actions) == 0, (
+            "Slot cleared after only 1 miss — expected retention"
+        )
+
+    async def test_miss_cycle_2_slot_still_retained(self) -> None:
+        """T085-2: After two consecutive misses (missing_count=2) slot still retained."""
+        from datetime import timezone as _tz
+
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = _tz.utc
+        res = self._mk("r-t085-miss2", missing_count=2)
+        slot = self._occupied(3, "r-t085-miss2")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot],
+            max_events=1,
+            plan_id="t085-c2",
+            generated_at=datetime(2026, 8, 1, tzinfo=_TZ),
+        )
+
+        assert "r-t085-miss2" in plan.selected
+        clear_actions = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_actions) == 0, (
+            "Slot cleared after only 2 misses — expected retention"
+        )
+
+    async def test_miss_cycle_3_slot_clearable(self) -> None:
+        """T085-3: After three consecutive misses (missing_count=3) slot becomes clearable.
+
+        The planner excludes the ghost from eligible candidates.  The slot
+        has no desired occupant → CLEAR action generated.
+        """
+        from datetime import timezone as _tz
+
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = _tz.utc
+        res = self._mk("r-t085-miss3", missing_count=3)
+        slot = self._occupied(3, "r-t085-miss3")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot],
+            max_events=1,
+            plan_id="t085-c3",
+            generated_at=datetime(2026, 8, 1, tzinfo=_TZ),
+        )
+
+        assert "r-t085-miss3" not in plan.selected
+        clear_actions = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_actions) == 1, "Expected CLEAR action on third miss"
+
+    async def test_missing_count_incremented_across_cycles_via_coordinator(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T085-4: Coordinator increments missing_count in _slot_mappings each cycle.
+
+        Runs _async_update_data() three times with an empty calendar while
+        a persisted occupied mapping exists.  After three cycles the
+        mapping's missing_count must be 3.
+        """
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = MockConfigEntry(
+            domain="rental_control",
+            title="Ghost Rental",
+            version=10,
+            unique_id="ghost-t085-cycles",
+            data={
+                "name": "Ghost Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "UTC",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 1,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "keymaster_entry_id": "ghost_lock",
+                "code_buffer_before": 0,
+                "code_buffer_after": 0,
+            },
+            entry_id="ghost-t085-cycles",
+        )
+        entry.add_to_hass(hass)
+
+        from datetime import timezone as _tz
+
+        _TZ = _tz.utc
+        fp = "t085cycles" + "0" * 54
+        start_state = "2026-08-01T14:00:00+00:00"
+        end_state = "2026-08-08T11:00:00+00:00"
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "ghost-t085-cycles",
+            "mappings": {
+                fp: {
+                    "slot": 10,
+                    "status": "occupied",
+                    "operation_id": None,
+                    "operation_kind": None,
+                    "identity": {
+                        "identity_key": fp,
+                        "summary": "Ghost A",
+                        "slot_name": "Ghost A",
+                        "uid_aliases": [],
+                        "booking_aliases": [],
+                    },
+                    "missing_count": 0,
+                    "pending_set_since": None,
+                    "pending_clear_since": None,
+                    "fingerprint_history": [],
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                    "last_observed_actual": {
+                        "slot": 10,
+                        "classification": "occupied",
+                        "name_state": "Ghost A",
+                        "has_code": True,
+                        "start_state": start_state,
+                        "end_state": end_state,
+                        "use_date_range": True,
+                        "enabled": True,
+                    },
+                }
+            },
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = store_data
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        empty_ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nEND:VCALENDAR\r\n"
+        )
+        frozen_time = datetime(2026, 8, 10, 12, 0, 0, tzinfo=_TZ)
+
+        def _mock_plan(cycle: int) -> MagicMock:
+            """Build a minimal DesiredPlan mock for one refresh cycle of T085."""
+            mp = MagicMock()
+            mp.plan_id = f"t085-cycle{cycle}"
+            mp.selected = {}
+            mp.overflow = {}
+            mp.actions = []
+            mp.diagnostics = {}
+            mp.validate.return_value = []
+            return mp
+
+        for cycle in range(1, 4):
+            mock_plan = _mock_plan(cycle)
+            with (
+                aioresponses() as mock_session,
+                patch.object(dt_util, "now", return_value=frozen_time),
+                patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+                patch(
+                    "custom_components.rental_control.coordinator.compute_desired_plan",
+                    return_value=mock_plan,
+                ),
+                patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+                patch.object(
+                    coordinator, "async_save_slot_store", new_callable=AsyncMock
+                ),
+            ):
+                mock_session.get("https://example.com/calendar.ics", body=empty_ics)
+                await coordinator._async_update_data()
+
+            mc = coordinator._slot_mappings["mappings"][fp]["missing_count"]
+            assert mc == cycle, (
+                f"After cycle {cycle}: expected missing_count={cycle}, got {mc}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# T086 – reappearing-before-third-miss resets missing_count
+# ---------------------------------------------------------------------------
+
+
+class TestReappearingBeforeThirdMiss:
+    """T086: When a reservation reappears in the feed before the third miss,
+    its missing_count is reset to 0 and its slot is retained without
+    interruption.
+    """
+
+    def _make_entry(self, entry_id: str = "rc-reappear-t086") -> MockConfigEntry:
+        """Build a minimal config entry for the reappear-before-third-miss scenario."""
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Reappear Rental",
+            version=10,
+            unique_id=f"reappear-{entry_id}",
+            data={
+                "name": "Reappear Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "UTC",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 1,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "keymaster_entry_id": "reappear_lock",
+                "code_buffer_before": 0,
+                "code_buffer_after": 0,
+            },
+            entry_id=entry_id,
+        )
+
+    async def test_reappear_at_miss2_resets_count_to_zero(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T086-1: Reservation reappearing on cycle 3 (after 2 misses) resets count.
+
+        Sequence:
+          Cycle 1: absent → missing_count 0→1
+          Cycle 2: absent → missing_count 1→2
+          Cycle 3: PRESENT → missing_count 2→0 (reset)
+        After cycle 3, _slot_mappings missing_count must be 0.
+        """
+        from datetime import timezone as _tz
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        _TZ = _tz.utc
+        entry = self._make_entry()
+        entry.add_to_hass(hass)
+
+        frozen_time = datetime(2026, 8, 10, 12, 0, 0, tzinfo=_TZ)
+        # The coordinator parses VALUE=DATE DTSTART with checkin=16:00 UTC and
+        # DTEND with checkout=11:00 UTC (from the config entry defaults).
+        start_dt = datetime(2026, 8, 15, 16, 0, 0, tzinfo=_TZ)
+        end_dt = datetime(2026, 8, 22, 11, 0, 0, tzinfo=_TZ)
+        fp = make_reservation_fingerprint(
+            "rc-reappear-t086", "Reappear Guest", start_dt, end_dt
+        )
+
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "rc-reappear-t086",
+            "mappings": {
+                fp: {
+                    "slot": 10,
+                    "status": "occupied",
+                    "operation_id": None,
+                    "operation_kind": None,
+                    "identity": {
+                        "identity_key": fp,
+                        "summary": "Reappear Guest",
+                        "slot_name": "Reappear Guest",
+                        "uid_aliases": [],
+                        "booking_aliases": [],
+                    },
+                    "missing_count": 0,
+                    "pending_set_since": None,
+                    "pending_clear_since": None,
+                    "fingerprint_history": [],
+                    "updated_at": "2026-08-01T00:00:00+00:00",
+                    "last_observed_actual": {
+                        "slot": 10,
+                        "classification": "occupied",
+                        "name_state": "Reappear Guest",
+                        "has_code": True,
+                        "start_state": start_dt.isoformat(),
+                        "end_state": end_dt.isoformat(),
+                        "use_date_range": True,
+                        "enabled": True,
+                    },
+                }
+            },
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = store_data
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        empty_ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nEND:VCALENDAR\r\n"
+        )
+        present_ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\n"
+            "BEGIN:VEVENT\r\n"
+            "DTSTART;VALUE=DATE:20260815\r\n"
+            "DTEND;VALUE=DATE:20260822\r\n"
+            "SUMMARY:Reappear Guest\r\nUID:uid-reappear-001\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+
+        def _mock_plan(cycle: int) -> MagicMock:
+            """Build a minimal DesiredPlan mock for one refresh cycle of T086."""
+            mp = MagicMock()
+            mp.plan_id = f"t086-c{cycle}"
+            mp.selected = {}
+            mp.overflow = {}
+            mp.actions = []
+            mp.diagnostics = {}
+            mp.validate.return_value = []
+            return mp
+
+        # Cycles 1 & 2: reservation absent
+        for cycle in range(1, 3):
+            mock_plan = _mock_plan(cycle)
+            with (
+                aioresponses() as mock_session,
+                patch.object(dt_util, "now", return_value=frozen_time),
+                patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+                patch(
+                    "custom_components.rental_control.coordinator.compute_desired_plan",
+                    return_value=mock_plan,
+                ),
+                patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+                patch.object(
+                    coordinator, "async_save_slot_store", new_callable=AsyncMock
+                ),
+            ):
+                mock_session.get("https://example.com/calendar.ics", body=empty_ics)
+                await coordinator._async_update_data()
+
+        mc_after_2 = coordinator._slot_mappings["mappings"][fp]["missing_count"]
+        assert mc_after_2 == 2, f"Expected 2 after two misses, got {mc_after_2}"
+
+        # Cycle 3: reservation REAPPEARS
+        mock_plan3 = _mock_plan(3)
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan3,
+            ),
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=present_ics)
+            await coordinator._async_update_data()
+
+        mc_after_return = coordinator._slot_mappings["mappings"][fp]["missing_count"]
+        assert mc_after_return == 0, (
+            f"Expected missing_count=0 after reappearance, got {mc_after_return}"
+        )
+
+    async def test_reappear_at_miss1_does_not_clear(self) -> None:
+        """T086-2: Reservation with missing_count=1 that reappears stays assigned.
+
+        When the reservation comes back at count=1 (before the tolerance
+        limit), the planner must see it as eligible and assign it to its
+        slot — no CLEAR action generated.
+        """
+        from datetime import timezone as _tz
+
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = _tz.utc
+        # Represents a "reappeared" reservation (missing_count reset to 0)
+        s = datetime(2026, 8, 1, 14, 0, 0, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        res = Reservation(
+            identity_key="r-reappear-t086",
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary="Reappear Guest",
+            slot_name="Reappear Guest",
+            display_slot_name="RC Reappear Guest",
+            slot_code="",
+            missing_count=0,  # reset on reappearance
+        )
+        slot3 = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="RC Reappear Guest",
+            actual_code_present=True,
+            persisted_identity_key="r-reappear-t086",
+            actual_start=s,
+            actual_end=e,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3],
+            max_events=1,
+            plan_id="t086-reappear",
+            generated_at=datetime(2026, 8, 1, tzinfo=_TZ),
+        )
+
+        assert "r-reappear-t086" in plan.selected
+        clear_actions = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_actions) == 0, (
+            "Slot was cleared after reappearance — expected NOOP"
+        )
+
+
+class TestPreservedSemanticsEndToEnd:
+    """T106 end-to-end regression: all preserved semantics in one refresh cycle.
+
+    Verifies that a single coordinator refresh produces the expected
+    *coordinator-level* outcomes for slot names, buffers, honor-PMS-times,
+    code regeneration, and check-in tracking protection.  Each assertion
+    references the coordinator attribute or reconciliation output; no
+    physical Keymaster service calls are made (all patched).
+    """
+
+    async def test_preserved_semantics_single_cycle(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Single cycle covers slot names, buffers, PMS times, code regen, check-in."""
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Regression Rental",
+            version=10,
+            unique_id="t106-regression",
+            data={
+                "name": "Regression Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 1,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+                "code_generation": "date_based",
+                "trim_names": True,
+                "max_name_length": 12,
+                "event_prefix": "RC",
+                "code_buffer_before": 30,
+                "code_buffer_after": 15,
+                "should_update_code": True,
+                "keymaster_entry_id": "front_door",
+            },
+            entry_id="t106_regression",
+        )
+        entry.add_to_hass(hass)
+        MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": "front_door"},
+            entry_id="km_t106_regression",
+        ).add_to_hass(hass)
+
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        ics_body = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20241225
+DTEND;VALUE=DATE:20241230
+UID:t106-reg@example.com
+SUMMARY:Reserved - Alice Bob
+DESCRIPTION:Check-in: 3:00 PM\\nEmail: alice@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+        mock_plan = MagicMock()
+        mock_plan.plan_id = "t106-plan"
+        mock_plan.selected = {}
+        mock_plan.overflow = {}
+        mock_plan.actions = []
+        mock_plan.diagnostics = {}
+        mock_plan.validate.return_value = []
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics", status=200, body=ics_body
+            )
+            coordinator = RentalControlCoordinator(hass, entry)
+            assert coordinator.event_overrides is not None
+            with (
+                patch.object(
+                    coordinator.event_overrides,
+                    "async_apply_plan",
+                    new=AsyncMock(return_value=[]),
+                ),
+                patch.object(
+                    coordinator,
+                    "async_save_slot_store",
+                    new=AsyncMock(),
+                ),
+            ):
+                coordinator.data = await coordinator._async_update_data()
+
+        assert coordinator.honor_event_times is True
+        assert coordinator.trim_names is True
+        assert coordinator.code_buffer_before == 30
+        assert coordinator.code_buffer_after == 15
+        assert len(coordinator.data) == 1
+        event = coordinator.data[0]
+        assert event.start is not None
+        assert event.end is not None
+        assert coordinator.should_update_code is True
+
+
+class TestManualOverrideSurvival:
+    """Regression tests for manual Keymaster override survival."""
+
+    async def test_manual_time_and_code_override_survive_reconciliation(
+        self,
+        hass: "HomeAssistant",
+    ) -> None:
+        """Issue #589: manual time-of-day and PIN edits survive reconcile."""
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.util import OperationResult
+        from custom_components.rental_control.util import handle_state_change
+
+        lockname = "front_door"
+        slot = 10
+
+        def _set_keymaster_slot(
+            name: str,
+            pin: str,
+            start: datetime,
+            end: datetime,
+            *,
+            enabled: bool,
+            use_date_range_limits: bool = True,
+        ) -> None:
+            """Populate the Keymaster entities observed by reconciliation."""
+            hass.states.async_set(
+                f"switch.{lockname}_code_slot_{slot}_enabled",
+                "on" if enabled else "off",
+            )
+            hass.states.async_set(
+                f"switch.{lockname}_code_slot_{slot}_use_date_range_limits",
+                "on" if use_date_range_limits else "off",
+            )
+            hass.states.async_set(
+                f"text.{lockname}_code_slot_{slot}_name",
+                name,
+            )
+            hass.states.async_set(
+                f"text.{lockname}_code_slot_{slot}_pin",
+                pin,
+            )
+            hass.states.async_set(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_start",
+                start.isoformat(),
+            )
+            hass.states.async_set(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_end",
+                end.isoformat(),
+            )
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Manual Override Rental",
+            version=10,
+            unique_id="manual-override-regression",
+            data={
+                "name": "Manual Override Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": slot,
+                "max_events": 1,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "code_generation": "date_based",
+                "should_update_code": True,
+                "keymaster_entry_id": lockname,
+                "refresh_frequency": 5,
+            },
+            entry_id="manual_override_regression",
+        )
+        entry.add_to_hass(hass)
+        MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": lockname},
+            entry_id="km_manual_override_regression",
+        ).add_to_hass(hass)
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator.async_request_refresh = AsyncMock()
+        assert coordinator.event_overrides is not None
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {COORDINATOR: coordinator}
+
+        _set_keymaster_slot(
+            "",
+            "",
+            FROZEN_START_OF_DAY,
+            FROZEN_START_OF_DAY,
+            enabled=False,
+        )
+
+        ics_body = future_ics(summary="Reserved - Manual Guest")
+        set_result = OperationResult(kind="set", slot=slot, confirmed=True)
+        update_result = OperationResult(kind="update_times", slot=slot, confirmed=True)
+        clear_result = OperationResult(kind="clear", slot=slot, confirmed=True)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=FROZEN_TIME),
+            patch.object(
+                dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(return_value=set_result),
+            ) as mock_set_code,
+            patch(
+                "custom_components.rental_control.event_overrides."
+                "async_fire_update_times",
+                new=AsyncMock(return_value=update_result),
+            ) as mock_update_times,
+            patch(
+                "custom_components.rental_control.event_overrides."
+                "async_fire_clear_code",
+                new=AsyncMock(return_value=clear_result),
+            ) as mock_clear_code,
+        ):
+            mock_session.get(entry.data["url"], status=200, body=ics_body, repeat=True)
+
+            coordinator.data = await coordinator._async_update_data()
+            await hass.async_block_till_done()
+
+            assert mock_set_code.call_count == 1
+            override = coordinator.event_overrides.overrides[slot]
+            assert override is not None
+            initial_pin = str(override["slot_code"])
+            initial_start = override["start_time"]
+            initial_end = override["end_time"]
+
+            _set_keymaster_slot(
+                "Manual Guest",
+                initial_pin,
+                initial_start,
+                initial_end,
+                enabled=True,
+            )
+
+            manual_pin = "8642"
+            assert manual_pin != initial_pin
+            manual_start = initial_start.replace(
+                hour=9,
+                minute=15,
+                second=0,
+                microsecond=0,
+            )
+            manual_end = initial_end.replace(
+                hour=20,
+                minute=45,
+                second=0,
+                microsecond=0,
+            )
+            assert manual_start != initial_start
+            assert manual_end != initial_end
+
+            _set_keymaster_slot(
+                "Manual Guest",
+                manual_pin,
+                manual_start,
+                manual_end,
+                enabled=True,
+            )
+
+            event = MagicMock()
+            event.data = {"entity_id": f"text.{lockname}_code_slot_{slot}_pin"}
+            with patch(
+                "custom_components.rental_control.util.asyncio.sleep",
+                new_callable=AsyncMock,
+            ):
+                await handle_state_change(hass, entry, event)
+            await hass.async_block_till_done()
+
+            override = coordinator.event_overrides.overrides[slot]
+            assert override is not None
+            assert override["slot_code"] == manual_pin
+            assert override["start_time"] == manual_start
+            assert override["end_time"] == manual_end
+
+            mock_set_code.reset_mock()
+            mock_update_times.reset_mock()
+            mock_clear_code.reset_mock()
+
+            observed_plan_ids = set()
+            previous_plan_id = (
+                coordinator.latest_plan.plan_id if coordinator.latest_plan else None
+            )
+            for _ in range(2):
+                coordinator.data = await coordinator._async_update_data()
+                await hass.async_block_till_done()
+
+                plan = coordinator.latest_plan
+                assert plan is not None
+                assert plan.plan_id != previous_plan_id
+                assert plan.slots[slot].action is ActionKind.NOOP
+                assert all(action.slot != slot for action in plan.actions)
+                observed_plan_ids.add(plan.plan_id)
+                previous_plan_id = plan.plan_id
+
+            override = coordinator.event_overrides.overrides[slot]
+            assert override is not None
+            assert override["slot_code"] == manual_pin
+            assert override["start_time"] == manual_start
+            assert override["end_time"] == manual_end
+            assert mock_update_times.call_count == 0
+            assert mock_set_code.call_count == 0
+            assert mock_clear_code.call_count == 0
+
+            plan = coordinator.latest_plan
+            assert plan is not None
+            assert len(observed_plan_ids) == 2
+            assert plan.slots[slot].action is ActionKind.NOOP
+            assert all(action.slot != slot for action in plan.actions)
+
+    async def test_manual_time_override_wins_pre_feedback_refresh_race(
+        self,
+        hass: "HomeAssistant",
+    ) -> None:
+        """Manual datetime event values survive a pre-feedback refresh race."""
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.util import OperationResult
+        from custom_components.rental_control.util import handle_state_change
+
+        lockname = "front_door"
+        slot = 10
+
+        def _set_keymaster_slot(
+            name: str,
+            pin: str,
+            start: datetime,
+            end: datetime,
+            *,
+            enabled: bool,
+            use_date_range_limits: bool = True,
+        ) -> None:
+            """Populate the Keymaster entities observed by reconciliation."""
+            hass.states.async_set(
+                f"switch.{lockname}_code_slot_{slot}_enabled",
+                "on" if enabled else "off",
+            )
+            hass.states.async_set(
+                f"switch.{lockname}_code_slot_{slot}_use_date_range_limits",
+                "on" if use_date_range_limits else "off",
+            )
+            hass.states.async_set(
+                f"text.{lockname}_code_slot_{slot}_name",
+                name,
+            )
+            hass.states.async_set(
+                f"text.{lockname}_code_slot_{slot}_pin",
+                pin,
+            )
+            hass.states.async_set(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_start",
+                start.isoformat(),
+            )
+            hass.states.async_set(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_end",
+                end.isoformat(),
+            )
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Manual Race Rental",
+            version=10,
+            unique_id="manual-override-race-regression",
+            data={
+                "name": "Manual Race Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": slot,
+                "max_events": 1,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "code_generation": "date_based",
+                "should_update_code": True,
+                "keymaster_entry_id": lockname,
+                "refresh_frequency": 5,
+            },
+            entry_id="manual_override_race_regression",
+        )
+        entry.add_to_hass(hass)
+        MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": lockname},
+            entry_id="km_manual_override_race_regression",
+        ).add_to_hass(hass)
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator.async_request_refresh = AsyncMock()
+        assert coordinator.event_overrides is not None
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {COORDINATOR: coordinator}
+
+        _set_keymaster_slot(
+            "",
+            "",
+            FROZEN_START_OF_DAY,
+            FROZEN_START_OF_DAY,
+            enabled=False,
+        )
+
+        ics_body = future_ics(summary="Reserved - Manual Guest")
+        set_result = OperationResult(kind="set", slot=slot, confirmed=True)
+        update_result = OperationResult(kind="update_times", slot=slot, confirmed=True)
+        clear_result = OperationResult(kind="clear", slot=slot, confirmed=True)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=FROZEN_TIME),
+            patch.object(
+                dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(return_value=set_result),
+            ) as mock_set_code,
+            patch(
+                "custom_components.rental_control.event_overrides."
+                "async_fire_update_times",
+                new=AsyncMock(return_value=update_result),
+            ) as mock_update_times,
+            patch(
+                "custom_components.rental_control.event_overrides."
+                "async_fire_clear_code",
+                new=AsyncMock(return_value=clear_result),
+            ) as mock_clear_code,
+        ):
+            mock_session.get(entry.data["url"], status=200, body=ics_body, repeat=True)
+
+            coordinator.data = await coordinator._async_update_data()
+            await hass.async_block_till_done()
+
+            assert mock_set_code.call_count == 1
+            override = coordinator.event_overrides.overrides[slot]
+            assert override is not None
+            initial_pin = str(override["slot_code"])
+            initial_start = override["start_time"]
+            initial_end = override["end_time"]
+
+            _set_keymaster_slot(
+                "Manual Guest",
+                initial_pin,
+                initial_start,
+                initial_end,
+                enabled=True,
+            )
+
+            manual_pin = "8642"
+            manual_start = initial_start.replace(
+                hour=9,
+                minute=15,
+                second=0,
+                microsecond=0,
+            )
+            manual_end = initial_end.replace(
+                hour=20,
+                minute=45,
+                second=0,
+                microsecond=0,
+            )
+            assert manual_pin != initial_pin
+            assert manual_start != initial_start
+            assert manual_end != initial_end
+            _set_keymaster_slot(
+                "Manual Guest",
+                manual_pin,
+                manual_start,
+                manual_end,
+                enabled=True,
+            )
+            start_state = hass.states.get(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_start"
+            )
+            end_state = hass.states.get(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_end"
+            )
+            pin_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_pin")
+            assert start_state is not None
+            assert end_state is not None
+            assert pin_state is not None
+
+            mock_set_code.reset_mock()
+            mock_update_times.reset_mock()
+            mock_clear_code.reset_mock()
+
+            coordinator.data = await coordinator._async_update_data()
+            await hass.async_block_till_done()
+
+            plan = coordinator.latest_plan
+            assert plan is not None
+            assert plan.slots[slot].action is ActionKind.UPDATE_TIMES
+            assert mock_update_times.call_count == 1
+            racing_update = mock_update_times.call_args.args[1]
+            assert racing_update.extra_state_attributes["start"] == initial_start
+            assert racing_update.extra_state_attributes["end"] == initial_end
+
+            _set_keymaster_slot(
+                "Manual Guest",
+                manual_pin,
+                initial_start,
+                initial_end,
+                enabled=True,
+            )
+            feedback_start_state = hass.states.get(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_start"
+            )
+            feedback_end_state = hass.states.get(
+                f"datetime.{lockname}_code_slot_{slot}_date_range_end"
+            )
+            assert feedback_start_state is not None
+            assert feedback_end_state is not None
+
+            for changed_state in (start_state, end_state, pin_state):
+                event = MagicMock()
+                event.data = {
+                    "entity_id": changed_state.entity_id,
+                    "new_state": changed_state,
+                }
+                with patch(
+                    "custom_components.rental_control.util.asyncio.sleep",
+                    new_callable=AsyncMock,
+                ):
+                    await handle_state_change(hass, entry, event)
+            for changed_state in (feedback_start_state, feedback_end_state):
+                event = MagicMock()
+                event.data = {
+                    "entity_id": changed_state.entity_id,
+                    "new_state": changed_state,
+                }
+                with patch(
+                    "custom_components.rental_control.util.asyncio.sleep",
+                    new_callable=AsyncMock,
+                ):
+                    await handle_state_change(hass, entry, event)
+            await hass.async_block_till_done()
+
+            override = coordinator.event_overrides.overrides[slot]
+            assert override is not None
+            assert override["slot_code"] == manual_pin
+            assert override["start_time"] == manual_start
+            assert override["end_time"] == manual_end
+
+            mock_set_code.reset_mock()
+            mock_update_times.reset_mock()
+            mock_clear_code.reset_mock()
+
+            coordinator.data = await coordinator._async_update_data()
+            await hass.async_block_till_done()
+
+            plan = coordinator.latest_plan
+            assert plan is not None
+            assert plan.slots[slot].action is ActionKind.UPDATE_TIMES
+            assert mock_update_times.call_count == 1
+            reapply_update = mock_update_times.call_args.args[1]
+            assert reapply_update.extra_state_attributes["start"] == manual_start
+            assert reapply_update.extra_state_attributes["end"] == manual_end
+            assert mock_set_code.call_count == 0
+            assert mock_clear_code.call_count == 0
+
+            _set_keymaster_slot(
+                "Manual Guest",
+                manual_pin,
+                manual_start,
+                manual_end,
+                enabled=True,
+            )
+            mock_update_times.reset_mock()
+
+            coordinator.data = await coordinator._async_update_data()
+            await hass.async_block_till_done()
+
+            plan = coordinator.latest_plan
+            assert plan is not None
+            assert plan.slots[slot].action is ActionKind.NOOP
+            assert all(action.slot != slot for action in plan.actions)
+            assert mock_update_times.call_count == 0

--- a/tests/integration/test_slot_concurrency.py
+++ b/tests/integration/test_slot_concurrency.py
@@ -582,3 +582,144 @@ class TestSingleReservationRegression:
         )
         assert r3.slot == 1
         assert r3.is_new is True
+
+
+class TestCallbackReentrancyFencing:
+    """Callbacks cannot launch reconciliation during a pending operation."""
+
+    @pytest.mark.asyncio
+    async def test_reconciliation_active_during_apply_plan(self) -> None:
+        """reconciliation_active is True during apply_plan execution."""
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import SlotAction
+        from custom_components.rental_control.util import OperationResult
+
+        eo = _populated_eo(start_slot=1, max_slots=2)
+        eo.update(1, "c1", "Guest", _make_dt(2026, 1, 1), _make_dt(2026, 1, 2))
+        observed_active_states: list[bool] = []
+
+        async def mock_clear_code(*args, **kwargs) -> OperationResult:
+            """Record reconciliation_active during the clear call."""
+            observed_active_states.append(eo.reconciliation_active)
+            return OperationResult(kind="clear", slot=1, confirmed=True)
+
+        now = _make_dt(2026, 8, 1)
+        plan = DesiredPlan(plan_id="t064-active", generated_at=now)
+        plan.actions = [SlotAction(kind=ActionKind.CLEAR, slot=1, identity_key=None)]
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            side_effect=mock_clear_code,
+        ):
+            await eo.async_apply_plan(coordinator, plan, {})
+
+        assert len(observed_active_states) == 1
+        assert observed_active_states[0] is True
+        assert eo.reconciliation_active is False
+
+    @pytest.mark.asyncio
+    async def test_handle_state_change_does_not_start_reconciliation(self) -> None:
+        """handle_state_change no longer calls async_check_overrides."""
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.const import COORDINATOR
+        from custom_components.rental_control.const import DOMAIN
+        from custom_components.rental_control.util import handle_state_change
+
+        lockname = "test_lock"
+        slot_num = 1
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = lockname
+        mock_coordinator.trim_names = False
+        mock_coordinator.event_overrides = MagicMock()
+        mock_coordinator.event_overrides.async_check_overrides = AsyncMock()
+        mock_coordinator.update_event_overrides = AsyncMock()
+
+        name_state = MagicMock()
+        name_state.state = "Guest"
+        pin_state = MagicMock()
+        pin_state.state = "1234"
+        enabled_state = MagicMock()
+        enabled_state.state = "on"
+
+        def states_get(entity_id: str):
+            """Return the mocked Keymaster state for the requested entity."""
+            if "enabled" in entity_id:
+                return enabled_state
+            if "pin" in entity_id:
+                return pin_state
+            if "name" in entity_id:
+                return name_state
+            return None
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_id": {COORDINATOR: mock_coordinator}}}
+        hass.states.get = states_get
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock()
+        event.data = {"entity_id": f"switch.{lockname}_code_slot_{slot_num}_enabled"}
+
+        with patch(
+            "custom_components.rental_control.util.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await handle_state_change(hass, config_entry, event)
+
+        mock_coordinator.event_overrides.async_check_overrides.assert_not_called()
+        mock_coordinator.update_event_overrides.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_pending_token_survives_state_change_callback(self) -> None:
+        """A concurrent callback does not clear the active fence token."""
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import SlotAction
+        from custom_components.rental_control.util import OperationResult
+
+        eo = _populated_eo(start_slot=1, max_slots=2)
+        eo.update(1, "c1", "Guest", _make_dt(2026, 1, 1), _make_dt(2026, 1, 2))
+
+        token_during_service_call: list[str | None] = []
+
+        async def mock_clear_with_callback(*args, **kwargs) -> OperationResult:
+            """Record the token and simulate a concurrent callback update."""
+            token_during_service_call.append(eo.pending_fences.get(1))
+            await eo.async_update(
+                slot=2,
+                slot_code="",
+                slot_name="",
+                start_time=_make_dt(2026, 1, 1),
+                end_time=_make_dt(2026, 1, 1),
+            )
+            return OperationResult(kind="clear", slot=1, confirmed=True)
+
+        now = _make_dt(2026, 8, 1)
+        plan = DesiredPlan(plan_id="t064-token", generated_at=now)
+        plan.actions = [SlotAction(kind=ActionKind.CLEAR, slot=1, identity_key=None)]
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            side_effect=mock_clear_with_callback,
+        ):
+            results = await eo.async_apply_plan(coordinator, plan, {})
+
+        assert token_during_service_call[0] is not None
+        assert eo.overrides[1] is None
+        assert results[0].confirmed is True

--- a/tests/unit/test_checkin_sensor.py
+++ b/tests/unit/test_checkin_sensor.py
@@ -4111,6 +4111,7 @@ class TestSupportingComponentAbsence:
 
         assert sensor._is_keymaster_monitoring_enabled() is expected
 
+    @freeze_time("2025-07-15T10:00:00+00:00")
     async def test_checkout_missing_early_expiry_switch_continues(
         self,
         hass: HomeAssistant,
@@ -4191,6 +4192,7 @@ class TestMissingEntryDataFallbacks:
         assert hass.data[DOMAIN] is domain_data
 
     @pytest.mark.parametrize("remove_domain", [True, False])
+    @freeze_time("2025-07-15T10:00:00+00:00")
     async def test_checkout_missing_entry_data_continues_without_early_expiry(
         self,
         hass: HomeAssistant,
@@ -4661,6 +4663,12 @@ class TestEventTrackingStability:
     (summary + start) rather than list position, preventing
     state oscillation when coordinator data reorders.
     """
+
+    @pytest.fixture(autouse=True)
+    def _freeze_midday(self) -> Generator[None, None, None]:
+        """Pin now away from day boundaries for stable follow-on timing tests."""
+        with freeze_time("2025-06-19T12:00:00+00:00"):
+            yield
 
     async def test_find_tracked_event_at_position_zero(
         self,
@@ -5881,3 +5889,125 @@ class TestCheckedInSelfHealing:
 
         # Should remain checked_in
         assert sensor._state == CHECKIN_STATE_CHECKED_IN
+
+
+class TestCheckinTrackingReconciliationRegression:
+    """T105 regression: Check-in state machine preserved under reconciliation.
+
+    Pins two behaviours: the sensor stays checked_in when the reconciler
+    reassigns the tracked reservation to a different slot (the slot_name
+    match is what matters, not the slot number), and the checked_out
+    state is preserved through coordinator updates.
+    """
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_checked_in_preserved_when_slot_reassigned(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Checked-in state survives reconciliation slot reassignment."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        now = dt_util.now()
+        tracked_event = _make_event(
+            summary="Reserved - John Smith",
+            start=now - timedelta(hours=2),
+            end=now + timedelta(days=2),
+        )
+
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_summary = tracked_event.summary
+        sensor._tracked_event_start = tracked_event.start
+        sensor._tracked_event_end = tracked_event.end
+        sensor._tracked_event_slot_name = "John Smith"
+        mock_checkin_coordinator.get_slot_assignment.return_value = 12
+        mock_checkin_coordinator.data = [tracked_event]
+
+        sensor._handle_coordinator_update()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_IN
+        assert sensor._tracked_event_slot_name == "John Smith"
+
+    @freeze_time("2025-07-01T12:00:00+00:00")
+    async def test_checked_out_state_preserved_through_coordinator_update(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Checked-out state is preserved during later coordinator refreshes."""
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        sensor._state = CHECKIN_STATE_CHECKED_OUT
+        sensor._tracked_event_slot_name = "John Smith"
+        sensor._checkout_time = dt_util.now() - timedelta(hours=1)
+        sensor._unsub_timer = MagicMock()
+        mock_checkin_coordinator.data = []
+
+        sensor._handle_coordinator_update()
+
+        assert sensor._state == CHECKIN_STATE_CHECKED_OUT
+
+    async def test_apply_checkin_protection_marks_checked_in_reservation(
+        self,
+        hass: HomeAssistant,
+        mock_checkin_coordinator: MagicMock,
+        mock_checkin_config_entry: MockConfigEntry,
+    ) -> None:
+        """Active checked-in guests are marked protected for reconciliation."""
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+        from custom_components.rental_control.reconciliation import Reservation
+
+        sensor = _create_sensor(
+            hass, mock_checkin_coordinator, mock_checkin_config_entry
+        )
+        sensor._state = CHECKIN_STATE_CHECKED_IN
+        sensor._tracked_event_slot_name = "John Smith"
+
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_checkin_config_entry.entry_id] = {
+            CHECKIN_SENSOR: sensor,
+            COORDINATOR: mock_checkin_coordinator,
+        }
+        mock_checkin_coordinator.hass = hass
+        mock_checkin_coordinator._entry_id = mock_checkin_config_entry.entry_id
+
+        now = dt_util.now()
+        reservations = [
+            Reservation(
+                identity_key="res-john",
+                start=now,
+                end=now + timedelta(days=2),
+                buffered_start=now,
+                buffered_end=now + timedelta(days=2),
+                summary="Reserved - John Smith",
+                slot_name="John Smith",
+                display_slot_name="RC John Smith",
+                slot_code="1234",
+            ),
+            Reservation(
+                identity_key="res-other",
+                start=now,
+                end=now + timedelta(days=2),
+                buffered_start=now,
+                buffered_end=now + timedelta(days=2),
+                summary="Reserved - Other Guest",
+                slot_name="Other Guest",
+                display_slot_name="RC Other Guest",
+                slot_code="5678",
+            ),
+        ]
+
+        RentalControlCoordinator._apply_checkin_protection(
+            mock_checkin_coordinator,
+            reservations,
+        )
+
+        assert reservations[0].protected_active is True
+        assert reservations[1].protected_active is False

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -5460,6 +5460,21 @@ class TestCoordinatorPersistenceUpdate:
         assert adopted_a not in mappings
         assert adopted_b not in mappings
 
+    def test_display_name_trims_full_name_when_prefix_consumes_limit(self) -> None:
+        """Display-name formatting avoids negative guest-name trim lengths."""
+        from custom_components.rental_control.coordinator import (
+            _format_display_slot_name,
+        )
+
+        display_name = _format_display_slot_name(
+            "Guest Name",
+            "VeryLongPrefix ",
+            trim_names=True,
+            max_name_length=8,
+        )
+
+        assert display_name == "VeryLong"
+
     async def test_wedged_350_store_recovers_on_load(
         self, hass: "HomeAssistant"
     ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -9,6 +9,7 @@ import asyncio
 from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from typing import Any
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -1455,6 +1456,97 @@ class TestLocknameSlugification:
 
         assert coordinator.event_overrides is not original_overrides
 
+    async def test_update_config_reloads_persisted_mappings_after_recreation(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify recreated overrides retain persisted slot ownership."""
+        data = dict(mock_config_entry.data)
+        data[CONF_LOCK_ENTRY] = "Front Door"
+        mock_config_entry.add_to_hass(hass)
+        hass.config_entries.async_update_entry(mock_config_entry, data=data)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+        identity_key = "persisted-active"
+        coordinator._slot_mappings = {
+            "mappings": {
+                identity_key: {
+                    "slot": 10,
+                    "status": "occupied",
+                    "identity": {
+                        "identity_key": identity_key,
+                        "summary": "Active Guest",
+                        "slot_name": "Active Guest",
+                        "uid_aliases": [],
+                        "booking_aliases": [],
+                    },
+                    "fingerprint_history": [],
+                }
+            }
+        }
+
+        config = dict(mock_config_entry.data)
+        config.update(mock_config_entry.options)
+        config[CONF_MAX_EVENTS] = coordinator.max_events + 1
+
+        with (
+            patch.object(
+                coordinator,
+                "async_request_refresh",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                coordinator,
+                "async_setup_keymaster_overrides",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await coordinator.update_config(config)
+
+        assert coordinator.event_overrides is not None
+        assert identity_key in coordinator.event_overrides.persisted_mappings
+
+    async def test_update_config_handles_invalid_persisted_mappings(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify config updates do not fail on duplicate persisted slots."""
+        data = dict(mock_config_entry.data)
+        data[CONF_LOCK_ENTRY] = "Front Door"
+        mock_config_entry.add_to_hass(hass)
+        hass.config_entries.async_update_entry(mock_config_entry, data=data)
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+        coordinator._slot_mappings = {
+            "mappings": {
+                "dup-a": {"slot": 10, "status": "occupied"},
+                "dup-b": {"slot": 10, "status": "occupied"},
+            }
+        }
+
+        config = dict(mock_config_entry.data)
+        config.update(mock_config_entry.options)
+        config[CONF_MAX_EVENTS] = coordinator.max_events + 1
+
+        with (
+            patch.object(
+                coordinator,
+                "async_request_refresh",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                coordinator,
+                "async_setup_keymaster_overrides",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await coordinator.update_config(config)
+
+        assert coordinator.event_overrides is not None
+        assert coordinator.event_overrides.persisted_mappings == {}
+
     async def test_update_config_bootstraps_overrides_after_recreation(
         self,
         hass: HomeAssistant,
@@ -1959,7 +2051,7 @@ class TestChildLockDiscovery:
 
 # ===========================================================================
 # Spec 006 Phase 5: Dynamic child lock lifecycle
-# ===========================================================================
+# =============================================================
 
 
 class TestChildLockDynamicLifecycle:
@@ -3957,3 +4049,2677 @@ END:VCALENDAR
         )
         assert event.start == expected_start
         assert event.end == expected_end
+
+
+# ---------------------------------------------------------------------------
+# TestStoreFirstUpgradeMigration (T010 / T011)
+# ---------------------------------------------------------------------------
+
+
+class TestStoreFirstUpgradeMigration:
+    """Tests for first-upgrade keymaster slot adoption (T010/T011)."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_lock_entry(
+        self,
+        entry_id: str = "lock_test_entry",
+        lockname: str = "test_lock",
+        start_slot: int = 10,
+        max_events: int = 3,
+        event_prefix: str = "",
+    ) -> MockConfigEntry:
+        """Create a config entry with a keymaster lockname."""
+        data: dict = {
+            "name": "Lock Rental",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "America/New_York",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            "start_slot": start_slot,
+            "max_events": max_events,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "honor_event_times": False,
+            "keymaster_entry_id": lockname,
+        }
+        if event_prefix:
+            data["event_prefix"] = event_prefix
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Lock Rental",
+            version=10,
+            unique_id=f"lock-{entry_id}",
+            data=data,
+            entry_id=entry_id,
+        )
+
+    # ------------------------------------------------------------------
+    # T010-1: populated slot is adopted with has_code=True
+    # ------------------------------------------------------------------
+
+    async def test_first_upgrade_adopts_populated_keymaster_slot(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T010-1: Slot with name AND code is adopted; has_code=True, no PIN."""
+        from custom_components.rental_control.const import SLOT_STATUS_OCCUPIED
+
+        entry = self._make_lock_entry()
+        entry.add_to_hass(hass)
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Jane Doe")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "1234")
+        hass.states.async_set("text.test_lock_code_slot_11_name", "")
+        hass.states.async_set("text.test_lock_code_slot_11_pin", "")
+        hass.states.async_set("text.test_lock_code_slot_12_name", "")
+        hass.states.async_set("text.test_lock_code_slot_12_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        await coordinator.async_adopt_keymaster_slots()
+
+        mappings = coordinator._slot_mappings.get("mappings", {})
+        assert len(mappings) == 1
+
+        mapping = next(iter(mappings.values()))
+        assert mapping["slot"] == 10
+        assert mapping["status"] == SLOT_STATUS_OCCUPIED
+
+        last_obs = mapping["last_observed_actual"]
+        assert last_obs["has_code"] is True
+        assert "pin" not in last_obs
+        assert "code" not in last_obs
+        assert "slot_code" not in last_obs
+
+    async def test_adoption_loads_event_override_persistence(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T010-1a: Adopted mappings are visible to first reconciliation."""
+        entry = self._make_lock_entry(entry_id="lock_adopt_load_entry")
+        entry.add_to_hass(hass)
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Adopt Me")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "2468")
+        hass.states.async_set("text.test_lock_code_slot_11_name", "")
+        hass.states.async_set("text.test_lock_code_slot_11_pin", "")
+        hass.states.async_set("text.test_lock_code_slot_12_name", "")
+        hass.states.async_set("text.test_lock_code_slot_12_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        await coordinator.async_adopt_keymaster_slots()
+
+        assert coordinator.event_overrides is not None
+        persisted = coordinator.event_overrides.persisted_mappings
+        assert len(persisted) == 1
+        assert next(iter(persisted.values()))["slot"] == 10
+
+    # ------------------------------------------------------------------
+    # T010-2: working code is NOT wiped during adoption
+    # ------------------------------------------------------------------
+
+    async def test_first_upgrade_does_not_wipe_working_codes(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T010-2: async_adopt_keymaster_slots does not wipe Keymaster state."""
+        entry = self._make_lock_entry(entry_id="lock_nowipe_entry")
+        entry.add_to_hass(hass)
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Bob Smith")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "5678")
+        hass.states.async_set("text.test_lock_code_slot_11_name", "")
+        hass.states.async_set("text.test_lock_code_slot_11_pin", "")
+        hass.states.async_set("text.test_lock_code_slot_12_name", "")
+        hass.states.async_set("text.test_lock_code_slot_12_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        await coordinator.async_adopt_keymaster_slots()
+
+        # Verify the PIN entity was NOT wiped — adoption is read-only
+        pin_state = hass.states.get("text.test_lock_code_slot_10_pin")
+        assert pin_state is not None
+        assert pin_state.state == "5678", "PIN should not be wiped during adoption"
+        name_state = hass.states.get("text.test_lock_code_slot_10_name")
+        assert name_state is not None
+        assert name_state.state == "Bob Smith", "Name should not be wiped"
+
+    # ------------------------------------------------------------------
+    # T010-3: empty slot produces no mapping
+    # ------------------------------------------------------------------
+
+    async def test_first_upgrade_empty_slot_not_adopted(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T010-3: Slot with empty name and code produces no mapping."""
+        entry = self._make_lock_entry(entry_id="lock_empty_entry")
+        entry.add_to_hass(hass)
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "")
+        hass.states.async_set("text.test_lock_code_slot_11_name", "")
+        hass.states.async_set("text.test_lock_code_slot_11_pin", "")
+        hass.states.async_set("text.test_lock_code_slot_12_name", "")
+        hass.states.async_set("text.test_lock_code_slot_12_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        await coordinator.async_adopt_keymaster_slots()
+
+        mappings = coordinator._slot_mappings.get("mappings", {})
+        assert len(mappings) == 0
+
+    # ------------------------------------------------------------------
+    # T011-4: prefixed name is stripped in adoption identity
+    # ------------------------------------------------------------------
+
+    async def test_first_upgrade_prefixed_name_adopted(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T011-4: Slot name 'VR Jane Doe' stores slot_name 'Jane Doe'."""
+        entry = self._make_lock_entry(
+            entry_id="lock_prefix_entry",
+            lockname="vr_lock",
+            event_prefix="VR",
+        )
+        entry.add_to_hass(hass)
+
+        hass.states.async_set("text.vr_lock_code_slot_10_name", "VR Jane Doe")
+        hass.states.async_set("text.vr_lock_code_slot_10_pin", "9999")
+        hass.states.async_set("text.vr_lock_code_slot_11_name", "")
+        hass.states.async_set("text.vr_lock_code_slot_11_pin", "")
+        hass.states.async_set("text.vr_lock_code_slot_12_name", "")
+        hass.states.async_set("text.vr_lock_code_slot_12_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        await coordinator.async_adopt_keymaster_slots()
+
+        mappings = coordinator._slot_mappings.get("mappings", {})
+        assert len(mappings) == 1
+
+        mapping = next(iter(mappings.values()))
+        identity = mapping["identity"]
+        assert identity["slot_name"] == "Jane Doe"
+        assert identity["summary"] == "Jane Doe"
+        # Raw name_state retains the full prefixed value
+        assert mapping["last_observed_actual"]["name_state"] == "VR Jane Doe"
+
+    # ------------------------------------------------------------------
+    # T011-5: phantom slot (name without code) → pending_clear
+    # ------------------------------------------------------------------
+
+    async def test_first_upgrade_phantom_slot_pending_clear(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T011-5: Name present but empty code produces pending_clear mapping."""
+        from custom_components.rental_control.const import SLOT_STATUS_PENDING_CLEAR
+
+        entry = self._make_lock_entry(entry_id="lock_phantom_entry")
+        entry.add_to_hass(hass)
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Ghost Guest")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "")
+        hass.states.async_set("text.test_lock_code_slot_11_name", "")
+        hass.states.async_set("text.test_lock_code_slot_11_pin", "")
+        hass.states.async_set("text.test_lock_code_slot_12_name", "")
+        hass.states.async_set("text.test_lock_code_slot_12_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        await coordinator.async_adopt_keymaster_slots()
+
+        mappings = coordinator._slot_mappings.get("mappings", {})
+        assert len(mappings) == 1
+
+        mapping = next(iter(mappings.values()))
+        assert mapping["slot"] == 10
+        assert mapping["status"] == SLOT_STATUS_PENDING_CLEAR
+        assert mapping["last_observed_actual"]["has_code"] is False
+        assert mapping["pending_clear_since"] is not None
+
+    # ------------------------------------------------------------------
+    # T011-6: two occupied slots → both adopted, neither wiped
+    # ------------------------------------------------------------------
+
+    async def test_first_upgrade_ambiguous_slots_blocked(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T011-6: Two populated slots are both adopted without being wiped."""
+        from custom_components.rental_control.const import SLOT_STATUS_OCCUPIED
+
+        entry = self._make_lock_entry(entry_id="lock_ambig_entry")
+        entry.add_to_hass(hass)
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Alice")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "1111")
+        hass.states.async_set("text.test_lock_code_slot_11_name", "Bob")
+        hass.states.async_set("text.test_lock_code_slot_11_pin", "2222")
+        hass.states.async_set("text.test_lock_code_slot_12_name", "")
+        hass.states.async_set("text.test_lock_code_slot_12_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        await coordinator.async_adopt_keymaster_slots()
+
+        mappings = coordinator._slot_mappings.get("mappings", {})
+        assert len(mappings) == 2, "Both slots should be adopted"
+
+        for mapping in mappings.values():
+            assert mapping["status"] == SLOT_STATUS_OCCUPIED
+
+        # Verify neither slot was wiped — entity state is unchanged
+        for entity_id, expected in [
+            ("text.test_lock_code_slot_10_pin", "1111"),
+            ("text.test_lock_code_slot_10_name", "Alice"),
+            ("text.test_lock_code_slot_11_pin", "2222"),
+            ("text.test_lock_code_slot_11_name", "Bob"),
+        ]:
+            state = hass.states.get(entity_id)
+            assert state is not None
+            assert state.state == expected, (
+                f"{entity_id} should not be modified during adoption"
+            )
+
+    # ------------------------------------------------------------------
+    # T011-7: pending_clear fence survives restart (reload)
+    # ------------------------------------------------------------------
+
+    def test_pending_clear_restart_fence(self) -> None:
+        """T011-7: pending_clear fence survives simulated restart."""
+        from custom_components.rental_control.const import SLOT_STATUS_PENDING_CLEAR
+        from custom_components.rental_control.event_overrides import EventOverrides
+
+        phantom_mapping = {
+            "slot": 10,
+            "status": SLOT_STATUS_PENDING_CLEAR,
+            "operation_id": "op-fence-1",
+            "operation_kind": None,
+            "identity": {
+                "identity_key": "phantom-1",
+                "summary": "Ghost",
+                "slot_name": "Ghost",
+                "uid_aliases": [],
+                "booking_aliases": [],
+            },
+            "missing_count": 0,
+            "pending_set_since": None,
+            "pending_clear_since": "2025-06-01T00:00:00+00:00",
+            "fingerprint_history": [],
+            "updated_at": "2025-06-01T00:00:00+00:00",
+            "last_observed_actual": {
+                "slot": 10,
+                "classification": "adopted",
+                "name_state": "Ghost",
+                "has_code": False,
+                "start_state": None,
+                "end_state": None,
+                "use_date_range": None,
+                "enabled": None,
+            },
+        }
+        stored_mappings = {"phantom-1": phantom_mapping}
+
+        # Initial load
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        eo.load_persisted_mappings(stored_mappings)
+        assert 10 in eo.pending_clear_slots
+
+        # Simulate restart: create fresh EventOverrides, reload same data
+        eo2 = EventOverrides(start_slot=10, max_slots=3)
+        eo2.load_persisted_mappings(stored_mappings)
+        assert 10 in eo2.pending_clear_slots, "Fence should be restored after restart"
+
+
+class TestCoordinatorReconciliation:
+    """Tests for coordinator-owned reconciliation (T028/T043)."""
+
+    def _make_reconcile_entry(
+        self,
+        entry_id: str = "reconcile_test_entry",
+        lockname: str = "test_lock",
+        start_slot: int = 10,
+        max_events: int = 3,
+    ) -> MockConfigEntry:
+        """Create a config entry with Keymaster lockname for reconciliation tests."""
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Reconcile Rental",
+            version=10,
+            unique_id=f"reconcile-{entry_id}",
+            data={
+                "name": "Reconcile Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": start_slot,
+                "max_events": max_events,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "keymaster_entry_id": lockname,
+                "code_buffer_before": 0,
+                "code_buffer_after": 0,
+            },
+            entry_id=entry_id,
+        )
+
+    @staticmethod
+    def _make_mock_plan(plan_id: str = "test-plan-id") -> "MagicMock":
+        """Build a minimal DesiredPlan stand-in for coordinator tests."""
+        mock_plan = MagicMock()
+        mock_plan.plan_id = plan_id
+        mock_plan.selected = {}
+        mock_plan.overflow = {}
+        mock_plan.actions = []
+        mock_plan.diagnostics = {}
+        mock_plan.validate.return_value = []
+        return mock_plan
+
+    # ------------------------------------------------------------------
+    # T028-1: one DesiredPlan computed per refresh
+    # ------------------------------------------------------------------
+
+    async def test_refresh_computes_one_desired_plan(self, hass: HomeAssistant) -> None:
+        """T028-1: _async_update_data computes exactly one DesiredPlan per call."""
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_reconcile_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        frozen_time = datetime(2025, 6, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        empty_ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nEND:VCALENDAR\r\n"
+        )
+        mock_plan = self._make_mock_plan("test-plan-id")
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ) as mock_compute,
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=empty_ics)
+            await coordinator._async_update_data()
+
+        mock_compute.assert_called_once()
+        assert coordinator.latest_plan is mock_plan
+
+    # ------------------------------------------------------------------
+    # T028-2: apply_plan called once per refresh
+    # ------------------------------------------------------------------
+
+    async def test_refresh_calls_apply_plan_once(self, hass: HomeAssistant) -> None:
+        """T028-2: async_apply_plan is called exactly once per _async_update_data."""
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_reconcile_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        frozen_time = datetime(2025, 6, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        empty_ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nEND:VCALENDAR\r\n"
+        )
+        mock_plan = self._make_mock_plan("apply-plan-test")
+        mock_apply = AsyncMock(return_value=[])
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ),
+            patch.object(eo, "async_apply_plan", new=mock_apply),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=empty_ics)
+            await coordinator._async_update_data()
+
+        mock_apply.assert_called_once()
+        call_args = mock_apply.call_args
+        assert call_args.args[0] is coordinator
+        assert call_args.args[1] is mock_plan
+
+    # ------------------------------------------------------------------
+    # T028-3: latest_plan published before return
+    # ------------------------------------------------------------------
+
+    async def test_latest_plan_published_after_apply(self, hass: HomeAssistant) -> None:
+        """T028-3: latest_plan is set after apply_plan completes."""
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_reconcile_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.latest_plan is None
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        frozen_time = datetime(2025, 6, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        empty_ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nEND:VCALENDAR\r\n"
+        )
+        mock_plan = self._make_mock_plan("publish-test")
+        mock_plan.selected = {"key-a": 10}
+        mock_plan.overflow = {"key-b": "capacity"}
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ),
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=empty_ics)
+            await coordinator._async_update_data()
+
+        assert coordinator.latest_plan is mock_plan
+        assert coordinator.get_slot_assignment("key-a") == 10
+        assert coordinator.get_overflow_reason("key-b") == "capacity"
+        assert coordinator.latest_overflow == {"key-b": "capacity"}
+
+    # ------------------------------------------------------------------
+    # T028-4: no reconciliation when event_overrides is None
+    # ------------------------------------------------------------------
+
+    async def test_no_reconciliation_without_lockname(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """T028-4: No plan computed when coordinator has no lockname."""
+        from unittest.mock import patch
+
+        mock_config_entry.add_to_hass(hass)
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        coordinator = RentalControlCoordinator(hass, mock_config_entry)
+        assert coordinator.event_overrides is None
+
+        frozen_time = datetime(2025, 6, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        empty_ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nEND:VCALENDAR\r\n"
+        )
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan"
+            ) as mock_compute,
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=empty_ics)
+            await coordinator._async_update_data()
+
+        mock_compute.assert_not_called()
+        assert coordinator.latest_plan is None
+
+    # ------------------------------------------------------------------
+    # T028-5: parser filtering / max_events preserved
+    # ------------------------------------------------------------------
+
+    async def test_max_events_passed_to_planner(self, hass: HomeAssistant) -> None:
+        """T028-5: compute_desired_plan receives coordinator.max_events."""
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_reconcile_entry(max_events=2)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        frozen_time = datetime(2025, 6, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        empty_ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nEND:VCALENDAR\r\n"
+        )
+        mock_plan = self._make_mock_plan("max-events-test")
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ) as mock_compute,
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=empty_ics)
+            await coordinator._async_update_data()
+
+        call_kwargs = mock_compute.call_args.kwargs
+        assert call_kwargs["max_events"] == 2
+
+    # ------------------------------------------------------------------
+    # T043-1: active checked-in guest marked protected
+    # ------------------------------------------------------------------
+
+    async def test_checkin_protection_marks_active_guest(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T043-1: checked_in sensor state marks matching reservation protected_active."""
+        from unittest.mock import patch
+
+        from custom_components.rental_control.const import CHECKIN_SENSOR
+        from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_IN
+        from custom_components.rental_control.const import DOMAIN
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_reconcile_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        mock_checkin = MagicMock()
+        mock_checkin.state = CHECKIN_STATE_CHECKED_IN
+        mock_checkin.extra_state_attributes = {"guest_name": "Alice Smith"}
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            CHECKIN_SENSOR: mock_checkin,
+        }
+
+        frozen_time = datetime(2025, 6, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = frozen_time + timedelta(days=5)
+        future_end = frozen_time + timedelta(days=10)
+        ics_body = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\n"
+            "BEGIN:VEVENT\r\n"
+            f"DTSTART;VALUE=DATE:{future_start.strftime('%Y%m%d')}\r\n"
+            f"DTEND;VALUE=DATE:{future_end.strftime('%Y%m%d')}\r\n"
+            "SUMMARY:Alice Smith\r\nUID:alice-test-uid\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        mock_plan = self._make_mock_plan("protect-test")
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ) as mock_compute,
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=ics_body)
+            await coordinator._async_update_data()
+
+        reservations = mock_compute.call_args.kwargs["reservations"]
+        assert len(reservations) == 1
+        assert reservations[0].slot_name == "Alice Smith"
+        assert reservations[0].protected_active is True
+
+    # ------------------------------------------------------------------
+    # T043-2: no protection when no checkin sensor
+    # ------------------------------------------------------------------
+
+    async def test_no_protection_without_checkin_sensor(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T043-2: No reservations protected when no CheckinTrackingSensor present."""
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_reconcile_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        frozen_time = datetime(2025, 6, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = frozen_time + timedelta(days=5)
+        future_end = frozen_time + timedelta(days=10)
+        ics_body = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\n"
+            "BEGIN:VEVENT\r\n"
+            f"DTSTART;VALUE=DATE:{future_start.strftime('%Y%m%d')}\r\n"
+            f"DTEND;VALUE=DATE:{future_end.strftime('%Y%m%d')}\r\n"
+            "SUMMARY:Bob Jones\r\nUID:bob-test-uid\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        mock_plan = self._make_mock_plan("no-protect-test")
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ) as mock_compute,
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=ics_body)
+            await coordinator._async_update_data()
+
+        reservations = mock_compute.call_args.kwargs["reservations"]
+        assert all(not r.protected_active for r in reservations)
+
+    # ------------------------------------------------------------------
+    # T043-3: checked_out guest marked checked_out not protected
+    # ------------------------------------------------------------------
+
+    async def test_checkin_protection_marks_checked_out_guest(
+        self, hass: HomeAssistant
+    ) -> None:
+        """T043-3: checked_out sensor state sets checked_out flag, not protected."""
+        from unittest.mock import patch
+
+        from custom_components.rental_control.const import CHECKIN_SENSOR
+        from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_OUT
+        from custom_components.rental_control.const import DOMAIN
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_reconcile_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        mock_checkin = MagicMock()
+        mock_checkin.state = CHECKIN_STATE_CHECKED_OUT
+        mock_checkin.extra_state_attributes = {"guest_name": "Carol White"}
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            CHECKIN_SENSOR: mock_checkin,
+        }
+
+        frozen_time = datetime(2025, 6, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        future_start = frozen_time + timedelta(days=3)
+        future_end = frozen_time + timedelta(days=8)
+        ics_body = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\n"
+            "BEGIN:VEVENT\r\n"
+            f"DTSTART;VALUE=DATE:{future_start.strftime('%Y%m%d')}\r\n"
+            f"DTEND;VALUE=DATE:{future_end.strftime('%Y%m%d')}\r\n"
+            "SUMMARY:Carol White\r\nUID:carol-test-uid\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        mock_plan = self._make_mock_plan("checkout-test")
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ) as mock_compute,
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=ics_body)
+            await coordinator._async_update_data()
+
+        reservations = mock_compute.call_args.kwargs["reservations"]
+        assert len(reservations) == 1
+        assert reservations[0].slot_name == "Carol White"
+        assert reservations[0].checked_out is True
+        assert reservations[0].protected_active is False
+
+
+# ---------------------------------------------------------------------------
+# T087: Coordinator rehydrates persisted state on startup
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinatorRehydration:
+    """T087: Coordinator rehydrates mappings, aliases, missing_count, pending
+    fences, and last observed actual state from the HA Store during setup.
+    """
+
+    def _make_rehydrate_entry(
+        self,
+        entry_id: str = "rehydrate_entry",
+        lockname: str = "test_lock",
+        start_slot: int = 10,
+        max_events: int = 2,
+    ) -> "MockConfigEntry":
+        """Config entry with a Keymaster lockname for rehydration tests."""
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Rehydrate Rental",
+            version=10,
+            unique_id=f"rehydrate-{entry_id}",
+            data={
+                "name": "Rehydrate Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "UTC",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": start_slot,
+                "max_events": max_events,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "keymaster_entry_id": lockname,
+                "code_buffer_before": 0,
+                "code_buffer_after": 0,
+            },
+            entry_id=entry_id,
+        )
+
+    def _make_occupied_mapping(
+        self,
+        identity_key: str,
+        slot_name: str,
+        slot: int,
+        *,
+        missing_count: int = 0,
+        uid_aliases: list[str] | None = None,
+        booking_aliases: list[str] | None = None,
+        start_state: str | None = "2026-07-01T14:00:00+00:00",
+        end_state: str | None = "2026-07-08T11:00:00+00:00",
+    ) -> dict:
+        """Build a v1 occupied slot mapping dict for rehydration tests."""
+        return {
+            "slot": slot,
+            "status": "occupied",
+            "operation_id": None,
+            "operation_kind": None,
+            "identity": {
+                "identity_key": identity_key,
+                "summary": slot_name,
+                "slot_name": slot_name,
+                "uid_aliases": uid_aliases or [],
+                "booking_aliases": booking_aliases or [],
+            },
+            "missing_count": missing_count,
+            "pending_set_since": None,
+            "pending_clear_since": None,
+            "fingerprint_history": [],
+            "updated_at": "2026-01-01T00:00:00+00:00",
+            "last_observed_actual": {
+                "slot": slot,
+                "classification": "occupied",
+                "name_state": slot_name,
+                "has_code": True,
+                "start_state": start_state,
+                "end_state": end_state,
+                "use_date_range": True,
+                "enabled": True,
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # T087-1: persisted mappings loaded into event_overrides on startup
+    # ------------------------------------------------------------------
+
+    async def test_rehydration_loads_mappings_into_event_overrides(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T087-1: async_load_slot_store + load_persisted_mappings rehydrates mappings.
+
+        Simulates the init sequence:
+          1. Store data is pre-populated (mocking async_load).
+          2. async_load_slot_store() reads and populates _slot_mappings.
+          3. load_persisted_mappings() injects into event_overrides.
+          4. persisted_mappings on event_overrides contains the rehydrated key.
+        """
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_rehydrate_entry()
+        entry.add_to_hass(hass)
+
+        fp = "cafebabe" + "0" * 56  # stand-in fingerprint (64 hex chars)
+        mapping = self._make_occupied_mapping(fp, "Alice Guest", 10)
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "rehydrate_entry",
+            "lockname": "test_lock",
+            "start_slot": 10,
+            "max_slots": 2,
+            "updated_at": "2026-01-01T00:00:00+00:00",
+            "mappings": {fp: mapping},
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+
+        # Directly populate _slot_mappings to simulate a loaded Store.
+        coordinator._slot_mappings = store_data
+        coordinator.event_overrides.load_persisted_mappings(store_data["mappings"])
+
+        pm = coordinator.event_overrides.persisted_mappings
+        assert fp in pm
+        assert pm[fp]["slot"] == 10
+        assert pm[fp]["status"] == "occupied"
+
+    # ------------------------------------------------------------------
+    # T087-2: missing_count rehydrated from Store mapping
+    # ------------------------------------------------------------------
+
+    async def test_rehydration_preserves_missing_count(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T087-2: Rehydrated mapping preserves non-zero missing_count.
+
+        When the Store recorded missing_count=2 for an absent reservation,
+        that value must survive the load so the planner increments to 3 (not 1)
+        on the next feed miss.
+        """
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_rehydrate_entry()
+        entry.add_to_hass(hass)
+
+        fp = "deadbeef" + "0" * 56
+        mapping = self._make_occupied_mapping(fp, "Bob Guest", 10, missing_count=2)
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "rehydrate_entry",
+            "mappings": {fp: mapping},
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+
+        coordinator._slot_mappings = store_data
+        coordinator.event_overrides.load_persisted_mappings(store_data["mappings"])
+
+        pm = coordinator.event_overrides.persisted_mappings
+        assert pm[fp]["missing_count"] == 2
+
+    # ------------------------------------------------------------------
+    # T087-3: pending_clear_slots rehydrated as pending fences
+    # ------------------------------------------------------------------
+
+    async def test_rehydration_restores_pending_clear_slots(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T087-3: Pending-clear mappings rehydrate as pending_clear_slots fences.
+
+        A mapping with status=pending_clear must be restored as a pending
+        fence so the coordinator re-attempts the clear rather than
+        treating the slot as free.
+        """
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_rehydrate_entry()
+        entry.add_to_hass(hass)
+
+        fp = "fedcba98" + "0" * 56
+        pending_mapping: dict = {
+            **self._make_occupied_mapping(fp, "Carol Guest", 10),
+            "status": "pending_clear",
+            "operation_id": "op-abc123",
+            "pending_clear_since": "2026-01-01T00:00:00+00:00",
+        }
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "rehydrate_entry",
+            "mappings": {fp: pending_mapping},
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+
+        coordinator._slot_mappings = store_data
+        coordinator.event_overrides.load_persisted_mappings(store_data["mappings"])
+
+        # pending_clear_slots maps slot→operation_id
+        pcs = coordinator.event_overrides.pending_clear_slots
+        assert 10 in pcs
+        assert pcs[10] == "op-abc123"
+
+    # ------------------------------------------------------------------
+    # T087-4: uid_aliases and booking_aliases rehydrated from identity dict
+    # ------------------------------------------------------------------
+
+    async def test_rehydration_preserves_identity_aliases(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T087-4: Identity aliases (uid_aliases, booking_aliases) survive load.
+
+        These aliases are used by find_reservation_rematch for UID-churn
+        and booking-platform alias matching after a restart.
+        """
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_rehydrate_entry()
+        entry.add_to_hass(hass)
+
+        fp = "aabbccdd" + "0" * 56
+        mapping = self._make_occupied_mapping(
+            fp,
+            "Dave Guest",
+            10,
+            uid_aliases=["uid-dave-001", "uid-dave-002"],
+            booking_aliases=["HMABCDE1234"],
+        )
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "rehydrate_entry",
+            "mappings": {fp: mapping},
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+
+        coordinator._slot_mappings = store_data
+        coordinator.event_overrides.load_persisted_mappings(store_data["mappings"])
+
+        pm = coordinator.event_overrides.persisted_mappings
+        assert pm[fp]["identity"]["uid_aliases"] == ["uid-dave-001", "uid-dave-002"]
+        assert pm[fp]["identity"]["booking_aliases"] == ["HMABCDE1234"]
+
+    # ------------------------------------------------------------------
+    # T087-5: no-raw-PIN invariant maintained after rehydration
+    # ------------------------------------------------------------------
+
+    async def test_rehydration_maintains_no_raw_pin_invariant(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T087-5: Rehydrated last_observed_actual never contains raw PINs.
+
+        The Store load path strips pin/code/slot_code keys from
+        last_observed_actual.  After async_load_slot_store(), none of
+        those keys should appear in the loaded mapping.
+        """
+        from unittest.mock import AsyncMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_rehydrate_entry()
+        entry.add_to_hass(hass)
+
+        fp = "11223344" + "0" * 56
+        mapping = self._make_occupied_mapping(fp, "Eve Guest", 10)
+        # Simulate a poorly-written store that leaked PIN fields.
+        mapping["last_observed_actual"]["pin"] = "9876"
+        mapping["last_observed_actual"]["slot_code"] = "1234"
+
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "rehydrate_entry",
+            "mappings": {fp: mapping},
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+
+        # async_load_slot_store strips PIN fields during load.
+        with patch("custom_components.rental_control.coordinator.Store") as MockStore:
+            mock_store_instance = AsyncMock()
+            mock_store_instance.async_load = AsyncMock(return_value=store_data)
+            mock_store_instance.async_save = AsyncMock()
+            MockStore.return_value = mock_store_instance
+            coordinator._store = mock_store_instance
+            await coordinator.async_load_slot_store()
+
+        loaded = coordinator._slot_mappings
+        for v in loaded.get("mappings", {}).values():
+            last_obs = v.get("last_observed_actual", {})
+            assert "pin" not in last_obs
+            assert "code" not in last_obs
+            assert "slot_code" not in last_obs
+
+
+# ---------------------------------------------------------------------------
+# T088: Coordinator updates _slot_mappings across refresh cycles
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinatorPersistenceUpdate:
+    """T088: _slot_mappings is updated after each refresh cycle so that
+    missing_count increments (and resets) survive across restarts via the
+    HA Store.
+    """
+
+    def _make_persist_entry(
+        self,
+        entry_id: str = "persist_entry",
+        lockname: str = "test_lock",
+        start_slot: int = 10,
+        max_events: int = 2,
+    ) -> "MockConfigEntry":
+        """Build a minimal config entry for persistence update tests."""
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Persist Rental",
+            version=10,
+            unique_id=f"persist-{entry_id}",
+            data={
+                "name": "Persist Rental",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "UTC",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": start_slot,
+                "max_events": max_events,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": False,
+                "keymaster_entry_id": lockname,
+                "code_buffer_before": 0,
+                "code_buffer_after": 0,
+            },
+            entry_id=entry_id,
+        )
+
+    def _make_occupied_mapping(
+        self,
+        identity_key: str,
+        slot_name: str,
+        slot: int,
+        *,
+        missing_count: int = 0,
+        start_state: str | None = "2026-07-01T14:00:00+00:00",
+        end_state: str | None = "2026-07-08T11:00:00+00:00",
+    ) -> dict:
+        """Build a v1 occupied slot mapping dict for persistence update tests."""
+        return {
+            "slot": slot,
+            "status": "occupied",
+            "operation_id": None,
+            "operation_kind": None,
+            "identity": {
+                "identity_key": identity_key,
+                "summary": slot_name,
+                "slot_name": slot_name,
+                "uid_aliases": [],
+                "booking_aliases": [],
+            },
+            "missing_count": missing_count,
+            "pending_set_since": None,
+            "pending_clear_since": None,
+            "fingerprint_history": [],
+            "updated_at": "2026-01-01T00:00:00+00:00",
+            "last_observed_actual": {
+                "slot": slot,
+                "classification": "occupied",
+                "name_state": slot_name,
+                "has_code": True,
+                "start_state": start_state,
+                "end_state": end_state,
+                "use_date_range": True,
+                "enabled": True,
+            },
+        }
+
+    async def test_no_wipe_when_adopted_slots_fail_rematch(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """3.5.0 repro: unrematched adopted occupied slots are preserved."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry(max_events=3)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator.event_prefix = "RC"
+        coordinator.trim_names = True
+        coordinator.max_name_length = 16
+        assert coordinator.event_overrides is not None
+
+        adopted_names = {
+            10: "RC Alexander",
+            11: "RC Repeat Guest",
+            12: "RC Repeat Guest",
+        }
+        for slot, name in adopted_names.items():
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_name", name)
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_pin", "1234")
+
+        await coordinator.async_adopt_keymaster_slots()
+
+        events = []
+        for summary, start_day in (
+            ("RC Alexander Very Long Guest Name", 1),
+            ("RC Repeat Guest Family A", 10),
+            ("RC Repeat Guest Family B", 20),
+        ):
+            event = MagicMock()
+            event.summary = summary
+            event.description = ""
+            event.start = datetime(2026, 8, start_day, 16, 0, tzinfo=dt_util.UTC)
+            event.end = event.start + timedelta(days=4)
+            event.uid = None
+            events.append(event)
+
+        reservations = coordinator._build_reservations(events)
+        observed = coordinator._observe_managed_slots()
+        plan = compute_desired_plan(
+            reservations,
+            observed,
+            max_events=coordinator.max_events,
+            plan_id="adopted-no-wipe",
+            generated_at=datetime(2026, 8, 1, tzinfo=dt_util.UTC),
+        )
+
+        assert not [
+            action
+            for action in plan.actions
+            if action.kind is ActionKind.CLEAR and action.slot in adopted_names
+        ]
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            new_callable=AsyncMock,
+            return_value=OperationResult(kind="clear", slot=10, confirmed=True),
+        ) as mock_clear:
+            await coordinator.event_overrides.async_apply_plan(
+                coordinator, plan, {res.identity_key: res for res in reservations}
+            )
+
+        mock_clear.assert_not_called()
+
+    def test_pending_clear_self_heals_when_physically_empty(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """3.5.0 repro: physically empty pending-clear slots become free."""
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        entry = self._make_persist_entry(max_events=2)
+        entry.add_to_hass(hass)
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        store_mappings = {}
+        for slot in (10, 11):
+            key = f"wedged-{slot}"
+            mapping = self._make_occupied_mapping(key, f"Old Guest {slot}", slot)
+            mapping["status"] = "pending_clear"
+            mapping["operation_id"] = f"clear-token-{slot}"
+            mapping["operation_kind"] = "clear"
+            mapping["pending_clear_since"] = "2026-08-01T00:00:00+00:00"
+            store_mappings[key] = mapping
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_name", "")
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_pin", "")
+
+        reservations = [
+            Reservation(
+                identity_key=f"new-{slot}",
+                start=start + timedelta(days=index * 7),
+                end=end + timedelta(days=index * 7),
+                buffered_start=start + timedelta(days=index * 7),
+                buffered_end=end + timedelta(days=index * 7),
+                summary=f"New Guest {slot}",
+                slot_name=f"New Guest {slot}",
+                display_slot_name=f"New Guest {slot}",
+                slot_code="1234",
+            )
+            for index, slot in enumerate((10, 11))
+        ]
+
+        for _restart in range(2):
+            coordinator = RentalControlCoordinator(hass, entry)
+            coordinator._slot_mappings = {
+                "schema_version": 1,
+                "entry_id": entry.entry_id,
+                "mappings": {key: dict(value) for key, value in store_mappings.items()},
+                "blocked_slots": {},
+            }
+            assert coordinator.event_overrides is not None
+            coordinator.event_overrides.load_persisted_mappings(
+                coordinator._slot_mappings["mappings"]
+            )
+
+            observed = coordinator._observe_managed_slots()
+            assert all(slot.status is SlotStatus.FREE for slot in observed)
+
+            plan = compute_desired_plan(
+                reservations,
+                observed,
+                max_events=2,
+                plan_id=f"pending-clear-self-heal-{_restart}",
+                generated_at=start,
+            )
+
+            assert plan.overflow == {}
+            assert set(plan.selected) == {"new-10", "new-11"}
+            assert sorted(plan.selected.values()) == [10, 11]
+
+    def test_pending_clear_stays_fenced_when_state_unreadable(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Pending-clear slots are not freed from unknown/unavailable states."""
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        entry = self._make_persist_entry(max_events=1)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        mapping = self._make_occupied_mapping("wedged-unknown", "Old Guest", 10)
+        mapping["status"] = "pending_clear"
+        mapping["operation_id"] = "clear-token"
+        mapping["operation_kind"] = "clear"
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {"wedged-unknown": mapping},
+            "blocked_slots": {},
+        }
+        hass.states.async_set("text.test_lock_code_slot_10_name", "unknown")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "unavailable")
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+
+        observed = coordinator._observe_managed_slots()
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        assert slot10.status is SlotStatus.PENDING_CLEAR
+
+        reservation = Reservation(
+            identity_key="new-unreadable",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="New Guest",
+            slot_code="1234",
+        )
+        plan = compute_desired_plan(
+            [reservation],
+            observed,
+            max_events=1,
+            plan_id="pending-clear-unreadable",
+            generated_at=start,
+        )
+
+        assert plan.selected == {}
+        assert plan.overflow == {"new-unreadable": "no_free_slot"}
+
+    def test_adoption_rematch_uses_buffered_observed_dates(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Ambiguous trimmed adopted names use observed buffered dates."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_persist_entry(max_events=2)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator.event_prefix = "RC"
+        coordinator.trim_names = True
+        coordinator.max_name_length = 16
+        coordinator.code_buffer_before = 60
+        coordinator.code_buffer_after = 120
+        start_a = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end_a = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        start_b = datetime(2026, 8, 10, 16, 0, tzinfo=dt_util.UTC)
+        end_b = datetime(2026, 8, 14, 11, 0, tzinfo=dt_util.UTC)
+        adopted_a = f"adopted.{entry.entry_id}.slot10"
+        adopted_b = f"adopted.{entry.entry_id}.slot11"
+        mapping_a = self._make_occupied_mapping(adopted_a, "Repeat Guest", 10)
+        mapping_b = self._make_occupied_mapping(adopted_b, "Repeat Guest", 11)
+        mapping_a["last_observed_actual"]["name_state"] = "RC Repeat Guest"
+        mapping_b["last_observed_actual"]["name_state"] = "RC Repeat Guest"
+        mapping_a["last_observed_actual"]["start_state"] = (
+            start_a - timedelta(minutes=60)
+        ).isoformat()
+        mapping_a["last_observed_actual"]["end_state"] = (
+            end_a + timedelta(minutes=120)
+        ).isoformat()
+        mapping_b["last_observed_actual"]["start_state"] = (
+            start_b - timedelta(minutes=60)
+        ).isoformat()
+        mapping_b["last_observed_actual"]["end_state"] = (
+            end_b + timedelta(minutes=120)
+        ).isoformat()
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {adopted_a: mapping_a, adopted_b: mapping_b},
+            "blocked_slots": {},
+        }
+
+        events = []
+        for summary, start, end in (
+            ("RC Repeat Guest Family A", start_a, end_a),
+            ("RC Repeat Guest Family B", start_b, end_b),
+        ):
+            event = MagicMock()
+            event.summary = summary
+            event.description = ""
+            event.start = start
+            event.end = end
+            event.uid = None
+            events.append(event)
+
+        coordinator._build_reservations(events)
+
+        expected_a = make_reservation_fingerprint(
+            entry.entry_id, "Repeat Guest Family A", start_a, end_a
+        )
+        expected_b = make_reservation_fingerprint(
+            entry.entry_id, "Repeat Guest Family B", start_b, end_b
+        )
+        mappings = coordinator._slot_mappings["mappings"]
+        assert mappings[expected_a]["slot"] == 10
+        assert mappings[expected_b]["slot"] == 11
+        assert adopted_a not in mappings
+        assert adopted_b not in mappings
+
+    async def test_wedged_350_store_recovers_on_load(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """3.5.0 repro: a wedged Store self-heals and programs codes."""
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry(max_events=2)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 10, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 10, 5, 11, 0, tzinfo=dt_util.UTC)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {},
+            "blocked_slots": {},
+        }
+        for slot in (10, 11):
+            key = f"adopted.{entry.entry_id}.slot{slot}"
+            mapping = self._make_occupied_mapping(key, f"Wedged Guest {slot}", slot)
+            mapping["status"] = "pending_clear"
+            mapping["operation_id"] = f"clear-token-{slot}"
+            mapping["operation_kind"] = "clear"
+            mapping["pending_clear_since"] = "2026-08-01T00:00:00+00:00"
+            coordinator._slot_mappings["mappings"][key] = mapping
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_name", "")
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_pin", "")
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+
+        events = []
+        for slot, guest in ((10, "Recovered Guest A"), (11, "Recovered Guest B")):
+            event = MagicMock()
+            event.summary = guest
+            event.description = ""
+            event.start = start + timedelta(days=(slot - 10) * 7)
+            event.end = end + timedelta(days=(slot - 10) * 7)
+            event.uid = f"uid-{slot}"
+            events.append(event)
+
+        reservations = coordinator._build_reservations(events)
+        observed = coordinator._observe_managed_slots()
+        plan = compute_desired_plan(
+            reservations,
+            observed,
+            max_events=2,
+            plan_id="wedged-store-recovers",
+            generated_at=start,
+        )
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            new_callable=AsyncMock,
+            return_value=OperationResult(kind="set", slot=10, confirmed=True),
+        ) as mock_set:
+            await coordinator.event_overrides.async_apply_plan(
+                coordinator, plan, {res.identity_key: res for res in reservations}
+            )
+
+        assert plan.overflow == {}
+        assert sorted(plan.selected.values()) == [10, 11]
+        assert mock_set.call_count == 2
+
+    # ------------------------------------------------------------------
+    # T088-1: missing_count incremented for absent occupied slot after cycle
+    # ------------------------------------------------------------------
+
+    async def test_missing_count_incremented_for_absent_occupied_slot(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-1: _slot_mappings missing_count incremented when reservation absent.
+
+        When an occupied persisted mapping is not present in the current
+        calendar feed, the coordinator's _build_ghost_reservations()
+        increments missing_count in _slot_mappings so that the new value
+        is persisted by async_save_slot_store at cycle end.
+        """
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+
+        fp = "aabbccddeeff0011" + "0" * 48
+        mapping = self._make_occupied_mapping(fp, "Alice Ghost", 10, missing_count=0)
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "persist_entry",
+            "mappings": {fp: mapping},
+            "blocked_slots": {},
+        }
+
+        frozen_time = datetime(2026, 7, 15, 12, 0, 0, tzinfo=dt_util.UTC)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = store_data
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        # Empty calendar: Alice Ghost absent from feed
+        empty_ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nEND:VCALENDAR\r\n"
+        )
+
+        mock_plan = MagicMock()
+        mock_plan.plan_id = "t088-test"
+        mock_plan.selected = {}
+        mock_plan.overflow = {}
+        mock_plan.actions = []
+        mock_plan.diagnostics = {}
+        mock_plan.validate.return_value = []
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ),
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=empty_ics)
+            await coordinator._async_update_data()
+
+        # missing_count in _slot_mappings must have been incremented to 1
+        updated_mc = coordinator._slot_mappings["mappings"][fp]["missing_count"]
+        assert updated_mc == 1, (
+            f"Expected missing_count=1 after one missed cycle, got {updated_mc}"
+        )
+
+    def test_pending_set_with_dates_uses_missing_lifecycle(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-11: Vanished pending SET with dates fences then clears."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        pending_key = "pending-dates." + "a" * 50
+        mapping = self._make_occupied_mapping(
+            pending_key,
+            "Pending Dates",
+            10,
+            missing_count=0,
+        )
+        mapping["status"] = "pending_set"
+        mapping["operation_id"] = "set-token"
+        mapping["operation_kind"] = "set"
+        mapping["pending_set_since"] = "2026-08-01T00:00:00+00:00"
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {pending_key: mapping},
+            "blocked_slots": {},
+        }
+
+        reservations = coordinator._build_reservations([])
+
+        assert mapping["missing_count"] == 1
+        ghost = next(res for res in reservations if res.identity_key == pending_key)
+        assert ghost.missing_count == 1
+
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        new_key = "new-reservation." + "b" * 48
+        new_reservation = Reservation(
+            identity_key=new_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="New Guest",
+            slot_code="1234",
+        )
+        plan = compute_desired_plan(
+            reservations + [new_reservation],
+            [
+                ManagedSlot(
+                    slot=10,
+                    managed=True,
+                    status=SlotStatus.OCCUPIED,
+                    persisted_identity_key=pending_key,
+                ),
+                ManagedSlot(slot=11, managed=True, status=SlotStatus.FREE),
+            ],
+            max_events=2,
+            plan_id="pending-dates",
+            generated_at=start,
+        )
+
+        assert plan.selected[pending_key] == 10
+        assert plan.selected[new_key] == 11
+
+        mapping["missing_count"] = 2
+        mapping["status"] = "pending_set"
+        reservations = coordinator._build_reservations([])
+
+        assert pending_key not in {res.identity_key for res in reservations}
+        assert mapping["missing_count"] == 3
+        assert mapping["status"] == "pending_clear"
+        assert mapping["operation_id"] is None
+        assert mapping["operation_kind"] == "clear"
+        assert mapping["pending_set_since"] is None
+
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        observed = [
+            ManagedSlot(
+                slot=10,
+                managed=True,
+                status=SlotStatus.PENDING_CLEAR,
+                persisted_identity_key=pending_key,
+            )
+        ]
+        clear_plan = compute_desired_plan(
+            [],
+            observed,
+            max_events=2,
+            plan_id="pending-dates-clear",
+            generated_at=start,
+        )
+
+        assert any(
+            action.kind is ActionKind.RETRY_CLEAR and action.slot == 10
+            for action in clear_plan.actions
+        )
+
+    def test_pending_set_without_dates_blocks_then_clears(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-12: Vanished pending SET without dates cannot orphan."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        pending_key = "pending-nodates." + "c" * 49
+        mapping = self._make_occupied_mapping(
+            pending_key,
+            "Pending No Dates",
+            10,
+            missing_count=0,
+            start_state=None,
+            end_state=None,
+        )
+        mapping["status"] = "pending_set"
+        mapping["operation_id"] = "set-token"
+        mapping["operation_kind"] = "set"
+        mapping["pending_set_since"] = "2026-08-01T00:00:00+00:00"
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {pending_key: mapping},
+            "blocked_slots": {},
+        }
+
+        reservations = coordinator._build_reservations([])
+
+        assert reservations == []
+        assert mapping["missing_count"] == 1
+        assert mapping["status"] == "pending_set"
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "")
+        hass.states.async_set("text.test_lock_code_slot_11_name", "")
+        hass.states.async_set("text.test_lock_code_slot_11_pin", "")
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        observed = coordinator._observe_managed_slots()
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        slot11 = next(slot for slot in observed if slot.slot == 11)
+
+        assert slot10.status is SlotStatus.BLOCKED
+        assert slot10.blocked_reason == "pending_set"
+        assert slot11.status is SlotStatus.FREE
+
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        new_key = "new-nodates." + "d" * 52
+        new_reservation = Reservation(
+            identity_key=new_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="New Guest",
+            slot_code="1234",
+        )
+        plan = compute_desired_plan(
+            [new_reservation],
+            observed,
+            max_events=2,
+            plan_id="pending-nodates",
+            generated_at=start,
+        )
+
+        assert plan.selected[new_key] == 11
+        assert 10 not in set(plan.selected.values())
+
+        mapping["missing_count"] = 2
+        reservations = coordinator._build_reservations([])
+
+        assert reservations == []
+        assert mapping["missing_count"] == 3
+        assert mapping["status"] == "pending_clear"
+        assert mapping["operation_id"] is None
+        assert mapping["operation_kind"] == "clear"
+
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        observed = coordinator._observe_managed_slots()
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        clear_plan = compute_desired_plan(
+            [],
+            observed,
+            max_events=2,
+            plan_id="pending-nodates-clear",
+            generated_at=start,
+        )
+
+        assert slot10.status is SlotStatus.FREE
+        assert not any(
+            action.kind is ActionKind.RETRY_CLEAR and action.slot == 10
+            for action in clear_plan.actions
+        )
+
+    # ------------------------------------------------------------------
+    # T088-2: missing_count reset to 0 when reservation reappears
+    # ------------------------------------------------------------------
+
+    async def test_missing_count_reset_when_reservation_reappears(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-2: _slot_mappings missing_count reset when reservation returns.
+
+        After one miss (missing_count=1), if the reservation reappears
+        in the feed, _build_reservations() resets missing_count to 0 in
+        _slot_mappings so it is correctly saved.
+        """
+        from unittest.mock import AsyncMock
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from custom_components.rental_control.coordinator import (
+            RentalControlCoordinator,
+        )
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+
+        frozen_time = datetime(2026, 7, 15, 12, 0, 0, tzinfo=dt_util.UTC)
+        # Dates that produce a fingerprint matching the ICS event below.
+        start_dt = datetime(2026, 7, 20, 16, 0, 0, tzinfo=dt_util.UTC)
+        end_dt = datetime(2026, 7, 25, 11, 0, 0, tzinfo=dt_util.UTC)
+        fp = make_reservation_fingerprint(
+            "persist_entry", "Alice Ghost", start_dt, end_dt
+        )
+
+        mapping = self._make_occupied_mapping(
+            fp,
+            "Alice Ghost",
+            10,
+            missing_count=1,  # previously missed once
+            start_state=start_dt.isoformat(),
+            end_state=end_dt.isoformat(),
+        )
+        store_data: dict[str, Any] = {
+            "schema_version": 1,
+            "entry_id": "persist_entry",
+            "mappings": {fp: mapping},
+            "blocked_slots": {},
+        }
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = store_data
+        assert coordinator.event_overrides is not None
+        eo = coordinator.event_overrides
+
+        # ICS with Alice Ghost — same name and dates as the persisted mapping
+        ics_body = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\n"
+            "BEGIN:VEVENT\r\n"
+            "DTSTART;VALUE=DATE:20260720\r\n"
+            "DTEND;VALUE=DATE:20260725\r\n"
+            "SUMMARY:Alice Ghost\r\nUID:alice-ghost-uid\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+
+        mock_plan = MagicMock()
+        mock_plan.plan_id = "t088-2"
+        mock_plan.selected = {}
+        mock_plan.overflow = {}
+        mock_plan.actions = []
+        mock_plan.diagnostics = {}
+        mock_plan.validate.return_value = []
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+            patch(
+                "custom_components.rental_control.coordinator.compute_desired_plan",
+                return_value=mock_plan,
+            ),
+            patch.object(eo, "async_apply_plan", new=AsyncMock(return_value=[])),
+            patch.object(coordinator, "async_save_slot_store", new_callable=AsyncMock),
+        ):
+            mock_session.get("https://example.com/calendar.ics", body=ics_body)
+            await coordinator._async_update_data()
+
+        updated_mc = coordinator._slot_mappings["mappings"][fp]["missing_count"]
+        assert updated_mc == 0, (
+            f"Expected missing_count=0 after reappearance, got {updated_mc}"
+        )
+
+    def test_sync_store_records_confirmed_selected_mapping(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-3: Confirmed selected slots are written to live Store mappings."""
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        identity_key = "selected." + "a" * 56
+        reservation = Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Alice Selected",
+            slot_name="Alice Selected",
+            display_slot_name="Alice Selected",
+            slot_code="1234",
+            uid_aliases={"uid-a"},
+            booking_aliases={"book-a"},
+        )
+        plan = DesiredPlan(plan_id="persist-set", generated_at=start)
+        plan.selected = {identity_key: 10}
+
+        coordinator._sync_slot_store_from_plan(
+            plan,
+            {identity_key: reservation},
+            [OperationResult(kind="set", slot=10, confirmed=True)],
+        )
+
+        mapping = coordinator._slot_mappings["mappings"][identity_key]
+        assert mapping["slot"] == 10
+        assert mapping["status"] == "occupied"
+        assert mapping["operation_id"] is None
+        assert mapping["operation_kind"] is None
+        assert mapping["pending_set_since"] is None
+        assert mapping["identity"]["slot_name"] == "Alice Selected"
+        assert mapping["identity"]["uid_aliases"] == ["uid-a"]
+        assert "slot_code" not in mapping
+        assert "pin" not in mapping["last_observed_actual"]
+        assert coordinator.event_overrides is not None
+        assert identity_key in coordinator.event_overrides.persisted_mappings
+
+    def test_sync_store_removes_confirmed_clear_mapping(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-4: Confirmed clear results remove the cleared slot mapping."""
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        identity_key = "cleared." + "b" * 56
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                identity_key: self._make_occupied_mapping(
+                    identity_key, "Cleared Guest", 10
+                )
+            },
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        plan = DesiredPlan(plan_id="persist-clear", generated_at=dt_util.now())
+
+        coordinator._sync_slot_store_from_plan(
+            plan,
+            {},
+            [OperationResult(kind="clear", slot=10, confirmed=True)],
+        )
+
+        assert coordinator._slot_mappings["mappings"] == {}
+        assert coordinator.event_overrides.persisted_mappings == {}
+
+    def test_sync_store_preserves_unconfirmed_set_mapping(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-5: Unconfirmed SET results keep reservation-slot mapping."""
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        identity_key = "unconfirmed." + "c" * 52
+        reservation = Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Unconfirmed Guest",
+            slot_name="Unconfirmed Guest",
+            display_slot_name="Unconfirmed Guest",
+            slot_code="1234",
+        )
+        plan = DesiredPlan(plan_id="persist-unconfirmed", generated_at=start)
+        plan.selected = {identity_key: 10}
+
+        coordinator._sync_slot_store_from_plan(
+            plan,
+            {identity_key: reservation},
+            [OperationResult(kind="set", slot=10, unconfirmed=True)],
+        )
+
+        mapping = coordinator._slot_mappings["mappings"][identity_key]
+        assert mapping["slot"] == 10
+        assert mapping["status"] == "pending_set"
+        assert mapping["operation_id"] == "persist-unconfirmed"
+        assert mapping["operation_kind"] == "set"
+        assert mapping["pending_set_since"] is not None
+
+    def test_sync_store_skips_failed_set_mapping(self, hass: "HomeAssistant") -> None:
+        """T088-5: Failed SET results are not persisted as occupied."""
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        identity_key = "failed." + "c" * 52
+        reservation = Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Failed Guest",
+            slot_name="Failed Guest",
+            display_slot_name="Failed Guest",
+            slot_code="1234",
+        )
+        plan = DesiredPlan(plan_id="persist-failed", generated_at=start)
+        plan.selected = {identity_key: 10}
+
+        coordinator._sync_slot_store_from_plan(
+            plan,
+            {identity_key: reservation},
+            [OperationResult(kind="set", slot=10, failed=True)],
+        )
+
+        assert identity_key not in coordinator._slot_mappings["mappings"]
+
+    def test_sync_store_serializes_actual_datetimes(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-13: Store last-observed datetimes as ISO strings."""
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        assert coordinator.event_overrides is not None
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        actual_start = start - timedelta(minutes=30)
+        actual_end = end + timedelta(minutes=30)
+        identity_key = "datetime." + "e" * 55
+        reservation = Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=actual_start,
+            buffered_end=actual_end,
+            summary="Datetime Guest",
+            slot_name="Datetime Guest",
+            display_slot_name="Datetime Guest",
+            slot_code="1234",
+        )
+        coordinator.event_overrides.update_actual_state(
+            10,
+            {
+                "slot": 10,
+                "classification": "occupied",
+                "name_state": "Datetime Guest",
+                "has_code": True,
+                "start_state": actual_start,
+                "end_state": actual_end,
+                "use_date_range": True,
+                "enabled": True,
+            },
+        )
+        plan = DesiredPlan(plan_id="datetime-store", generated_at=start)
+        plan.selected = {identity_key: 10}
+
+        coordinator._sync_slot_store_from_plan(
+            plan,
+            {identity_key: reservation},
+            [OperationResult(kind="set", slot=10, confirmed=True)],
+        )
+
+        observed = coordinator._slot_mappings["mappings"][identity_key][
+            "last_observed_actual"
+        ]
+        assert observed["start_state"] == actual_start.isoformat()
+        assert observed["end_state"] == actual_end.isoformat()
+
+    def test_sync_store_does_not_readd_confirmed_clear_selection(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-6: Confirmed CLEAR wins over stale selected mappings."""
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        identity_key = "clear-selected." + "d" * 49
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                identity_key: self._make_occupied_mapping(
+                    identity_key, "Clear Selected", 10
+                )
+            },
+            "blocked_slots": {},
+        }
+        reservation = Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Clear Selected",
+            slot_name="Clear Selected",
+            display_slot_name="Clear Selected",
+            slot_code="",
+        )
+        plan = DesiredPlan(plan_id="persist-clear-selected", generated_at=start)
+        plan.selected = {identity_key: 10}
+
+        coordinator._sync_slot_store_from_plan(
+            plan,
+            {identity_key: reservation},
+            [OperationResult(kind="clear", slot=10, confirmed=True)],
+        )
+
+        assert identity_key not in coordinator._slot_mappings["mappings"]
+
+    def test_build_reservations_rematches_uid_date_shift(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-7: UID rematch migrates a shifted fingerprint in place."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        old_start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        old_end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        new_start = datetime(2026, 8, 2, 16, 0, tzinfo=dt_util.UTC)
+        new_end = datetime(2026, 8, 6, 11, 0, tzinfo=dt_util.UTC)
+        old_key = make_reservation_fingerprint(
+            entry.entry_id, "Shift Guest", old_start, old_end
+        )
+        new_key = make_reservation_fingerprint(
+            entry.entry_id, "Shift Guest", new_start, new_end
+        )
+        mapping = self._make_occupied_mapping(
+            old_key,
+            "Shift Guest",
+            10,
+            start_state=old_start.isoformat(),
+            end_state=old_end.isoformat(),
+        )
+        mapping["identity"]["uid_aliases"] = ["stable-uid"]
+        mapping["identity"]["start"] = old_start.isoformat()
+        mapping["identity"]["end"] = old_end.isoformat()
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {old_key: mapping},
+            "blocked_slots": {},
+        }
+
+        event = MagicMock()
+        event.summary = "Shift Guest"
+        event.description = ""
+        event.start = new_start
+        event.end = new_end
+        event.uid = "stable-uid"
+
+        reservations = coordinator._build_reservations([event])
+
+        assert [res.identity_key for res in reservations] == [new_key]
+        assert old_key not in coordinator._slot_mappings["mappings"]
+        migrated = coordinator._slot_mappings["mappings"][new_key]
+        assert migrated["slot"] == 10
+        assert old_key in migrated["fingerprint_history"]
+        assert migrated["identity"]["identity_key"] == new_key
+
+    def test_observe_slots_uses_rematched_store_identity(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T084-3: First refresh observes rematched adopted ownership."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator.event_prefix = "RC"
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        adopted_key = f"adopted.{entry.entry_id}.slot10"
+        fingerprint = make_reservation_fingerprint(
+            entry.entry_id, "Adopt Guest", start, end
+        )
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                adopted_key: self._make_occupied_mapping(
+                    adopted_key,
+                    "Adopt Guest",
+                    10,
+                )
+            },
+            "blocked_slots": {},
+        }
+        coordinator._slot_mappings["mappings"][adopted_key]["last_observed_actual"][
+            "name_state"
+        ] = "RC Adopt Guest"
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        hass.states.async_set("text.test_lock_code_slot_10_name", "RC Adopt Guest")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "1234")
+
+        event = MagicMock()
+        event.summary = "RC Adopt Guest"
+        event.description = ""
+        event.start = start
+        event.end = end
+        event.uid = None
+
+        coordinator._build_reservations([event])
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        observed = coordinator._observe_managed_slots()
+
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        assert slot10.persisted_identity_key == fingerprint
+
+    def test_build_reservations_uses_full_set_for_ambiguous_rematch(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-10: Rematch ambiguity considers all current reservations."""
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        adopted_key = f"adopted.{entry.entry_id}.slot10"
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                adopted_key: self._make_occupied_mapping(
+                    adopted_key,
+                    "Repeat Guest",
+                    10,
+                )
+            },
+            "blocked_slots": {},
+        }
+
+        first = MagicMock()
+        first.summary = "Repeat Guest"
+        first.description = ""
+        first.start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        first.end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        first.uid = None
+        second = MagicMock()
+        second.summary = "Repeat Guest"
+        second.description = ""
+        second.start = datetime(2026, 8, 10, 16, 0, tzinfo=dt_util.UTC)
+        second.end = datetime(2026, 8, 15, 11, 0, tzinfo=dt_util.UTC)
+        second.uid = None
+
+        reservations = coordinator._build_reservations([first, second])
+
+        current_reservations = [
+            reservation
+            for reservation in reservations
+            if reservation.start in {first.start, second.start}
+        ]
+        assert len(current_reservations) == 2
+        assert all(
+            reservation.identity_key != adopted_key
+            for reservation in current_reservations
+        )
+        assert adopted_key in coordinator._slot_mappings["mappings"]
+
+    def test_diagnostics_deep_scrubs_raw_code_keys(self, hass: "HomeAssistant") -> None:
+        """T098-2: Diagnostics recursively omit raw code-bearing fields."""
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        plan = MagicMock()
+        plan.diagnostics = {
+            "slot_code": "1234",
+            "nested": {"pin": "5678", "safe": "ok"},
+            "items": [{"code": "9999", "slot": 10}],
+        }
+        coordinator._latest_plan = plan
+        coordinator.event_overrides = MagicMock()
+        coordinator.event_overrides.diagnostics_snapshot = {
+            "slot": {"slot_code": "0000", "state": "occupied"}
+        }
+
+        diagnostics = coordinator.latest_reconciliation_diagnostics
+
+        assert "slot_code" not in diagnostics
+        assert "pin" not in diagnostics["nested"]
+        assert "code" not in diagnostics["items"][0]
+        assert "slot_code" not in diagnostics["event_overrides"]["slot"]
+        assert diagnostics["nested"]["safe"] == "ok"
+
+    def test_observe_unknown_keymaster_state_blocks_slot(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-9: Unknown Keymaster entity states are not treated as free."""
+        from custom_components.rental_control.reconciliation import SlotStatus
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        hass.states.async_set("text.test_lock_code_slot_10_name", "unavailable")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "1234")
+
+        observed = coordinator._observe_managed_slots()
+
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        assert slot10.status is SlotStatus.UNKNOWN
+
+    def test_build_reservations_honors_last_four_code_generation(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T103-5: Coordinator-owned writes preserve last_four PIN generation."""
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator.code_generator = "last_four"
+        coordinator.code_length = 4
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        event = MagicMock()
+        event.summary = "Code Guest"
+        event.description = "Last 4 Digits: 2468"
+        event.start = start
+        event.end = end
+        event.uid = "code-guest"
+
+        reservations = coordinator._build_reservations([event])
+
+        assert reservations[0].slot_code == "2468"
+
+    def test_build_reservations_honors_static_random_generation(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T103-6: Coordinator-owned writes preserve static_random generation."""
+        import random
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator.code_generator = "static_random"
+        coordinator.code_length = 4
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        event = MagicMock()
+        event.summary = "Random Guest"
+        event.description = "Phone: 555 123 4567"
+        event.start = start
+        event.end = end
+        event.uid = "stable-random-uid"
+
+        reservations = coordinator._build_reservations([event])
+
+        expected = str(random.Random("stable-random-uid").randrange(1, 9999, 4)).zfill(
+            4
+        )
+        assert reservations[0].slot_code == expected
+
+    def test_sync_store_writes_identity_start_and_end(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T088-8: Store identities include unbuffered start/end for rematch."""
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import Reservation
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        identity_key = "start-end." + "e" * 54
+        reservation = Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start - timedelta(hours=1),
+            buffered_end=end + timedelta(hours=1),
+            summary="Start End Guest",
+            slot_name="Start End Guest",
+            display_slot_name="Start End Guest",
+            slot_code="1234",
+        )
+        plan = DesiredPlan(plan_id="persist-start-end", generated_at=start)
+        plan.selected = {identity_key: 10}
+
+        coordinator._sync_slot_store_from_plan(plan, {identity_key: reservation}, [])
+
+        identity = coordinator._slot_mappings["mappings"][identity_key]["identity"]
+        assert identity["start"] == start.isoformat()
+        assert identity["end"] == end.isoformat()
+
+    def test_sync_store_evicts_stale_mapping_for_reused_slot(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """T089-4: Reusing a free slot drops its stale occupied mapping."""
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import Reservation
+
+        entry = self._make_persist_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        old_key = "old-stale." + "f" * 54
+        new_key = "new-active." + "a" * 53
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                old_key: self._make_occupied_mapping(old_key, "Old Guest", 10)
+            },
+            "blocked_slots": {},
+        }
+
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 5, 11, 0, tzinfo=dt_util.UTC)
+        reservation = Reservation(
+            identity_key=new_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="New Guest",
+            slot_code="1234",
+        )
+        plan = DesiredPlan(plan_id="persist-reuse", generated_at=start)
+        plan.selected = {new_key: 10}
+
+        coordinator._sync_slot_store_from_plan(plan, {new_key: reservation}, [])
+
+        mappings = coordinator._slot_mappings["mappings"]
+        assert old_key not in mappings
+        assert mappings[new_key]["slot"] == 10
+
+
+class TestHonorPMSTimesRegression:
+    """T103 regression: honor_event_times semantics preserved.
+
+    These tests pin four honour-PMS-times branches that must survive the
+    reconciliation refactor: timed PMS events take calendar times, all-day
+    events use description times, override fallback, and configured defaults.
+    """
+
+    @staticmethod
+    def _expected_utc(day: int, hour: int, minute: int = 0) -> datetime:
+        """Return an America/New_York local time converted to UTC."""
+        from datetime import time as time_cls
+        from zoneinfo import ZoneInfo
+
+        result: datetime = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, day).date(),
+                time_cls(hour, minute),
+                ZoneInfo("America/New_York"),
+            )
+        )
+        return result
+
+    @staticmethod
+    def _make_entry(
+        entry_id: str,
+        *,
+        checkin: str = "16:00",
+        checkout: str = "11:00",
+        lockname: str | None = None,
+    ) -> MockConfigEntry:
+        """Build a minimal config entry for honor-event-time regression tests."""
+        data = {
+            "name": "Honor Regression",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "America/New_York",
+            "checkin": checkin,
+            "checkout": checkout,
+            "start_slot": 10,
+            "max_events": 3,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "honor_event_times": True,
+        }
+        if lockname is not None:
+            data[CONF_LOCK_ENTRY] = lockname
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Honor Regression",
+            version=8,
+            unique_id=entry_id,
+            data=data,
+            entry_id=entry_id,
+        )
+
+    async def test_timed_event_uses_pms_times(self, hass: HomeAssistant) -> None:
+        """Timed events keep their explicit PMS calendar times."""
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        timed_ics = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART:20241225T150000
+DTEND:20241230T100000
+UID:t103-reg-1@example.com
+SUMMARY:Reserved - Timed Guest
+DESCRIPTION:Email: timed@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+        entry = self._make_entry("t103_reg_1")
+        entry.add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics", status=200, body=timed_ics
+            )
+            coordinator = RentalControlCoordinator(hass, entry)
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        assert result[0].start == self._expected_utc(25, 15)
+        assert result[0].end == self._expected_utc(30, 10)
+
+    async def test_allday_description_times_used(self, hass: HomeAssistant) -> None:
+        """All-day events prefer description-derived times over overrides."""
+        from custom_components.rental_control.event_overrides import EventOverrides
+
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        allday_ics = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20241225
+DTEND;VALUE=DATE:20241230
+UID:t103-reg-2@example.com
+SUMMARY:Reserved - Desc Guest
+DESCRIPTION:Check-in: 3:00 PM\\nCheck-out: 11:00 AM
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+        entry = self._make_entry("t103_reg_2", lockname="front_door")
+        entry.add_to_hass(hass)
+        MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": "front_door"},
+            entry_id="km_t103_reg_2",
+        ).add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics", status=200, body=allday_ics
+            )
+            coordinator = RentalControlCoordinator(hass, entry)
+            coordinator.event_overrides = EventOverrides(10, 3)
+            coordinator.event_overrides._overrides[10] = {
+                "slot_name": "Desc Guest",
+                "slot_code": "1234",
+                "start_time": datetime(2024, 12, 25, 18, 0, 0, tzinfo=dt_util.UTC),
+                "end_time": datetime(2024, 12, 30, 14, 0, 0, tzinfo=dt_util.UTC),
+            }
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        assert result[0].start == self._expected_utc(25, 15)
+        assert result[0].end == self._expected_utc(30, 11)
+
+    async def test_allday_override_fallback_when_no_description_times(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """All-day events fall back to override times when descriptions lack them."""
+        from custom_components.rental_control.event_overrides import EventOverrides
+
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        allday_ics = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20241225
+DTEND;VALUE=DATE:20241230
+UID:t103-reg-3@example.com
+SUMMARY:Reserved - Override Guest
+DESCRIPTION:Email: override@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+        entry = self._make_entry("t103_reg_3", lockname="front_door")
+        entry.add_to_hass(hass)
+        MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": "front_door"},
+            entry_id="km_t103_reg_3",
+        ).add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics", status=200, body=allday_ics
+            )
+            coordinator = RentalControlCoordinator(hass, entry)
+            coordinator.event_overrides = EventOverrides(10, 3)
+            coordinator.event_overrides._overrides[10] = {
+                "slot_name": "Override Guest",
+                "slot_code": "1234",
+                "start_time": datetime(2024, 12, 25, 18, 0, 0, tzinfo=dt_util.UTC),
+                "end_time": datetime(2024, 12, 30, 14, 0, 0, tzinfo=dt_util.UTC),
+            }
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        assert result[0].start == self._expected_utc(25, 13)
+        assert result[0].end == self._expected_utc(30, 9)
+
+    async def test_allday_configured_defaults_when_no_description_no_override(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """All-day events fall back to configured defaults without overrides."""
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        allday_ics = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20241225
+DTEND;VALUE=DATE:20241230
+UID:t103-reg-4@example.com
+SUMMARY:Reserved - Default Guest
+DESCRIPTION:Email: default@example.com
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+        entry = self._make_entry(
+            "t103_reg_4",
+            checkin="15:00",
+            checkout="10:00",
+        )
+        entry.add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics", status=200, body=allday_ics
+            )
+            coordinator = RentalControlCoordinator(hass, entry)
+            result = await coordinator._async_update_data()
+
+        assert len(result) == 1
+        assert result[0].start == self._expected_utc(25, 15)
+        assert result[0].end == self._expected_utc(30, 10)

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -16,10 +16,21 @@ from unittest.mock import patch
 from homeassistant.util import dt as dt_util
 import pytest
 
+from custom_components.rental_control import event_overrides as _eo_module
+from custom_components.rental_control.const import COORDINATOR
+from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.event_overrides import EventOverride
 from custom_components.rental_control.event_overrides import EventOverrides
 from custom_components.rental_control.event_overrides import ReserveResult
+from custom_components.rental_control.reconciliation import ActionKind
+from custom_components.rental_control.reconciliation import DesiredPlan
+from custom_components.rental_control.reconciliation import Reservation
+from custom_components.rental_control.reconciliation import SlotAction
 from custom_components.rental_control.util import EventIdentity
+from custom_components.rental_control.util import OperationResult
+from custom_components.rental_control.util import async_fire_set_code
+from custom_components.rental_control.util import handle_state_change
+from custom_components.rental_control.util import trim_name
 
 # ---------------------------------------------------------------------------
 # Helpers / Fixtures
@@ -482,6 +493,7 @@ class TestAsyncCheckOverrides:
         with patch(
             "custom_components.rental_control.event_overrides.async_fire_clear_code",
             new_callable=AsyncMock,
+            return_value=OperationResult(kind="clear", slot=1, confirmed=True),
         ) as mock_fire:
             await eo.async_check_overrides(coordinator)
             mock_fire.assert_not_called()
@@ -498,6 +510,7 @@ class TestAsyncCheckOverrides:
         with patch(
             "custom_components.rental_control.event_overrides.async_fire_clear_code",
             new_callable=AsyncMock,
+            return_value=OperationResult(kind="clear", slot=1, confirmed=True),
         ) as mock_fire:
             await eo.async_check_overrides(coordinator)
             mock_fire.assert_not_called()
@@ -519,6 +532,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -548,6 +562,7 @@ class TestAsyncCheckOverrides:
         with patch(
             "custom_components.rental_control.event_overrides.async_fire_clear_code",
             new_callable=AsyncMock,
+            return_value=OperationResult(kind="clear", slot=1, confirmed=True),
         ) as mock_fire:
             await eo.async_check_overrides(coordinator)
             mock_fire.assert_called_once()
@@ -568,11 +583,31 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
             await eo.async_check_overrides(coordinator)
             mock_fire.assert_called_once_with(coordinator, 1, expected_name="Bad Guest")
+
+    async def test_unconfirmed_legacy_clear_keeps_slot_occupied(self) -> None:
+        """Verify legacy clears do not free slots without confirmation."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        start = _make_dt(2025, 7, 10)
+        end = _make_dt(2025, 7, 5)
+        eo.update(1, "c", "Bad Guest", start, end)
+        coordinator = _make_coordinator(
+            calendar_events=[_make_event(_make_dt(2025, 8, 1), "Bad Guest")],
+        )
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            new_callable=AsyncMock,
+            return_value=OperationResult(kind="clear", slot=1, unconfirmed=True),
+        ):
+            await eo.async_check_overrides(coordinator)
+
+        assert eo.overrides[1] is not None
 
     async def test_clears_when_end_before_today(self) -> None:
         """Verify slot is cleared when end_date < current date."""
@@ -617,6 +652,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -648,6 +684,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -674,6 +711,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -714,6 +752,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -761,6 +800,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -797,6 +837,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -831,6 +872,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -870,6 +912,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -910,6 +953,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -950,6 +994,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -989,6 +1034,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -1031,6 +1077,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -1074,6 +1121,7 @@ class TestAsyncCheckOverrides:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -1203,6 +1251,7 @@ class TestEdgeCases:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=today),
         ):
@@ -1228,6 +1277,7 @@ class TestEdgeCases:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=today),
         ):
@@ -1235,14 +1285,7 @@ class TestEdgeCases:
             mock_fire.assert_not_called()
 
     async def test_clear_failure_still_frees_slot(self) -> None:
-        """Verify slot is freed even when async_fire_clear_code raises.
-
-        Before #535 fix the slot remained occupied on failure, which
-        permanently blocked new events from being assigned.  The new
-        behavior frees the override so ``next_slot`` becomes
-        available; the stale Keymaster code will be overwritten when
-        the replacement event is programmed.
-        """
+        """Verify failed clear leaves the slot occupied for retry."""
         eo = EventOverrides(start_slot=1, max_slots=1)
         start = _make_dt(2025, 6, 1)
         end = _make_dt(2025, 6, 5)
@@ -1257,7 +1300,7 @@ class TestEdgeCases:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
-                side_effect=Exception("lock command failed"),
+                return_value=OperationResult(kind="clear", slot=1, failed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -1265,9 +1308,8 @@ class TestEdgeCases:
             mock_fire.assert_called_once_with(
                 coordinator, 1, expected_name="Past Guest"
             )
-            # Slot is freed despite clear failure (#535 fix)
-            assert eo.overrides[1] is None
-            assert eo.next_slot == 1
+            assert eo.overrides[1] is not None
+            assert eo.next_slot is None
 
     async def test_clears_slot_beyond_max_events_boundary(self) -> None:
         """Verify slot is cleared when its event is beyond max_events.
@@ -1325,6 +1367,7 @@ class TestEdgeCases:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=today),
         ):
@@ -2093,6 +2136,7 @@ class TestDateExtensionUidChange:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -2802,6 +2846,7 @@ class TestSlotEvictionOnNewEarlierEvent:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -2862,6 +2907,7 @@ class TestSlotEvictionOnNewEarlierEvent:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -2881,12 +2927,7 @@ class TestSlotEvictionOnNewEarlierEvent:
             assert eo.overrides[result.slot]["slot_name"] == "Delta"
 
     async def test_slot_freed_even_when_clear_code_fails(self) -> None:
-        """Verify slot is freed even if async_fire_clear_code raises.
-
-        Before the fix for #535, a failed clear_code would keep the
-        slot occupied, permanently blocking new events from being
-        assigned a slot.
-        """
+        """Verify failed clear does not free the evicted slot."""
         eo = EventOverrides(start_slot=1, max_slots=2)
 
         # Fill both slots
@@ -2916,8 +2957,9 @@ class TestSlotEvictionOnNewEarlierEvent:
 
         frozen = _make_dt(2025, 7, 1)
 
-        # Simulate Keymaster being unavailable
-        failing_clear = AsyncMock(side_effect=RuntimeError("service unavailable"))
+        failing_clear = AsyncMock(
+            return_value=OperationResult(kind="clear", slot=2, failed=True)
+        )
         with (
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
@@ -2927,17 +2969,9 @@ class TestSlotEvictionOnNewEarlierEvent:
         ):
             await eo.async_check_overrides(coordinator)
 
-            # Despite clear_code failure, slot should still be freed
-            assert eo.overrides[2] is None
-            assert eo.next_slot is not None
-
-            # New event can now reserve the freed slot
-            result = await eo.async_reserve_or_get_slot(
-                "Delta", "newcode", new_s, new_e
-            )
-            assert result.slot is not None
-            assert result.is_new is True
-            assert eo.overrides[result.slot]["slot_name"] == "Delta"
+            assert eo.overrides[2] is not None
+            assert eo.overrides[2]["slot_name"] == "Beta"
+            assert eo.next_slot is None
 
 
 class TestSlotEvictionTolerance:
@@ -3011,6 +3045,7 @@ class TestSlotEvictionTolerance:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -3052,6 +3087,7 @@ class TestSlotEvictionTolerance:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -3089,6 +3125,7 @@ class TestSlotEvictionTolerance:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -3120,6 +3157,7 @@ class TestSlotEvictionTolerance:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=2, confirmed=True),
             ),
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -3154,6 +3192,7 @@ class TestSlotEvictionTolerance:
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
                 new_callable=AsyncMock,
+                return_value=OperationResult(kind="clear", slot=1, confirmed=True),
             ) as mock_fire,
             patch.object(dt_util, "start_of_local_day", return_value=frozen),
         ):
@@ -3162,3 +3201,2756 @@ class TestSlotEvictionTolerance:
         mock_fire.assert_called_once_with(coordinator, 1, expected_name="Broken")
         assert eo.overrides[1] is None
         assert 1 not in eo._slot_miss_counts
+
+
+# ---------------------------------------------------------------------------
+# TestStoreSchemaV1 (T009)
+# ---------------------------------------------------------------------------
+
+
+class TestStoreSchemaV1:
+    """Tests for store schema v1 serialisation, deserialisation, and fencing."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_v1_mapping(
+        self,
+        identity_key: str = "test-key-1",
+        slot: int = 10,
+        status: str = "occupied",
+        has_code: bool = True,
+    ) -> dict:
+        """Build a minimal v1 slot mapping dict."""
+        return {
+            "slot": slot,
+            "status": status,
+            "operation_id": None,
+            "operation_kind": None,
+            "identity": {
+                "identity_key": identity_key,
+                "summary": "Jane Doe",
+                "slot_name": "Jane Doe",
+                "uid_aliases": [],
+                "booking_aliases": [],
+            },
+            "missing_count": 0,
+            "pending_set_since": None,
+            "pending_clear_since": None,
+            "fingerprint_history": [],
+            "updated_at": "2025-01-01T00:00:00+00:00",
+            "last_observed_actual": {
+                "slot": slot,
+                "classification": "adopted",
+                "name_state": "Jane Doe",
+                "has_code": has_code,
+                "start_state": None,
+                "end_state": None,
+                "use_date_range": None,
+                "enabled": None,
+            },
+        }
+
+    def _make_v1_store(
+        self,
+        mappings: dict | None = None,
+    ) -> dict:
+        """Build a minimal schema v1 store dict."""
+        return {
+            "schema_version": 1,
+            "entry_id": "test_entry_id",
+            "lockname": "test_lock",
+            "start_slot": 10,
+            "max_slots": 3,
+            "updated_at": "2025-01-01T00:00:00+00:00",
+            "mappings": mappings or {},
+            "blocked_slots": {},
+        }
+
+    # ------------------------------------------------------------------
+    # T009-1: v1 serialisation
+    # ------------------------------------------------------------------
+
+    def test_store_schema_v1_serialization(self) -> None:
+        """T009-1: v1 store dict has required keys and no raw PIN."""
+        mapping = self._make_v1_mapping()
+        store = self._make_v1_store({"test-key-1": mapping})
+
+        assert store["schema_version"] == 1
+        assert "entry_id" in store
+        assert "lockname" in store
+        assert "start_slot" in store
+        assert "max_slots" in store
+        assert "updated_at" in store
+        assert "mappings" in store
+        assert "blocked_slots" in store
+
+        m = store["mappings"]["test-key-1"]
+        assert m["slot"] == 10
+        assert m["status"] == "occupied"
+        last_obs = m["last_observed_actual"]
+        assert last_obs["has_code"] is True
+        assert "pin" not in last_obs
+        assert "code" not in last_obs
+        assert "slot_code" not in last_obs
+
+    # ------------------------------------------------------------------
+    # T009-2: v1 deserialisation via load_persisted_mappings
+    # ------------------------------------------------------------------
+
+    def test_store_schema_v1_deserialization(self) -> None:
+        """T009-2: load_persisted_mappings loads v1 mappings correctly."""
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        mapping = self._make_v1_mapping()
+        eo.load_persisted_mappings({"test-key-1": mapping})
+
+        pm = eo.persisted_mappings
+        assert "test-key-1" in pm
+        assert pm["test-key-1"]["slot"] == 10
+        assert pm["test-key-1"]["status"] == "occupied"
+
+    # ------------------------------------------------------------------
+    # T009-3: no raw PIN in last_observed_actual
+    # ------------------------------------------------------------------
+
+    def test_no_raw_pin_in_store(self) -> None:
+        """T009-3: has_code bool is acceptable; raw pin/code keys are not."""
+        mapping_true = self._make_v1_mapping(has_code=True)
+        mapping_false = self._make_v1_mapping(
+            identity_key="test-key-2", slot=11, status="free", has_code=False
+        )
+        last_true = mapping_true["last_observed_actual"]
+        last_false = mapping_false["last_observed_actual"]
+
+        # has_code as bool is allowed
+        assert last_true["has_code"] is True
+        assert last_false["has_code"] is False
+
+        # Raw PIN keys must not be present
+        for last_obs in (last_true, last_false):
+            assert "pin" not in last_obs
+            assert "code" not in last_obs
+            assert "slot_code" not in last_obs
+
+    # ------------------------------------------------------------------
+    # T009-4: duplicate occupied slot rejection
+    # ------------------------------------------------------------------
+
+    def test_duplicate_slot_rejection(self) -> None:
+        """T009-4: two occupied mappings claiming the same slot raise ValueError."""
+        from custom_components.rental_control.const import SLOT_STATUS_OCCUPIED
+
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        m1 = self._make_v1_mapping(
+            identity_key="key-a", slot=10, status=SLOT_STATUS_OCCUPIED
+        )
+        m2 = self._make_v1_mapping(
+            identity_key="key-b", slot=10, status=SLOT_STATUS_OCCUPIED
+        )
+
+        with pytest.raises(ValueError, match="Duplicate occupied slot 10"):
+            eo.load_persisted_mappings({"key-a": m1, "key-b": m2})
+
+    # ------------------------------------------------------------------
+    # T009-5: pending_clear fence rebuilt on load
+    # ------------------------------------------------------------------
+
+    def test_pending_fence_on_load(self) -> None:
+        """T009-5: pending_clear mapping populates pending_clear_slots."""
+        from custom_components.rental_control.const import SLOT_STATUS_PENDING_CLEAR
+
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        m = self._make_v1_mapping(
+            identity_key="phantom-key",
+            slot=10,
+            status=SLOT_STATUS_PENDING_CLEAR,
+            has_code=False,
+        )
+        m["pending_clear_since"] = "2025-01-01T00:00:00+00:00"
+        eo.load_persisted_mappings({"phantom-key": m})
+
+        assert 10 in eo.pending_clear_slots
+
+
+# ---------------------------------------------------------------------------
+# T061 / T032 / T064: apply-plan fencing and callback re-entrancy
+# ---------------------------------------------------------------------------
+
+
+class TestPendingClearFenceTokenLifecycle:
+    """Tests for _apply_clear fence-token lifecycle."""
+
+    def _make_eo(self) -> EventOverrides:
+        """Return an EventOverrides with one occupied slot."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 1, 1)
+        eo.update(1, "1234", "Guest", now, now)
+        return eo
+
+    def _make_coordinator(self, eo: EventOverrides) -> MagicMock:
+        """Return a minimal coordinator for apply-clear tests."""
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.event_overrides = eo
+        return coordinator
+
+    async def test_fence_token_set_before_service_call(self) -> None:
+        """Fence token is present before the clear service call starts."""
+        eo = self._make_eo()
+        coordinator = self._make_coordinator(eo)
+        observed: dict[str, str | None] = {}
+
+        async def mock_clear_code(*args, **kwargs) -> OperationResult:
+            """Capture fence state during the clear service call."""
+            observed["fence"] = eo.pending_fences.get(1)
+            observed["pending_clear"] = eo.pending_clear_slots.get(1)
+            return OperationResult(kind="clear", slot=1, failed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            side_effect=mock_clear_code,
+        ):
+            await eo._apply_clear(coordinator, 1)
+
+        assert observed["fence"] is not None
+        assert observed["fence"] == observed["pending_clear"]
+
+    async def test_fence_cleared_on_confirmed_free(self) -> None:
+        """Confirmed clear frees the slot and removes both fences."""
+        eo = self._make_eo()
+        coordinator = self._make_coordinator(eo)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=OperationResult(kind="clear", slot=1, confirmed=True),
+        ):
+            result = await eo._apply_clear(coordinator, 1)
+
+        assert result.confirmed is True
+        assert eo.overrides[1] is None
+        assert 1 not in eo.pending_fences
+        assert 1 not in eo.pending_clear_slots
+
+    async def test_stale_token_rejected(self) -> None:
+        """A replaced token causes the original clear result to be discarded."""
+        eo = self._make_eo()
+        coordinator = self._make_coordinator(eo)
+
+        async def mock_clear_code(*args, **kwargs) -> OperationResult:
+            """Replace the token to simulate a newer in-flight operation."""
+            eo._pending_fences[1] = "newer-token"
+            return OperationResult(kind="clear", slot=1, confirmed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            side_effect=mock_clear_code,
+        ):
+            result = await eo._apply_clear(coordinator, 1)
+
+        assert result.unconfirmed is True
+        assert eo.overrides[1] is not None
+        assert eo.pending_fences[1] == "newer-token"
+
+    async def test_retry_clear_persists_new_token(self) -> None:
+        """A retry-clear call replaces the prior fence token."""
+        eo = self._make_eo()
+        coordinator = self._make_coordinator(eo)
+
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.uuid.uuid4",
+                side_effect=["token-1", "token-2"],
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                return_value=OperationResult(kind="clear", slot=1, failed=True),
+            ),
+        ):
+            await eo._apply_clear(coordinator, 1)
+            first_token = eo.pending_fences[1]
+            await eo._apply_clear(coordinator, 1)
+
+        assert first_token == "token-1"
+        assert eo.pending_fences[1] == "token-2"
+
+    async def test_slot_remains_pending_on_lingering_name(self) -> None:
+        """Lingering name keeps the slot fenced and unavailable."""
+        eo = self._make_eo()
+        coordinator = self._make_coordinator(eo)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=OperationResult(
+                kind="clear",
+                slot=1,
+                unconfirmed=True,
+                lingering_name=True,
+            ),
+        ):
+            result = await eo._apply_clear(coordinator, 1)
+
+        assert result.lingering_name is True
+        assert eo.overrides[1] is not None
+        assert 1 in eo.pending_fences
+
+    async def test_slot_remains_pending_on_failure(self) -> None:
+        """Failed clear keeps the slot fenced and unavailable."""
+        eo = self._make_eo()
+        coordinator = self._make_coordinator(eo)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=OperationResult(kind="clear", slot=1, failed=True),
+        ):
+            result = await eo._apply_clear(coordinator, 1)
+
+        assert result.failed is True
+        assert eo.overrides[1] is not None
+        assert 1 in eo.pending_fences
+
+    async def test_later_confirmed_free_clears_fence(self) -> None:
+        """A later confirmed retry finally clears the slot and fence."""
+        eo = self._make_eo()
+        coordinator = self._make_coordinator(eo)
+
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.uuid.uuid4",
+                side_effect=["token-1", "token-2"],
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                side_effect=[
+                    OperationResult(kind="clear", slot=1, failed=True),
+                    OperationResult(kind="clear", slot=1, confirmed=True),
+                ],
+            ),
+        ):
+            await eo._apply_clear(coordinator, 1)
+            assert 1 in eo.pending_fences
+            result = await eo._apply_clear(coordinator, 1)
+
+        assert result.confirmed is True
+        assert eo.overrides[1] is None
+        assert 1 not in eo.pending_fences
+        assert 1 not in eo.pending_clear_slots
+
+
+class TestApplyPlanActions:
+    """Tests for EventOverrides.async_apply_plan."""
+
+    def _make_reservation(
+        self,
+        identity_key: str = "res-1",
+        *,
+        slot_name: str = "Guest",
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> Reservation:
+        """Return a Reservation suitable for apply-plan tests."""
+        start_dt = start or _make_dt(2026, 8, 1, 14)
+        end_dt = end or _make_dt(2026, 8, 8, 11)
+        return Reservation(
+            identity_key=identity_key,
+            start=start_dt,
+            end=end_dt,
+            buffered_start=start_dt,
+            buffered_end=end_dt,
+            summary=slot_name,
+            slot_name=slot_name,
+            display_slot_name=f"RC {slot_name}",
+            slot_code="1234",
+        )
+
+    def _make_plan(self, *actions: SlotAction) -> DesiredPlan:
+        """Return a DesiredPlan with the provided actions."""
+        plan = DesiredPlan(plan_id="plan-1", generated_at=_make_dt(2026, 8, 1))
+        plan.actions = list(actions)
+        return plan
+
+    def _make_coordinator(self, eo: EventOverrides) -> MagicMock:
+        """Return a coordinator mock for async_apply_plan."""
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.event_overrides = eo
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = None
+        return coordinator
+
+    async def test_set_action_pre_assigns_and_confirms(self) -> None:
+        """SET pre-assigns the override before the service call and confirms."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 8, 1)
+        eo.update(1, "", "", now, now)
+        coordinator = self._make_coordinator(eo)
+        res = self._make_reservation()
+        observed: list[bool] = []
+
+        async def mock_set_code(*args, **kwargs) -> OperationResult:
+            """Verify pre-assignment state during the set service call."""
+            observed.append(eo.overrides[1] is not None)
+            observed.append(1 in eo.pending_fences)
+            return OperationResult(kind="set", slot=1, confirmed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            side_effect=mock_set_code,
+        ):
+            results = await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(
+                    SlotAction(
+                        kind=ActionKind.SET, slot=1, identity_key=res.identity_key
+                    )
+                ),
+                {res.identity_key: res},
+            )
+
+        assert results[0].confirmed is True
+        assert observed == [True, True]
+        assert eo.overrides[1] is not None
+        assert eo.overrides[1]["slot_name"] == "Guest"
+        assert 1 not in eo.pending_fences
+
+    async def test_set_action_passes_unbuffered_dates(self) -> None:
+        """SET helpers receive unbuffered dates so util applies buffer once."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 8, 1)
+        eo.update(1, "", "", now, now)
+        coordinator = self._make_coordinator(eo)
+        res = self._make_reservation()
+        res.buffered_start = res.start.replace(hour=res.start.hour - 1)
+        res.buffered_end = res.end.replace(hour=res.end.hour + 1)
+        observed: list[tuple[datetime, datetime]] = []
+
+        async def mock_set_code(_coordinator, event, _slot) -> OperationResult:
+            """Capture the event dates passed to the physical helper."""
+            observed.append(
+                (
+                    event.extra_state_attributes["start"],
+                    event.extra_state_attributes["end"],
+                )
+            )
+            return OperationResult(kind="set", slot=1, confirmed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            side_effect=mock_set_code,
+        ):
+            await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(
+                    SlotAction(
+                        kind=ActionKind.SET, slot=1, identity_key=res.identity_key
+                    )
+                ),
+                {res.identity_key: res},
+            )
+
+        assert observed == [(res.start, res.end)]
+
+    async def test_set_action_reverted_on_failure(self) -> None:
+        """Failed SET reverts the tentative in-memory assignment."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 8, 1)
+        eo.update(1, "", "", now, now)
+        coordinator = self._make_coordinator(eo)
+        res = self._make_reservation()
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            return_value=OperationResult(kind="set", slot=1, failed=True),
+        ):
+            results = await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(
+                    SlotAction(
+                        kind=ActionKind.SET, slot=1, identity_key=res.identity_key
+                    )
+                ),
+                {res.identity_key: res},
+            )
+
+        assert results[0].failed is True
+        assert eo.overrides[1] is None
+        assert 1 not in eo.pending_fences
+
+    async def test_update_times_action_updates_dates(self) -> None:
+        """Confirmed UPDATE_TIMES updates in-memory dates."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        old_start = _make_dt(2026, 8, 1, 14)
+        old_end = _make_dt(2026, 8, 8, 11)
+        eo.update(1, "1234", "Guest", old_start, old_end)
+        coordinator = self._make_coordinator(eo)
+        res = self._make_reservation(
+            start=_make_dt(2026, 8, 2, 14),
+            end=_make_dt(2026, 8, 9, 11),
+        )
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_update_times",
+            return_value=OperationResult(kind="update_times", slot=1, confirmed=True),
+        ):
+            results = await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(
+                    SlotAction(
+                        kind=ActionKind.UPDATE_TIMES,
+                        slot=1,
+                        identity_key=res.identity_key,
+                    )
+                ),
+                {res.identity_key: res},
+            )
+
+        assert results[0].confirmed is True
+        override = eo.overrides[1]
+        assert override is not None
+        assert override["start_time"] == res.buffered_start
+        assert override["end_time"] == res.buffered_end
+
+    async def test_update_times_passes_unbuffered_dates(self) -> None:
+        """UPDATE_TIMES helpers receive unbuffered dates."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        old_start = _make_dt(2026, 8, 1, 14)
+        old_end = _make_dt(2026, 8, 8, 11)
+        eo.update(1, "1234", "Guest", old_start, old_end)
+        coordinator = self._make_coordinator(eo)
+        res = self._make_reservation(
+            start=_make_dt(2026, 8, 2, 14),
+            end=_make_dt(2026, 8, 9, 11),
+        )
+        res.buffered_start = res.start.replace(hour=res.start.hour - 1)
+        res.buffered_end = res.end.replace(hour=res.end.hour + 1)
+        observed: list[tuple[datetime, datetime]] = []
+
+        async def mock_update_times(_coordinator, event, _slot) -> OperationResult:
+            """Capture the event dates passed to the physical helper."""
+            observed.append(
+                (
+                    event.extra_state_attributes["start"],
+                    event.extra_state_attributes["end"],
+                )
+            )
+            return OperationResult(kind="update_times", slot=1, confirmed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_update_times",
+            side_effect=mock_update_times,
+        ):
+            await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(
+                    SlotAction(
+                        kind=ActionKind.UPDATE_TIMES,
+                        slot=1,
+                        identity_key=res.identity_key,
+                    )
+                ),
+                {res.identity_key: res},
+            )
+
+        assert observed == [(res.start, res.end)]
+
+    async def test_noop_action_not_executed(self) -> None:
+        """NOOP actions do not execute any physical service helpers."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        coordinator = self._make_coordinator(eo)
+
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new_callable=AsyncMock,
+            ) as mock_clear,
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new_callable=AsyncMock,
+            ) as mock_set,
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_update_times",
+                new_callable=AsyncMock,
+            ) as mock_update,
+        ):
+            results = await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(SlotAction(kind=ActionKind.NOOP, slot=1)),
+                {},
+            )
+
+        assert results == []
+        mock_clear.assert_not_called()
+        mock_set.assert_not_called()
+        mock_update.assert_not_called()
+
+    async def test_clear_action_removes_slot_on_confirm(self) -> None:
+        """Confirmed CLEAR frees the slot."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 8, 1)
+        eo.update(1, "1234", "Guest", now, now)
+        coordinator = self._make_coordinator(eo)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=OperationResult(kind="clear", slot=1, confirmed=True),
+        ):
+            results = await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(SlotAction(kind=ActionKind.CLEAR, slot=1)),
+                {},
+            )
+
+        assert results[0].confirmed is True
+        assert eo.overrides[1] is None
+        assert 1 not in eo.pending_fences
+
+    async def test_overflow_action_not_executed(self) -> None:
+        """Overflow reservations do not become physical slot actions."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        coordinator = self._make_coordinator(eo)
+        plan = DesiredPlan(plan_id="plan-overflow", generated_at=_make_dt(2026, 8, 1))
+        plan.overflow["res-overflow"] = "capacity"
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            new_callable=AsyncMock,
+        ) as mock_set:
+            results = await eo.async_apply_plan(coordinator, plan, {})
+
+        assert not hasattr(ActionKind, "OVERFLOW")
+        assert results == []
+        mock_set.assert_not_called()
+
+    async def test_reconciliation_active_flag_set_during_plan(self) -> None:
+        """reconciliation_active is True during execution and False after."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 8, 1)
+        eo.update(1, "1234", "Guest", now, now)
+        coordinator = self._make_coordinator(eo)
+        observed: list[bool] = []
+
+        async def mock_clear_code(*args, **kwargs) -> OperationResult:
+            """Capture reconciliation_active during the clear service call."""
+            observed.append(eo.reconciliation_active)
+            return OperationResult(kind="clear", slot=1, confirmed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            side_effect=mock_clear_code,
+        ):
+            await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(SlotAction(kind=ActionKind.CLEAR, slot=1)),
+                {},
+            )
+
+        assert observed == [True]
+        assert eo.reconciliation_active is False
+
+
+class TestCallbackReentrancyFencing:
+    """Tests callback re-entrancy fencing at the unit level."""
+
+    async def test_handle_state_change_does_not_call_check_overrides(self) -> None:
+        """handle_state_change updates state without starting reconciliation."""
+        lockname = "test_lock"
+        slot_num = 1
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = lockname
+        mock_coordinator.trim_names = False
+        mock_coordinator.event_overrides = MagicMock()
+        mock_coordinator.event_overrides.async_check_overrides = AsyncMock()
+        mock_coordinator.update_event_overrides = AsyncMock()
+
+        name_state = MagicMock()
+        name_state.state = "Guest"
+        pin_state = MagicMock()
+        pin_state.state = "1234"
+        enabled_state = MagicMock()
+        enabled_state.state = "on"
+
+        def states_get(entity_id: str) -> MagicMock | None:
+            """Return the mocked Keymaster state for the requested entity."""
+            if "enabled" in entity_id:
+                return enabled_state
+            if "pin" in entity_id:
+                return pin_state
+            if "name" in entity_id:
+                return name_state
+            return None
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_id": {COORDINATOR: mock_coordinator}}}
+        hass.states.get = states_get
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock()
+        event.data = {"entity_id": f"switch.{lockname}_code_slot_{slot_num}_enabled"}
+
+        with patch(
+            "custom_components.rental_control.util.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await handle_state_change(hass, config_entry, event)
+
+        mock_coordinator.event_overrides.async_check_overrides.assert_not_called()
+        mock_coordinator.update_event_overrides.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# T078: Exact stable-fingerprint restart mapping preservation
+# ---------------------------------------------------------------------------
+
+
+class TestExactFingerprintRestartPreservation:
+    """T078: Persisted mappings keyed by stable fingerprint survive restarts.
+
+    These tests verify the complete chain:
+    1. Compute fingerprint from reservation attributes.
+    2. Persist a mapping keyed by that fingerprint via load_persisted_mappings().
+    3. On a simulated restart, find_reservation_rematch() returns EXACT.
+
+    This proves that slot assignments survive restarts when the calendar
+    feed returns the same reservation data (even with a new volatile UID).
+    """
+
+    def _make_fp_mapping(
+        self,
+        identity_key: str,
+        slot_name: str,
+        slot: int = 10,
+        uid_aliases: list[str] | None = None,
+    ) -> dict:
+        """Build a minimal v1 mapping suitable for fingerprint restart tests."""
+        return {
+            "identity_key": identity_key,
+            "slot": slot,
+            "status": "occupied",
+            "operation_id": None,
+            "operation_kind": None,
+            "identity": {
+                "identity_key": identity_key,
+                "summary": slot_name,
+                "slot_name": slot_name,
+                "uid_aliases": uid_aliases or [],
+                "booking_aliases": [],
+            },
+            "missing_count": 0,
+            "pending_set_since": None,
+            "pending_clear_since": None,
+            "fingerprint_history": [],
+            "updated_at": "2026-01-01T00:00:00+00:00",
+            "last_observed_actual": {
+                "slot": slot,
+                "classification": "occupied",
+                "name_state": slot_name,
+                "has_code": True,
+                "start_state": None,
+                "end_state": None,
+                "use_date_range": None,
+                "enabled": None,
+            },
+        }
+
+    def test_fingerprint_key_survives_load(self) -> None:
+        """T078-1: load_persisted_mappings retains fingerprint as mapping key."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry_id = "entry-restart-001"
+        name = "Alice Guest"
+        start = _make_dt(2026, 7, 1)
+        end = _make_dt(2026, 7, 8)
+
+        fp = make_reservation_fingerprint(entry_id, name, start, end)
+        mapping = self._make_fp_mapping(identity_key=fp, slot_name=name)
+
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        eo.load_persisted_mappings({fp: mapping})
+
+        pm = eo.persisted_mappings
+        assert fp in pm
+        assert pm[fp]["slot"] == 10
+        assert pm[fp]["status"] == "occupied"
+
+    def test_exact_rematch_after_restart_no_uid_change(self) -> None:
+        """T078-2: EXACT rematch found when feed returns same reservation data.
+
+        Simulates: integration persists the mapping, HA restarts, feed
+        returns the same reservation → find_reservation_rematch returns EXACT.
+        """
+        from custom_components.rental_control.reconciliation import RematchKind
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import (
+            find_reservation_rematch,
+        )
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry_id = "entry-restart-002"
+        name = "Bob Guest"
+        start = _make_dt(2026, 7, 10)
+        end = _make_dt(2026, 7, 17)
+        uid = "uid-stable-bob"
+
+        fp = make_reservation_fingerprint(entry_id, name, start, end)
+        mapping = self._make_fp_mapping(
+            identity_key=fp, slot_name=name, uid_aliases=[uid]
+        )
+
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        eo.load_persisted_mappings({fp: mapping})
+
+        # After restart: feed returns same reservation (same fingerprint)
+        reservation = Reservation(
+            identity_key=fp,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="1234",
+        )
+        reservation.uid_aliases.add(uid)
+
+        result = find_reservation_rematch(reservation, eo.persisted_mappings)
+        assert result.kind is RematchKind.EXACT
+        assert result.matched_identity_key == fp
+
+    def test_exact_rematch_after_restart_with_uid_churn(self) -> None:
+        """T078-3: EXACT rematch even when UID changed between restarts.
+
+        Simulates: integration persists with old UID, platform reissues
+        UID before HA restarts, feed returns new UID but same name/dates
+        → fingerprint unchanged → EXACT match → mapping preserved.
+        """
+        from custom_components.rental_control.reconciliation import RematchKind
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import (
+            find_reservation_rematch,
+        )
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry_id = "entry-restart-003"
+        name = "Carol Guest"
+        start = _make_dt(2026, 8, 1)
+        end = _make_dt(2026, 8, 8)
+        old_uid = "uid-carol-original"
+        new_uid = "uid-carol-reissued"
+
+        fp = make_reservation_fingerprint(entry_id, name, start, end)
+        mapping = self._make_fp_mapping(
+            identity_key=fp, slot_name=name, uid_aliases=[old_uid]
+        )
+
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        eo.load_persisted_mappings({fp: mapping})
+
+        # After restart: feed returns SAME reservation with NEW uid
+        reservation = Reservation(
+            identity_key=fp,  # fingerprint is UID-independent → same fp
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="5678",
+        )
+        reservation.uid_aliases.add(new_uid)  # new UID after platform churn
+
+        result = find_reservation_rematch(reservation, eo.persisted_mappings)
+        assert result.kind is RematchKind.EXACT
+        assert result.matched_identity_key == fp
+        assert result.date_shifted is False  # no date shift, only UID changed
+
+    def test_no_raw_pin_in_fingerprint_keyed_mapping(self) -> None:
+        """T078-4: Fingerprint-keyed mappings maintain no-raw-PIN invariant."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        fp = make_reservation_fingerprint(
+            "entry-001", "Diana Guest", _make_dt(2026, 9, 1), _make_dt(2026, 9, 8)
+        )
+        mapping = self._make_fp_mapping(identity_key=fp, slot_name="Diana Guest")
+
+        # Verify the fixture itself (and any real persistence) has no raw PIN
+        last_obs = mapping["last_observed_actual"]
+        assert "pin" not in last_obs
+        assert "code" not in last_obs
+        assert "slot_code" not in last_obs
+        assert "has_code" in last_obs  # only the bool flag
+
+    def test_multiple_fingerprint_keyed_mappings_loaded(self) -> None:
+        """T078-5: Multiple fingerprint-keyed mappings all survive load."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        guests = [
+            ("Alice", _make_dt(2026, 7, 1), _make_dt(2026, 7, 8), 10),
+            ("Bob", _make_dt(2026, 7, 9), _make_dt(2026, 7, 16), 11),
+            ("Carol", _make_dt(2026, 7, 17), _make_dt(2026, 7, 24), 12),
+        ]
+        entry_id = "entry-multi"
+        mappings = {}
+        fps = []
+        for name, start, end, slot in guests:
+            fp = make_reservation_fingerprint(entry_id, name, start, end)
+            fps.append(fp)
+            mappings[fp] = self._make_fp_mapping(
+                identity_key=fp, slot_name=name, slot=slot
+            )
+
+        eo = EventOverrides(start_slot=10, max_slots=3)
+        eo.load_persisted_mappings(mappings)
+
+        pm = eo.persisted_mappings
+        for fp in fps:
+            assert fp in pm
+
+    def test_dataclass_invariants_preserved_after_restart(self) -> None:
+        """T078-6: SlotMapping invariants from prior commits remain intact post-restart.
+
+        Verifies that schema_version >= 1 and missing_count >= 0 invariants
+        from the SlotMapping dataclass (T014/commit 2) are not violated by
+        fingerprint-keyed mappings used in restart scenarios.
+        """
+        from custom_components.rental_control.reconciliation import SlotMapping
+        from custom_components.rental_control.reconciliation import StoredActual
+        from custom_components.rental_control.reconciliation import StoredIdentity
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry_id = "entry-inv"
+        name = "Eve Guest"
+        start = _make_dt(2026, 10, 1)
+        end = _make_dt(2026, 10, 8)
+        fp = make_reservation_fingerprint(entry_id, name, start, end)
+
+        sm = SlotMapping(
+            schema_version=1,
+            entry_id=entry_id,
+            identity_key=fp,
+            slot=10,
+            status="occupied",
+            identity=StoredIdentity(
+                identity_key=fp,
+                summary=name,
+                slot_name=name,
+            ),
+            last_observed_actual=StoredActual(slot=10, classification="occupied"),
+            updated_at=_make_dt(2026, 10, 1),
+        )
+        # schema_version=1 and missing_count=0 are valid per SlotMapping.__post_init__
+        assert sm.schema_version == 1
+        assert sm.missing_count == 0
+        assert sm.identity_key == fp
+        assert sm.fingerprint_history == []
+
+
+# ---------------------------------------------------------------------------
+# T029: Desired-plan action scaffolding (set, update_times, noop, overflow)
+# ---------------------------------------------------------------------------
+# These tests verify that compute_desired_plan generates the correct action
+# kinds for the four fundamental scenarios that the EventOverrides apply-plan
+# phase (commits 5-6) will need to execute.  They are pure model tests:
+# no HA service calls, no coordinator wiring, no locks.
+# ---------------------------------------------------------------------------
+
+
+class TestDesiredPlanActionScaffold:
+    """T029: pure model tests for set/update_times/noop/overflow action types."""
+
+    from datetime import timezone as _tz_import
+
+    _TZ = _tz_import.utc
+
+    def _dt(self, year: int, month: int, day: int, hour: int = 14) -> datetime:
+        """Return a UTC-aware datetime."""
+        return datetime(year, month, day, hour, tzinfo=self._TZ)
+
+    def _make_res(
+        self,
+        identity_key: str,
+        *,
+        start_day: int = 1,
+        start_month: int = 8,
+    ):
+        """Return a minimal Reservation for action-scaffold tests."""
+        from datetime import timedelta
+
+        from custom_components.rental_control.reconciliation import Reservation
+
+        start = self._dt(2026, start_month, start_day)
+        end = (start + timedelta(days=7)).replace(hour=11)
+        return Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=f"Guest {identity_key}",
+            slot_name=f"Guest {identity_key}",
+            display_slot_name=f"RC Guest {identity_key}",
+            slot_code="5678",
+        )
+
+    def _make_ms(
+        self,
+        slot: int,
+        status,
+        persisted_key: str | None = None,
+        actual_start=None,
+        actual_end=None,
+    ):
+        """Return a minimal ManagedSlot for action-scaffold tests."""
+        from custom_components.rental_control.reconciliation import ManagedSlot
+
+        return ManagedSlot(
+            slot=slot,
+            managed=True,
+            status=status,
+            persisted_identity_key=persisted_key,
+            actual_start=actual_start,
+            actual_end=actual_end,
+        )
+
+    def test_free_slot_desired_reservation_generates_set_action(self) -> None:
+        """A FREE managed slot assigned a desired reservation → SET action.
+
+        This is the most common initial-assignment scenario: a new reservation
+        arrives and an empty slot is available.
+        """
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._make_res("res-set")
+        ms = self._make_ms(5, SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t029-set",
+            generated_at=self._dt(2026, 8, 1),
+        )
+
+        assert "res-set" in plan.selected
+        set_actions = [a for a in plan.actions if a.kind is ActionKind.SET]
+        assert len(set_actions) == 1
+        assert set_actions[0].slot == 5
+        assert set_actions[0].identity_key == "res-set"
+
+    def test_occupied_same_reservation_different_dates_generates_update_times(
+        self,
+    ) -> None:
+        """OCCUPIED slot with same reservation but different buffered dates → UPDATE_TIMES.
+
+        This happens when a guest modifies check-in/check-out dates; Rental
+        Control must update the Keymaster date range without changing the PIN.
+        """
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._make_res("res-update")
+        # Slot has old dates (different from res.buffered_start / buffered_end)
+        old_start = self._dt(2026, 7, 25)
+        old_end = self._dt(2026, 8, 1, 11)
+        ms = self._make_ms(
+            5,
+            SlotStatus.OCCUPIED,
+            persisted_key="res-update",
+            actual_start=old_start,
+            actual_end=old_end,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t029-update",
+            generated_at=self._dt(2026, 8, 1),
+        )
+
+        assert plan.slots[5].action is ActionKind.UPDATE_TIMES
+        update_actions = [a for a in plan.actions if a.kind is ActionKind.UPDATE_TIMES]
+        assert len(update_actions) == 1
+        assert update_actions[0].identity_key == "res-update"
+
+    def test_occupied_same_reservation_same_dates_generates_noop(self) -> None:
+        """OCCUPIED slot with same reservation and matching dates → no action (NOOP).
+
+        This is the steady-state scenario: everything is already correct and
+        the apply-plan phase should issue no Keymaster service call.
+        """
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._make_res("res-noop")
+        # Slot has exactly the same dates as res.buffered_start / buffered_end
+        ms = self._make_ms(
+            5,
+            SlotStatus.OCCUPIED,
+            persisted_key="res-noop",
+            actual_start=res.buffered_start,
+            actual_end=res.buffered_end,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t029-noop",
+            generated_at=self._dt(2026, 8, 1),
+        )
+
+        assert plan.slots[5].action is ActionKind.NOOP
+        # NOOP must NOT appear in plan.actions (only non-noop actions are listed)
+        assert not any(a.kind is ActionKind.NOOP for a in plan.actions)
+
+    def test_overflow_reservation_not_in_selected(self) -> None:
+        """Reservations beyond max_events end up in overflow, not in selected.
+
+        The apply-plan phase must not attempt a SET action for overflow
+        reservations; it should only report them as unassigned.
+        """
+        from datetime import timezone
+
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = timezone.utc
+
+        def _mk(key: str, day: int):
+            """Build a minimal August Reservation with *key* starting on *day*."""
+            from custom_components.rental_control.reconciliation import Reservation
+
+            s = datetime(2026, 8, day, 14, tzinfo=_TZ)
+            e = datetime(2026, 8, day + 7, 11, tzinfo=_TZ)
+            return Reservation(
+                identity_key=key,
+                start=s,
+                end=e,
+                buffered_start=s,
+                buffered_end=e,
+                summary=f"G {key}",
+                slot_name=f"G {key}",
+                display_slot_name=f"RC G {key}",
+                slot_code="0000",
+            )
+
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+
+        reservations = [_mk("ov-r1", 1), _mk("ov-r2", 8), _mk("ov-r3", 15)]
+        slots = [
+            ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE),
+            ManagedSlot(slot=6, managed=True, status=SlotStatus.FREE),
+        ]
+
+        plan = compute_desired_plan(
+            reservations,
+            slots,
+            max_events=2,
+            plan_id="t029-ov",
+            generated_at=datetime(2026, 8, 1, tzinfo=_TZ),
+        )
+
+        assert "ov-r1" in plan.selected
+        assert "ov-r2" in plan.selected
+        assert "ov-r3" in plan.overflow
+        assert plan.overflow["ov-r3"] == "capacity"
+        assert "ov-r3" not in plan.selected
+
+
+# ---------------------------------------------------------------------------
+# T091: EventOverrides diagnostics snapshot tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsSnapshot:
+    """T091: Diagnostics snapshot tests for matched slots, pending corrections,
+    blocked clear reasons, retry count, last error, and no raw codes."""
+
+    _TZ = dt_util.UTC
+
+    def _make_dt(self, day: int) -> datetime:
+        """Return a UTC-aware datetime for Aug *day* 2026 at 14:00."""
+        return datetime(2026, 8, day, 14, tzinfo=self._TZ)
+
+    def _make_plan(
+        self,
+        *,
+        plan_id: str = "diag-plan-001",
+    ) -> DesiredPlan:
+        """Return a minimal DesiredPlan for snapshot tests."""
+        return DesiredPlan(
+            plan_id=plan_id,
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+
+    def _make_planned_slot(
+        self,
+        slot: int,
+        *,
+        desired_identity_key: str | None = None,
+        actual_classification: str = "free",
+        action: ActionKind = ActionKind.NOOP,
+        pending_reason: str | None = None,
+        retry_count: int = 0,
+        last_error: str | None = None,
+    ):
+        """Return a minimal PlannedSlot for snapshot tests."""
+        from custom_components.rental_control.reconciliation import PlannedSlot
+
+        return PlannedSlot(
+            slot=slot,
+            desired_identity_key=desired_identity_key,
+            actual_classification=actual_classification,
+            action=action,
+            pending_reason=pending_reason,
+            retry_count=retry_count,
+            last_error=last_error,
+        )
+
+    def test_initial_snapshot_is_empty(self) -> None:
+        """Before any plan is applied, diagnostics_snapshot is an empty dict."""
+        eo = EventOverrides(start_slot=5, max_slots=3)
+        assert eo.diagnostics_snapshot == {}
+
+    def test_snapshot_has_matched_slots(self) -> None:
+        """After update_diagnostics_snapshot, matched slots appear in snapshot."""
+        eo = EventOverrides(start_slot=5, max_slots=3)
+        plan = self._make_plan()
+        plan.slots[5] = self._make_planned_slot(
+            5,
+            desired_identity_key="res-abc",
+            actual_classification="occupied",
+            action=ActionKind.NOOP,
+        )
+        plan.slots[6] = self._make_planned_slot(6)  # no desired key → not matched
+
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+
+        assert 5 in snap["matched_slots"]
+        assert snap["matched_slots"][5]["identity_key"] == "res-abc"
+        assert 6 not in snap["matched_slots"]
+
+    def test_snapshot_has_pending_corrections_for_retry_clear(self) -> None:
+        """RETRY_CLEAR action appears in pending_corrections."""
+        eo = EventOverrides(start_slot=5, max_slots=3)
+        plan = self._make_plan()
+        plan.slots[5] = self._make_planned_slot(
+            5,
+            desired_identity_key=None,
+            actual_classification="pending_clear",
+            action=ActionKind.RETRY_CLEAR,
+            pending_reason="prior clear unconfirmed",
+            retry_count=2,
+        )
+
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+
+        assert 5 in snap["pending_corrections"]
+        correction = snap["pending_corrections"][5]
+        assert correction["action"] == ActionKind.RETRY_CLEAR.value
+        assert correction["retry_count"] == 2
+
+    def test_snapshot_has_pending_corrections_for_blocked(self) -> None:
+        """BLOCKED action appears in pending_corrections."""
+        eo = EventOverrides(start_slot=5, max_slots=3)
+        plan = self._make_plan()
+        plan.slots[6] = self._make_planned_slot(
+            6,
+            actual_classification="blocked",
+            action=ActionKind.BLOCKED,
+            pending_reason="manual change detected",
+        )
+
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+
+        assert 6 in snap["pending_corrections"]
+        assert snap["pending_corrections"][6]["action"] == ActionKind.BLOCKED.value
+
+    def test_snapshot_has_blocked_clear_reasons(self) -> None:
+        """blocked_reason from PlannedSlot appears in pending_corrections."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        plan = self._make_plan()
+        plan.slots[5] = self._make_planned_slot(
+            5,
+            actual_classification="blocked",
+            action=ActionKind.BLOCKED,
+            pending_reason="slot entity unavailable",
+        )
+
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+
+        assert (
+            snap["pending_corrections"][5]["blocked_reason"]
+            == "slot entity unavailable"
+        )
+
+    def test_snapshot_has_slot_retry_counts(self) -> None:
+        """slot_retry_counts includes all managed slots."""
+        eo = EventOverrides(start_slot=5, max_slots=3)
+        # Record a failure to bump retry count
+        eo.record_retry_failure(5)
+        eo.record_retry_failure(5)
+
+        plan = self._make_plan()
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+
+        # All three managed slots (5, 6, 7) appear
+        assert 5 in snap["slot_retry_counts"]
+        assert 6 in snap["slot_retry_counts"]
+        assert 7 in snap["slot_retry_counts"]
+        assert snap["slot_retry_counts"][5] == 2
+
+    def test_snapshot_has_last_errors_after_failed_clear(self) -> None:
+        """After a failed clear, last_slot_errors appears in snapshot."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        # Directly use the private helper to simulate a recorded error
+        eo._record_slot_error(5, "lock offline")
+
+        plan = self._make_plan()
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+
+        assert 5 in snap["last_slot_errors"]
+        assert snap["last_slot_errors"][5] == "lock offline"
+
+    async def test_snapshot_captures_error_from_failed_apply(self) -> None:
+        """apply_plan with a failed clear records the error in the snapshot."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "c1", "OldGuest", now, now + timedelta(days=7))
+        eo.update(6, "", "", now, now + timedelta(days=7))
+
+        plan = self._make_plan()
+        plan.actions = [SlotAction(kind=ActionKind.CLEAR, slot=5, identity_key=None)]
+        plan.slots[5] = self._make_planned_slot(
+            5,
+            desired_identity_key=None,
+            actual_classification="occupied",
+            action=ActionKind.CLEAR,
+        )
+        plan.slots[6] = self._make_planned_slot(6)
+
+        failed_result = OperationResult(
+            kind="clear",
+            slot=5,
+            failed=True,
+            error="lock unreachable",
+        )
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=failed_result,
+        ):
+            await eo.async_apply_plan(coordinator, plan, {})
+
+        snap = eo.diagnostics_snapshot
+        assert 5 in snap["last_slot_errors"]
+        assert snap["last_slot_errors"][5] == "lock unreachable"
+
+    async def test_snapshot_clears_error_after_successful_clear(self) -> None:
+        """After a successful clear, the slot error is removed from snapshot."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "c1", "OldGuest", now, now + timedelta(days=7))
+        eo.update(6, "", "", now, now + timedelta(days=7))
+        # Pre-seed an error from a previous failed attempt
+        eo._record_slot_error(5, "previous error")
+
+        plan = self._make_plan()
+        plan.actions = [SlotAction(kind=ActionKind.CLEAR, slot=5, identity_key=None)]
+        plan.slots[5] = self._make_planned_slot(
+            5,
+            desired_identity_key=None,
+            actual_classification="occupied",
+            action=ActionKind.CLEAR,
+        )
+        plan.slots[6] = self._make_planned_slot(6)
+
+        success_result = OperationResult(kind="clear", slot=5, confirmed=True)
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=success_result,
+        ):
+            await eo.async_apply_plan(coordinator, plan, {})
+
+        snap = eo.diagnostics_snapshot
+        assert 5 not in snap["last_slot_errors"]
+
+    def test_snapshot_has_no_raw_slot_codes(self) -> None:
+        """Diagnostics snapshot contains no slot_code or PIN values."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "secret1234", "Guest A", now, now + timedelta(days=7))
+
+        plan = self._make_plan()
+        plan.slots[5] = self._make_planned_slot(
+            5,
+            desired_identity_key="res-001",
+            actual_classification="occupied",
+            action=ActionKind.NOOP,
+        )
+        eo.update_diagnostics_snapshot(plan)
+
+        snap = eo.diagnostics_snapshot
+        snap_str = str(snap)
+        assert "secret1234" not in snap_str
+        assert "slot_code" not in snap_str
+        assert "pin" not in snap_str.lower()
+
+    def test_snapshot_has_plan_id_and_timestamp(self) -> None:
+        """Snapshot includes plan_id and generated_at from the plan."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        plan = self._make_plan(plan_id="unique-plan-xyz")
+        eo.update_diagnostics_snapshot(plan)
+
+        snap = eo.diagnostics_snapshot
+        assert snap["plan_id"] == "unique-plan-xyz"
+        assert "generated_at" in snap
+
+    def test_snapshot_pending_clear_slots_list(self) -> None:
+        """pending_clear_slots in snapshot matches internal state."""
+        eo = EventOverrides(start_slot=5, max_slots=3)
+        # Manually simulate pending clear state
+        eo._pending_clear_slots[5] = "op-token-abc"
+
+        plan = self._make_plan()
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+
+        assert 5 in snap["pending_clear_slots"]
+
+
+# ---------------------------------------------------------------------------
+# T070: Manual managed-slot drift tests (name, code, start, end, switch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestManualDriftLogging:
+    """T070: Tests for manual/external managed-slot drift detection and logging.
+
+    Verifies that EventOverrides correctly handles OVERWRITE_MANUAL_CHANGE
+    actions: logging drift details with redacted code fields, restoring the
+    desired state, and surfacing manual drift in the diagnostics snapshot.
+    Unmanaged slot edits are invisible to the reconciliation system because
+    compute_desired_plan only iterates managed slots.
+    """
+
+    _TZ = dt_util.UTC
+
+    def _make_res(
+        self,
+        identity_key: str = "r-drift-001",
+        *,
+        slot_name: str = "Alice Smith",
+        display_slot_name: str = "RC Alice Smith",
+        slot_code: str = "SECRETPIN",
+        start_day: int = 1,
+    ) -> Reservation:
+        """Return a minimal Reservation for drift tests."""
+        start = datetime(2026, 8, start_day, 14, tzinfo=self._TZ)
+        end = start + timedelta(days=7)
+        return Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=f"Guest {slot_name}",
+            slot_name=slot_name,
+            display_slot_name=display_slot_name,
+            slot_code=slot_code,
+        )
+
+    def _make_overwrite_action(
+        self,
+        slot: int = 5,
+        identity_key: str = "r-drift-001",
+        drift_fields: list[str] | None = None,
+    ) -> SlotAction:
+        """Return a minimal OVERWRITE_MANUAL_CHANGE SlotAction."""
+        fields = drift_fields if drift_fields is not None else ["name"]
+        reason = "drifted fields: " + ", ".join(fields)
+        return SlotAction(
+            kind=ActionKind.OVERWRITE_MANUAL_CHANGE,
+            slot=slot,
+            identity_key=identity_key,
+            reason=reason,
+        )
+
+    async def test_name_drift_logged_at_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Name drift triggers a WARNING log including the field name."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+
+        res = self._make_res()
+        action = self._make_overwrite_action(drift_fields=["name"])
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        assert any(
+            "name" in r.message and "slot 5" in r.message for r in caplog.records
+        )
+
+    async def test_code_drift_logged_at_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Code drift triggers a WARNING log including the 'code' field."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+
+        res = self._make_res()
+        action = self._make_overwrite_action(drift_fields=["code"])
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        assert any(
+            "code" in r.message and "slot 5" in r.message for r in caplog.records
+        )
+
+    async def test_start_date_drift_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Start-date drift is included in the WARNING log's field list."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+
+        res = self._make_res()
+        action = self._make_overwrite_action(drift_fields=["name", "start"])
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "start" in log_text
+
+    async def test_end_date_drift_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """End-date drift is included in the WARNING log's field list."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+
+        res = self._make_res()
+        action = self._make_overwrite_action(drift_fields=["name", "end"])
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "end" in log_text
+
+    async def test_overwrite_passes_unbuffered_dates(self) -> None:
+        """Manual-drift overwrite passes unbuffered dates to set helper."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+
+        res = self._make_res()
+        res.buffered_start = res.start - timedelta(hours=1)
+        res.buffered_end = res.end + timedelta(hours=1)
+        action = self._make_overwrite_action(drift_fields=["name", "start"])
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+        observed: list[tuple[datetime, datetime]] = []
+
+        async def mock_set_code(_coordinator, event, _slot) -> OperationResult:
+            """Capture the event dates passed to the physical helper."""
+            observed.append(
+                (
+                    event.extra_state_attributes["start"],
+                    event.extra_state_attributes["end"],
+                )
+            )
+            return OperationResult(kind="set", slot=5, confirmed=True)
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            side_effect=mock_set_code,
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        assert observed == [(res.start, res.end)]
+
+    async def test_date_range_switch_drift_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """date_range_enabled drift is included in the WARNING log's field list."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+
+        res = self._make_res()
+        action = self._make_overwrite_action(
+            drift_fields=["name", "date_range_enabled"]
+        )
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "date_range_enabled" in log_text
+
+    async def test_raw_pin_never_in_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Raw PIN value must never appear in WARNING (or above) log records during overwrite.
+
+        The existing EventOverrides.update() debug log includes the overrides
+        dict; that is pre-existing behaviour outside this commit's scope.  This
+        test targets WARNING-and-above records to verify that the new
+        OVERWRITE_MANUAL_CHANGE log message never exposes the raw PIN.
+        """
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SUPERSECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+
+        res = self._make_res(slot_code="SUPERSECRETPIN")
+        action = self._make_overwrite_action(drift_fields=["name"])
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        # Only WARNING+ records are captured; none must contain the raw PIN.
+        for record in (r for r in caplog.records if r.levelno >= logging.WARNING):
+            assert "SUPERSECRETPIN" not in record.message
+
+    async def test_desired_identity_in_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The desired reservation identity_key appears in the WARNING log."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+
+        res = self._make_res(identity_key="r-identity-check")
+        action = self._make_overwrite_action(
+            identity_key="r-identity-check", drift_fields=["name"]
+        )
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "r-identity-check" in log_text
+
+    async def test_observed_name_from_actual_state_cache_in_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Observed name from actual-state cache appears in the WARNING log."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+        # Simulate actual-state cache with a different observed name
+        eo.update_actual_state(
+            5,
+            {
+                "slot": 5,
+                "classification": "occupied",
+                "name_state": "MANUALLY CHANGED",
+                "has_code": True,
+                "start_state": None,
+                "end_state": None,
+                "use_date_range": True,
+                "enabled": True,
+            },
+        )
+
+        res = self._make_res()
+        action = self._make_overwrite_action(drift_fields=["name"])
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "MANUALLY CHANGED" in log_text
+
+    async def test_async_apply_plan_routes_overwrite_manual_change(self) -> None:
+        """async_apply_plan dispatches OVERWRITE_MANUAL_CHANGE to the handler."""
+        from custom_components.rental_control.reconciliation import PlannedSlot
+
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "SECRETPIN", "Alice Smith", now, now + timedelta(days=7))
+        eo.update(6, "", "", now, now + timedelta(days=7))
+
+        res = self._make_res()
+        action = self._make_overwrite_action(slot=5, drift_fields=["name"])
+
+        plan = DesiredPlan(
+            plan_id="t070-route",
+            generated_at=now,
+        )
+        plan.actions = [action]
+        plan.slots[5] = PlannedSlot(
+            slot=5,
+            desired_identity_key=res.identity_key,
+            actual_classification="occupied",
+            action=ActionKind.OVERWRITE_MANUAL_CHANGE,
+            pending_reason=action.reason,
+        )
+        plan.slots[6] = PlannedSlot(
+            slot=6,
+            desired_identity_key=None,
+            actual_classification="free",
+            action=ActionKind.NOOP,
+        )
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="set", slot=5, confirmed=True)
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            return_value=confirmed,
+        ) as mock_set:
+            results = await eo.async_apply_plan(
+                coordinator, plan, {res.identity_key: res}
+            )
+
+        assert mock_set.called
+        assert len(results) == 1
+        assert results[0].confirmed is True
+
+    async def test_snapshot_includes_manual_drift_slot(self) -> None:
+        """update_diagnostics_snapshot captures OVERWRITE_MANUAL_CHANGE slots."""
+        from custom_components.rental_control.reconciliation import PlannedSlot
+
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        plan = DesiredPlan(
+            plan_id="t070-snap",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+        plan.slots[5] = PlannedSlot(
+            slot=5,
+            desired_identity_key="r-drift-snap",
+            actual_classification="occupied",
+            action=ActionKind.OVERWRITE_MANUAL_CHANGE,
+            pending_reason="drifted fields: name",
+        )
+        plan.slots[6] = PlannedSlot(
+            slot=6,
+            desired_identity_key=None,
+            actual_classification="free",
+            action=ActionKind.NOOP,
+        )
+
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+
+        assert "manual_drift_slots" in snap
+        assert 5 in snap["manual_drift_slots"]
+        drift_entry = snap["manual_drift_slots"][5]
+        assert drift_entry["identity_key"] == "r-drift-snap"
+        assert "name" in drift_entry["drift_fields"]
+
+    async def test_snapshot_manual_drift_no_raw_codes(self) -> None:
+        """manual_drift_slots in snapshot must not contain raw PIN values."""
+        from custom_components.rental_control.reconciliation import PlannedSlot
+
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        plan = DesiredPlan(
+            plan_id="t070-nodrift",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+        plan.slots[5] = PlannedSlot(
+            slot=5,
+            desired_identity_key="r-drift-check",
+            actual_classification="occupied",
+            action=ActionKind.OVERWRITE_MANUAL_CHANGE,
+            pending_reason="drifted fields: name",
+        )
+
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+
+        snap_str = str(snap)
+        assert "slot_code" not in snap_str
+        # No raw PIN values (no standalone 'pin' token outside expected keys)
+        assert "SECRETPIN" not in snap_str
+
+    async def test_unmanaged_slot_edit_not_in_actions(self) -> None:
+        """Unmanaged slots never appear in plan.actions and are ignored."""
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = self._TZ
+        s = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        r = Reservation(
+            identity_key="r-unmanaged",
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary="Guest Unmanaged",
+            slot_name="Guest Unmanaged",
+            display_slot_name="RC Guest Unmanaged",
+            slot_code="SECRETPIN",
+        )
+
+        # Slot 3 is NOT managed; slot 5 is managed and free
+        unmanaged_slot = ManagedSlot(
+            slot=3,
+            managed=False,  # not in RC range
+            status=SlotStatus.OCCUPIED,
+            actual_name="MANUALLY EDITED NAME",
+            actual_code_present=True,
+        )
+        managed_slot = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [r],
+            [unmanaged_slot, managed_slot],
+            max_events=3,
+            plan_id="t070-unmanaged",
+            generated_at=s,
+        )
+
+        # No OVERWRITE_MANUAL_CHANGE action must reference slot 3
+        overwrite_actions = [
+            a for a in plan.actions if a.kind is ActionKind.OVERWRITE_MANUAL_CHANGE
+        ]
+        assert not any(a.slot == 3 for a in overwrite_actions)
+        # Unmanaged slot is absent from plan.slots entirely
+        assert 3 not in plan.slots
+
+
+# ---------------------------------------------------------------------------
+# T045 – duplicate actual assignment: canonical slot and non-canonical clear
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateActualAssignment:
+    """T045: Tests for duplicate actual assignment handling.
+
+    When the same reservation identity key is found in multiple OCCUPIED
+    managed slots, the planner treats the lowest-numbered slot as canonical
+    (keeping the reservation) and generates CLEAR actions for all
+    non-canonical slots.
+    """
+
+    _TZ = dt_util.UTC
+
+    def _make_res(
+        self,
+        identity_key: str = "r-dup",
+        *,
+        start_day: int = 1,
+    ) -> Reservation:
+        """Return a minimal Reservation for duplicate tests."""
+        start = datetime(2026, 8, start_day, 14, tzinfo=self._TZ)
+        end = start + timedelta(days=7)
+        return Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=f"Guest {identity_key}",
+            slot_name=f"Guest {identity_key}",
+            display_slot_name=f"RC Guest {identity_key}",
+            slot_code="DUPPIN",
+        )
+
+    def _occupied_slot(self, slot: int, persisted_key: str):
+        """Return an OCCUPIED ManagedSlot with *persisted_key*."""
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+
+        return ManagedSlot(
+            slot=slot,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name=f"Guest {persisted_key}",
+            actual_code_present=True,
+            persisted_identity_key=persisted_key,
+        )
+
+    def test_canonical_slot_keeps_reservation(self) -> None:
+        """Lower-numbered slot is canonical and keeps the desired assignment.
+
+        Scenario: slots 3 and 5 both have persisted_identity_key='r-dup'
+        (OCCUPIED).  The planner selects slot 3 as canonical because it is
+        the lower slot number.  plan.selected must map 'r-dup' to slot 3.
+        """
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._make_res("r-dup")
+        slot3 = self._occupied_slot(3, "r-dup")
+        slot5 = self._occupied_slot(5, "r-dup")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3, slot5],
+            max_events=3,
+            plan_id="t045-canonical",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+
+        assert "r-dup" in plan.selected
+        assert plan.selected["r-dup"] == 3
+
+    def test_non_canonical_slot_gets_clear_action(self) -> None:
+        """Non-canonical duplicate slot receives a CLEAR action.
+
+        Slot 5 is non-canonical (higher number than slot 3).  After
+        compute_desired_plan the actions list must contain exactly one CLEAR
+        targeting slot 5.
+        """
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._make_res("r-dup")
+        slot3 = self._occupied_slot(3, "r-dup")
+        slot5 = self._occupied_slot(5, "r-dup")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3, slot5],
+            max_events=3,
+            plan_id="t045-noncanon",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+
+        clear_actions = [a for a in plan.actions if a.kind is ActionKind.CLEAR]
+        assert any(a.slot == 5 for a in clear_actions), (
+            f"Expected CLEAR on slot 5; actions were {plan.actions}"
+        )
+
+    def test_non_canonical_clear_reason_is_duplicate(self) -> None:
+        """CLEAR action for non-canonical slot carries reason 'duplicate_non_canonical'."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._make_res("r-dup")
+        slot3 = self._occupied_slot(3, "r-dup")
+        slot5 = self._occupied_slot(5, "r-dup")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3, slot5],
+            max_events=3,
+            plan_id="t045-reason",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+
+        clear_slot5 = next(
+            (a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 5),
+            None,
+        )
+        assert clear_slot5 is not None
+        assert clear_slot5.reason == "duplicate_non_canonical"
+
+    async def test_non_canonical_slot_enters_pending_clear_after_apply(self) -> None:
+        """Applying CLEAR on non-canonical slot puts it in pending_clear state."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import SlotAction
+        from custom_components.rental_control.util import OperationResult
+
+        eo = EventOverrides(start_slot=3, max_slots=3)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(3, "DUPPIN", "Guest r-dup", now, now + timedelta(days=7))
+        eo.update(4, "", "", now, now + timedelta(days=7))
+        eo.update(5, "DUPPIN", "Guest r-dup", now, now + timedelta(days=7))
+
+        plan = DesiredPlan(plan_id="t045-pending", generated_at=now)
+        plan.actions = [
+            SlotAction(
+                kind=ActionKind.CLEAR,
+                slot=5,
+                identity_key=None,
+                reason="duplicate_non_canonical",
+            )
+        ]
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        # Unconfirmed clear → slot stays in pending_fences
+        unconfirmed = OperationResult(kind="clear", slot=5, confirmed=False)
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=unconfirmed,
+        ):
+            await eo.async_apply_plan(coordinator, plan, {})
+
+        # Slot 5 fence token must persist (clear unconfirmed)
+        assert 5 in eo.pending_fences
+
+    async def test_canonical_slot_noop_non_canonical_cleared(self) -> None:
+        """Full plan: canonical gets NOOP, non-canonical gets CLEAR applied."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        res = self._make_res("r-dup")
+        slot3 = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="RC Guest r-dup",
+            actual_code_present=True,
+            persisted_identity_key="r-dup",
+            actual_start=res.buffered_start,
+            actual_end=res.buffered_end,
+        )
+        slot5 = self._occupied_slot(5, "r-dup")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3, slot5],
+            max_events=3,
+            plan_id="t045-full",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+
+        # Canonical slot 3: NOOP (same reservation, same dates)
+        assert plan.slots[3].action is ActionKind.NOOP
+        # Non-canonical slot 5: CLEAR
+        assert plan.slots[5].action is ActionKind.CLEAR
+
+        eo = EventOverrides(start_slot=3, max_slots=3)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(3, "DUPPIN", "Guest r-dup", now, now + timedelta(days=7))
+        eo.update(4, "", "", now, now + timedelta(days=7))
+        eo.update(5, "DUPPIN", "Guest r-dup", now, now + timedelta(days=7))
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="clear", slot=5, confirmed=True)
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=confirmed,
+        ) as mock_clear:
+            await eo.async_apply_plan(coordinator, plan, {"r-dup": res})
+
+        # Clear was called exactly once for slot 5
+        assert mock_clear.called
+        # Slot 5 override cleared
+        assert eo.overrides.get(5) is None
+
+
+# ---------------------------------------------------------------------------
+# T053 – caplog coverage for corrupt-state self-heal log messages
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptStateCaplog:
+    """T053: caplog tests for corrupt-state self-heal log messages.
+
+    Verifies that the reconciliation system emits WARNING-level log entries
+    for each class of corrupt-state correction:
+
+    - duplicate collapse
+    - overflow decision (no_free_slot)
+    - phantom recovery
+    - stale correction
+    - mis-assignment correction
+    """
+
+    _TZ = dt_util.UTC
+
+    def _mk_res(
+        self,
+        identity_key: str = "r-test",
+        *,
+        start_day: int = 1,
+    ) -> Reservation:
+        """Return a minimal Reservation for caplog tests."""
+        start = datetime(2026, 8, start_day, 14, tzinfo=self._TZ)
+        end = start + timedelta(days=7)
+        return Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=f"Guest {identity_key}",
+            slot_name=f"Guest {identity_key}",
+            display_slot_name=f"RC Guest {identity_key}",
+            slot_code="CAPLOGPIN",
+        )
+
+    def test_duplicate_collapse_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Duplicate assignment detection emits a WARNING log entry."""
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._mk_res("r-dup-caplog")
+        slot3 = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest r-dup-caplog",
+            actual_code_present=True,
+            persisted_identity_key="r-dup-caplog",
+        )
+        slot5 = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest r-dup-caplog",
+            actual_code_present=True,
+            persisted_identity_key="r-dup-caplog",
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.rental_control"
+        ):
+            compute_desired_plan(
+                [res],
+                [slot3, slot5],
+                max_events=3,
+                plan_id="t053-dup",
+                generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+            )
+
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "duplicate" in log_text.lower() or "Duplicate" in log_text
+
+    async def test_duplicate_collapse_apply_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """async_apply_plan logs duplicate-collapse WARNING when clearing non-canonical slot."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import SlotAction
+        from custom_components.rental_control.util import OperationResult
+
+        eo = EventOverrides(start_slot=3, max_slots=3)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(3, "PIN3", "Guest dup", now, now + timedelta(days=7))
+        eo.update(4, "", "", now, now + timedelta(days=7))
+        eo.update(5, "PIN5", "Guest dup", now, now + timedelta(days=7))
+
+        plan = DesiredPlan(plan_id="t053-dup-apply", generated_at=now)
+        plan.actions = [
+            SlotAction(
+                kind=ActionKind.CLEAR,
+                slot=5,
+                identity_key=None,
+                reason="duplicate_non_canonical",
+            )
+        ]
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="clear", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo.async_apply_plan(coordinator, plan, {})
+
+        log_text = " ".join(
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        )
+        assert "duplicate" in log_text.lower() or "Duplicate" in log_text
+
+    def test_overflow_decision_no_free_slot_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Overflow (no_free_slot) emits a WARNING log entry."""
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        # max_events=1, slot 3 occupied by r-old; r-new needs a slot but all occupied
+        r_old = self._mk_res("r-old", start_day=10)
+        r_new = self._mk_res("r-new", start_day=1)
+        slot3 = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest r-old",
+            actual_code_present=True,
+            persisted_identity_key="r-old",
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.rental_control"
+        ):
+            plan = compute_desired_plan(
+                [r_old, r_new],
+                [slot3],
+                max_events=1,  # only r-new selected (nearer), but no free slot
+                plan_id="t053-overflow",
+                generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+            )
+
+        # r-new should overflow (no_free_slot) because slot 3 is OCCUPIED by r-old
+        assert "r-new" in plan.overflow
+
+        log_text = " ".join(
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        )
+        assert "overflow" in log_text.lower() or "Overflow" in log_text
+
+    async def test_phantom_recovery_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Phantom slot clear emits 'Phantom recovery' WARNING in async_apply_plan."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import SlotAction
+        from custom_components.rental_control.util import OperationResult
+
+        eo = EventOverrides(start_slot=5, max_slots=1)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "", "PhantomGuest", now, now + timedelta(days=7))
+
+        plan = DesiredPlan(plan_id="t053-phantom", generated_at=now)
+        plan.actions = [
+            SlotAction(
+                kind=ActionKind.CLEAR,
+                slot=5,
+                identity_key=None,
+                reason="phantom",
+            )
+        ]
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="clear", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo.async_apply_plan(coordinator, plan, {})
+
+        log_text = " ".join(
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        )
+        assert "phantom" in log_text.lower() or "Phantom" in log_text
+
+    async def test_stale_correction_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Stale assignment clear emits 'Stale correction' WARNING in async_apply_plan."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import SlotAction
+        from custom_components.rental_control.util import OperationResult
+
+        eo = EventOverrides(start_slot=5, max_slots=1)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "STALEPIN", "OldGuest", now, now + timedelta(days=7))
+
+        plan = DesiredPlan(plan_id="t053-stale", generated_at=now)
+        plan.actions = [
+            SlotAction(
+                kind=ActionKind.CLEAR,
+                slot=5,
+                identity_key=None,
+                reason="stale",
+            )
+        ]
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="clear", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo.async_apply_plan(coordinator, plan, {})
+
+        log_text = " ".join(
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        )
+        assert "stale" in log_text.lower() or "Stale" in log_text
+
+    async def test_misassignment_correction_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Mis-assigned slot clear emits 'Mis-assignment correction' WARNING."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import SlotAction
+        from custom_components.rental_control.util import OperationResult
+
+        eo = EventOverrides(start_slot=5, max_slots=1)
+        now = datetime(2026, 8, 1, tzinfo=self._TZ)
+        eo.update(5, "WRONGPIN", "WrongGuest", now, now + timedelta(days=7))
+
+        plan = DesiredPlan(plan_id="t053-misassign", generated_at=now)
+        plan.actions = [
+            SlotAction(
+                kind=ActionKind.CLEAR,
+                slot=5,
+                identity_key="r-desired",
+                reason="mis_assigned",
+            )
+        ]
+
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        confirmed = OperationResult(kind="clear", slot=5, confirmed=True)
+        with (
+            caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                return_value=confirmed,
+            ),
+        ):
+            await eo.async_apply_plan(coordinator, plan, {})
+
+        log_text = " ".join(
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        )
+        assert "mis-assignment" in log_text.lower() or "Mis-assignment" in log_text
+
+
+# ---------------------------------------------------------------------------
+# T054 – unmanaged-slot ignored: outside managed range never changed
+# ---------------------------------------------------------------------------
+
+
+class TestUnmanagedSlotIgnoredCorrupt:
+    """T054: Slots outside the RC-managed range are never changed.
+
+    Even when an unmanaged slot has a corrupt name, phantom state, or
+    duplicate persisted key, compute_desired_plan must not generate any
+    action targeting it.  The managed-range invariant is enforced by the
+    ``managed=False`` attribute on ManagedSlot.
+    """
+
+    _TZ = dt_util.UTC
+
+    def _mk_res(self, identity_key: str = "r-um") -> Reservation:
+        """Return a minimal Reservation for unmanaged-slot tests."""
+        start = datetime(2026, 8, 1, 14, tzinfo=self._TZ)
+        end = start + timedelta(days=7)
+        return Reservation(
+            identity_key=identity_key,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=f"Guest {identity_key}",
+            slot_name=f"Guest {identity_key}",
+            display_slot_name=f"RC Guest {identity_key}",
+            slot_code="UNMGDPIN",
+        )
+
+    def test_unmanaged_phantom_slot_never_cleared(self) -> None:
+        """PHANTOM unmanaged slot generates no action."""
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._mk_res()
+        unmanaged = ManagedSlot(
+            slot=3,
+            managed=False,
+            status=SlotStatus.PHANTOM,
+            actual_name="PhantomGuest",
+            actual_code_present=False,
+        )
+        managed_free = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [res],
+            [unmanaged, managed_free],
+            max_events=3,
+            plan_id="t054-phantom",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+
+        assert 3 not in plan.slots
+        assert not any(a.slot == 3 for a in plan.actions)
+
+    def test_unmanaged_stale_occupied_slot_never_cleared(self) -> None:
+        """Stale OCCUPIED unmanaged slot generates no action."""
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._mk_res()
+        # Unmanaged slot with stale reservation (expired key)
+        unmanaged = ManagedSlot(
+            slot=2,
+            managed=False,
+            status=SlotStatus.OCCUPIED,
+            actual_name="OldStaleGuest",
+            actual_code_present=True,
+            persisted_identity_key="r-expired-stale",
+        )
+        managed_free = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [res],
+            [unmanaged, managed_free],
+            max_events=3,
+            plan_id="t054-stale",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+
+        assert 2 not in plan.slots
+        assert not any(a.slot == 2 for a in plan.actions)
+
+    def test_unmanaged_duplicate_slot_never_cleared(self) -> None:
+        """Unmanaged slot sharing a persisted key with a managed slot is ignored."""
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._mk_res("r-shared-dup")
+        # Slot 2: unmanaged (outside range), has same persisted key
+        unmanaged_dup = ManagedSlot(
+            slot=2,
+            managed=False,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest r-shared-dup",
+            actual_code_present=True,
+            persisted_identity_key="r-shared-dup",
+        )
+        # Slot 5: managed, has same persisted key (canonical because managed)
+        managed_canon = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Guest r-shared-dup",
+            actual_code_present=True,
+            persisted_identity_key="r-shared-dup",
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [unmanaged_dup, managed_canon],
+            max_events=3,
+            plan_id="t054-dup",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+
+        assert 2 not in plan.slots
+        assert not any(a.slot == 2 for a in plan.actions)
+        # Managed canonical slot 5 must be present and assigned
+        assert "r-shared-dup" in plan.selected
+
+    def test_unmanaged_slot_outside_range_never_set(self) -> None:
+        """A reservation is never SET into an unmanaged slot."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        res = self._mk_res()
+        unmanaged_free = ManagedSlot(
+            slot=1,
+            managed=False,
+            status=SlotStatus.FREE,
+        )
+        managed_free = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [res],
+            [unmanaged_free, managed_free],
+            max_events=3,
+            plan_id="t054-set",
+            generated_at=datetime(2026, 8, 1, tzinfo=self._TZ),
+        )
+
+        # No SET or CLEAR action references the unmanaged slot
+        assert not any(a.slot == 1 for a in plan.actions)
+        # Reservation must land in the managed slot 5
+        set_actions = [a for a in plan.actions if a.kind is ActionKind.SET]
+        assert len(set_actions) == 1
+        assert set_actions[0].slot == 5
+
+
+class TestSlotNameTrimmingRegression:
+    """T101 regression: Slot-name trimming and prefix preservation.
+
+    These tests pin the semantics that must survive the reconciliation
+    refactor: the Keymaster display name is constructed by prepending the
+    event prefix and (when trim_names is True) trimming the guest portion
+    to fit.  The legacy EventOverrides read APIs that sensors depend on
+    must also continue to work.
+    """
+
+    @staticmethod
+    def _make_slot_event(slot_name: str) -> MagicMock:
+        """Build a minimal slot event for set-code tests."""
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": slot_name,
+            "slot_code": "2468",
+            "start": _make_dt(2025, 7, 15, 15, 0),
+            "end": _make_dt(2025, 7, 18, 11, 0),
+        }
+        return event
+
+    @staticmethod
+    def _make_set_coordinator(expected_state: str, *, trim_names: bool) -> MagicMock:
+        """Return a coordinator mock for set-code regression tests."""
+        coordinator = MagicMock()
+        coordinator.lockname = "test_lock"
+        coordinator.event_prefix = "RC"
+        coordinator.trim_names = trim_names
+        coordinator.max_name_length = 10
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+        state = MagicMock()
+        state.state = expected_state
+        coordinator.hass.states.get.return_value = state
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides._escalated = {}
+        return coordinator
+
+    def test_trim_name_word_boundary(self) -> None:
+        """Names trim on word boundaries when possible."""
+        assert trim_name("Alice Bob Charlie", 10) == "Alice Bob"
+
+    def test_trim_name_hard_truncate_single_word(self) -> None:
+        """Single words hard-truncate when no boundary fits."""
+        assert trim_name("Verylongname", 5) == "Veryl"
+
+    def test_trim_name_already_fits_unchanged(self) -> None:
+        """Short names are returned unchanged."""
+        assert trim_name("Short", 20) == "Short"
+
+    def test_strip_prefix_removes_prefix_and_space(self) -> None:
+        """Prefix stripping removes the prefix plus separator."""
+        assert _eo_module._strip_prefix("RC Alice", "RC") == "Alice"
+
+    def test_strip_prefix_no_match_unchanged(self) -> None:
+        """Non-matching prefixes leave the name unchanged."""
+        assert _eo_module._strip_prefix("NoPrefix Alice", "RC") == "NoPrefix Alice"
+
+    def test_strip_prefix_empty_prefix_unchanged(self) -> None:
+        """Empty prefixes never strip anything."""
+        assert _eo_module._strip_prefix("Alice", "") == "Alice"
+
+    def test_is_trimmed_match_detects_word_boundary_truncation(self) -> None:
+        """Trim-match detection recognises word-boundary trimming."""
+        assert (
+            _eo_module._is_trimmed_match("Alice Bob Charlie", "Alice Bob", 10) is True
+        )
+
+    def test_is_trimmed_match_false_when_trim_off(self) -> None:
+        """Equal names are not treated as trimmed matches."""
+        assert _eo_module._is_trimmed_match("Alice", "Alice", 10) is False
+
+    def test_legacy_overrides_property_accessible(self) -> None:
+        """Legacy overrides property remains readable."""
+        assert EventOverrides(10, 3).overrides == {}
+
+    def test_legacy_get_slot_with_name_finds_override(self) -> None:
+        """Legacy get_slot_with_name continues returning matching overrides."""
+        eo = EventOverrides(10, 3)
+        start = _make_dt(2025, 7, 15, 15, 0)
+        end = _make_dt(2025, 7, 18, 11, 0)
+        eo.update(10, "1234", "Alice", start, end)
+
+        override = eo.get_slot_with_name("Alice")
+
+        assert override is not None
+        assert override["slot_name"] == "Alice"
+
+    def test_legacy_trim_names_property_settable(self) -> None:
+        """Legacy trim_names property remains writable."""
+        eo = EventOverrides(10, 3)
+        eo.trim_names = True
+
+        assert eo.trim_names is True
+
+    def test_legacy_prefix_length_property_settable(self) -> None:
+        """Legacy prefix_length property remains writable."""
+        eo = EventOverrides(10, 3)
+        eo.prefix_length = 5
+
+        assert eo.prefix_length == 5
+
+    async def test_set_code_writes_prefix_plus_name_to_keymaster(self) -> None:
+        """Set-code preserves the configured prefix in the Keymaster display name."""
+        coordinator = self._make_set_coordinator("RC Alice", trim_names=False)
+        event = self._make_slot_event("Alice")
+
+        result = await async_fire_set_code(coordinator, event, 10)
+
+        name_calls = [
+            awaited.kwargs
+            for awaited in coordinator.hass.services.async_call.await_args_list
+            if awaited.kwargs.get("target", {}).get("entity_id")
+            == "text.test_lock_code_slot_10_name"
+        ]
+        assert result.confirmed is True
+        assert name_calls[-1]["service_data"]["value"] == "RC Alice"
+
+    async def test_set_code_trims_name_when_trim_enabled(self) -> None:
+        """Set-code trims only the guest portion when prefixing is enabled."""
+        coordinator = self._make_set_coordinator("RC Alice", trim_names=True)
+        event = self._make_slot_event("Alice Bob")
+
+        result = await async_fire_set_code(coordinator, event, 10)
+
+        name_calls = [
+            awaited.kwargs
+            for awaited in coordinator.hass.services.async_call.await_args_list
+            if awaited.kwargs.get("target", {}).get("entity_id")
+            == "text.test_lock_code_slot_10_name"
+        ]
+        assert result.confirmed is True
+        assert name_calls[-1]["service_data"]["value"] == "RC Alice"

--- a/tests/unit/test_keymaster_event_diagnostics.py
+++ b/tests/unit/test_keymaster_event_diagnostics.py
@@ -524,3 +524,134 @@ class TestDiagnosticsAttribute:
         assert "keymaster_event_diagnostics" in attrs
         assert isinstance(attrs["keymaster_event_diagnostics"], list)
         assert attrs["keymaster_event_diagnostics"][0]["disposition"] == "accepted"
+
+
+# ---------------------------------------------------------------------------
+# T094: Diagnostics redaction compatibility tests
+# ---------------------------------------------------------------------------
+
+
+class TestRedactionCompatibility:
+    """T094: Verify that neither the keymaster event diagnostics ring buffer
+    nor the new slot-plan diagnostics snapshot expose raw slot codes or
+    sensitive reservation metadata."""
+
+    def test_keymaster_event_buffer_has_no_slot_code_field(self) -> None:
+        """Entries in keymaster_event_diagnostics never contain slot_code."""
+        from collections import deque
+
+        buf: deque = deque(maxlen=10)
+        entry = {
+            "timestamp": "2026-05-15T13:08:11+00:00",
+            "lockname": "Front Door",
+            "lockname_slug": "front_door",
+            "state": "unlocked",
+            "code_slot_num": 11,
+            "disposition": "accepted",
+        }
+        buf.append(entry)
+        for item in list(buf):
+            assert "slot_code" not in item
+            assert "pin" not in item
+            assert "code_value" not in item
+
+    def test_keymaster_event_buffer_fields_are_non_sensitive(self) -> None:
+        """Accepted entries contain only lockname, state, slot num, disposition, timestamp."""
+        from collections import deque
+
+        buf: deque = deque(maxlen=10)
+        entry = {
+            "timestamp": "2026-05-15T13:08:11+00:00",
+            "lockname": "Front Door",
+            "lockname_slug": "front_door",
+            "state": "unlocked",
+            "code_slot_num": 11,
+            "disposition": "accepted",
+        }
+        buf.append(entry)
+        allowed_keys = {
+            "timestamp",
+            "lockname",
+            "lockname_slug",
+            "state",
+            "code_slot_num",
+            "disposition",
+        }
+        for item in list(buf):
+            assert set(item.keys()).issubset(allowed_keys)
+
+    def test_event_overrides_diagnostics_snapshot_has_no_raw_codes(self) -> None:
+        """EventOverrides.diagnostics_snapshot contains no slot_code or PIN data."""
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+
+        from custom_components.rental_control.event_overrides import EventOverrides
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import DesiredPlan
+        from custom_components.rental_control.reconciliation import PlannedSlot
+
+        _TZ = timezone.utc
+        now = datetime(2026, 8, 1, tzinfo=_TZ)
+        eo = EventOverrides(start_slot=10, max_slots=2)
+        eo.update(10, "SECRETPIN123", "Guest A", now, now + timedelta(days=7))
+
+        plan = DesiredPlan(plan_id="redact-test", generated_at=now)
+        plan.slots[10] = PlannedSlot(
+            slot=10,
+            desired_identity_key="res-a",
+            actual_classification="occupied",
+            action=ActionKind.NOOP,
+        )
+        plan.slots[11] = PlannedSlot(
+            slot=11,
+            desired_identity_key=None,
+            actual_classification="free",
+            action=ActionKind.NOOP,
+        )
+
+        eo.update_diagnostics_snapshot(plan)
+        snap = eo.diagnostics_snapshot
+        snap_str = str(snap)
+
+        assert "SECRETPIN123" not in snap_str
+        assert "slot_code" not in snap_str
+
+    def test_compute_desired_plan_diagnostics_has_no_slot_code(self) -> None:
+        """compute_desired_plan diagnostics exclude slot_code from all entries."""
+        from datetime import datetime
+        from datetime import timedelta
+        from datetime import timezone
+
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        _TZ = timezone.utc
+        start = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        end = start + timedelta(days=7)
+        r = Reservation(
+            identity_key="r-redact",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Guest Redact",
+            slot_name="Guest Redact",
+            display_slot_name="RC Guest Redact",
+            slot_code="RAWPIN4567",
+        )
+        ms = ManagedSlot(slot=10, managed=True, status=SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [r],
+            [ms],
+            max_events=3,
+            plan_id="p-redact",
+            generated_at=start,
+        )
+
+        diag_str = str(plan.diagnostics)
+        assert "RAWPIN4567" not in diag_str
+        assert "slot_code" not in diag_str

--- a/tests/unit/test_sensors.py
+++ b/tests/unit/test_sensors.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from datetime import datetime
 from datetime import timezone
 import random
-from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import call
 from unittest.mock import patch
@@ -20,7 +19,6 @@ from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.const import ICON
 from custom_components.rental_control.const import NAME
-from custom_components.rental_control.event_overrides import ReserveResult
 from custom_components.rental_control.sensor import async_setup_entry
 from custom_components.rental_control.sensor import async_setup_platform
 from custom_components.rental_control.sensors.calsensor import RentalControlCalSensor
@@ -57,6 +55,7 @@ def _make_coordinator(
     *,
     name: str = "Test Rental",
     unique_id: str = "test_unique_id",
+    entry_id: str = "test_entry_id",
     last_update_success: bool = True,
     data: list | None = None,
     event_prefix: str = "",
@@ -64,11 +63,14 @@ def _make_coordinator(
     code_length: int = 4,
     event_overrides: MagicMock | None = None,
     should_update_code: bool = True,
+    slot_assignment: int | None = None,
+    slot_code: str | None = None,
 ) -> MagicMock:
     """Create a mock coordinator for sensor testing."""
     coordinator = MagicMock()
     coordinator.name = name
     coordinator.unique_id = unique_id
+    coordinator.entry_id = entry_id
     coordinator.last_update_success = last_update_success
     coordinator.data = data
     coordinator.event_prefix = event_prefix
@@ -76,6 +78,8 @@ def _make_coordinator(
     coordinator.code_length = code_length
     coordinator.event_overrides = event_overrides
     coordinator.should_update_code = should_update_code
+    coordinator.get_slot_assignment.return_value = slot_assignment
+    coordinator.get_slot_code.return_value = slot_code
     coordinator.device_info = {
         "identifiers": {(DOMAIN, unique_id)},
         "name": f"{NAME} {name}",
@@ -1350,70 +1354,33 @@ class TestHandleCoordinatorUpdateNoEvents:
 
 
 # ---------------------------------------------------------------------------
-# Override interaction tests
+# Override interaction tests — reconciliation read-only path
 # ---------------------------------------------------------------------------
 
 
 class TestHandleCoordinatorUpdateOverrides:
-    """Tests for _handle_coordinator_update interactions with event_overrides."""
+    """Tests for _handle_coordinator_update reading from reconciliation state."""
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    async def test_fires_set_code_when_new_reservation(self, hass) -> None:
-        """Verify async_fire_set_code is called when slot is newly reserved."""
+    def test_slot_code_from_reconciliation(self, hass) -> None:
+        """Verify slot_code is read from coordinator reconciliation state."""
         event = _make_event()
-        overrides = MagicMock()
-        overrides.ready = True
-        overrides.get_slot_with_name.return_value = None
-        overrides.async_reserve_or_get_slot = AsyncMock(
-            return_value=ReserveResult(10, True, False)
+        coordinator = _make_coordinator(
+            data=[event],
+            event_overrides=MagicMock(),
+            slot_code="5555",
         )
-        coordinator = _make_coordinator(data=[event], event_overrides=overrides)
-        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
-        sensor.hass = MagicMock()
-        sensor.async_write_ha_state = MagicMock()
-
-        with patch(
-            "custom_components.rental_control.sensors.calsensor.async_fire_set_code",
-            new_callable=AsyncMock,
-        ) as mock_set_code:
-            sensor._handle_coordinator_update()
-            coro = sensor.hass.async_create_task.call_args[0][0]
-            await coro
-            mock_set_code.assert_called_once_with(coordinator, sensor, 10)
-
-    @freeze_time("2025-03-10T12:00:00+00:00")
-    async def test_uses_override_slot_code(self, hass) -> None:
-        """Verify slot_code from override is displayed immediately in sync path."""
-        event = _make_event()
-        override = {
-            "slot_code": "5555",
-            "start_time": event.start,
-            "end_time": event.end,
-        }
-        overrides = MagicMock()
-        overrides.ready = True
-        overrides.get_slot_with_name.return_value = override
-        overrides.async_reserve_or_get_slot = AsyncMock(
-            return_value=ReserveResult(10, False, False)
-        )
-        overrides.overrides = {10: override}
-        coordinator = _make_coordinator(data=[event], event_overrides=overrides)
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
         sensor.async_write_ha_state = MagicMock()
 
         sensor._handle_coordinator_update()
 
-        # Code is available immediately from the sync read-only lookup
         assert sensor.extra_state_attributes["slot_code"] == "5555"
-
-        # Await the scheduled task to avoid unawaited coroutine warning
-        coro = sensor.hass.async_create_task.call_args[0][0]
-        await coro
 
     @freeze_time("2025-03-10T12:00:00+00:00")
     def test_generates_code_when_no_override(self, hass) -> None:
-        """Verify code is always generated synchronously in coordinator update."""
+        """Verify code is generated when event_overrides is None."""
         event = _make_event()
         coordinator = _make_coordinator(
             data=[event], event_overrides=None, code_generator="date_based"
@@ -1429,23 +1396,14 @@ class TestHandleCoordinatorUpdateOverrides:
         assert attrs["slot_code"].isdigit()
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    async def test_generates_code_when_override_has_no_code(self, hass) -> None:
-        """Verify code is generated when override exists but has no slot_code."""
+    def test_falls_back_to_generated_when_no_reconciliation_code(self, hass) -> None:
+        """Verify code is generated when reconciliation has no code for the event."""
         event = _make_event()
-        override = {
-            "slot_code": None,
-            "start_time": event.start,
-            "end_time": event.end,
-        }
-        overrides = MagicMock()
-        overrides.ready = True
-        overrides.get_slot_with_name.return_value = override
-        overrides.async_reserve_or_get_slot = AsyncMock(
-            return_value=ReserveResult(10, False, False)
-        )
-        overrides.overrides = {10: override}
         coordinator = _make_coordinator(
-            data=[event], event_overrides=overrides, code_generator="date_based"
+            data=[event],
+            event_overrides=MagicMock(),
+            code_generator="date_based",
+            slot_code=None,
         )
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
@@ -1453,93 +1411,13 @@ class TestHandleCoordinatorUpdateOverrides:
 
         sensor._handle_coordinator_update()
 
-        # Code is generated since override has no slot_code
         attrs = sensor.extra_state_attributes
         assert attrs["slot_code"] is not None
         assert attrs["slot_code"].isdigit()
 
-        # Await the scheduled task to avoid unawaited coroutine warning
-        coro = sensor.hass.async_create_task.call_args[0][0]
-        await coro
-
     @freeze_time("2025-03-10T12:00:00+00:00")
-    async def test_fires_update_times_when_dates_change(self, hass) -> None:
-        """Verify async_fire_update_times is called when times_updated is True."""
-        event = _make_event(
-            start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
-            end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
-        )
-        override = {
-            "slot_code": "1234",
-            "start_time": event.start,
-            "end_time": event.end,
-        }
-        overrides = MagicMock()
-        overrides.ready = True
-        overrides.get_slot_with_name.return_value = override
-        overrides.async_reserve_or_get_slot = AsyncMock(
-            return_value=ReserveResult(10, False, True)
-        )
-        overrides.overrides = {10: override}
-        coordinator = _make_coordinator(
-            data=[event],
-            event_overrides=overrides,
-            code_generator="static_random",
-        )
-        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
-        sensor.hass = MagicMock()
-        sensor.async_write_ha_state = MagicMock()
-
-        with patch(
-            "custom_components.rental_control.sensors.calsensor.async_fire_update_times",
-            new_callable=AsyncMock,
-        ) as mock_update_times:
-            sensor._handle_coordinator_update()
-            coro = sensor.hass.async_create_task.call_args[0][0]
-            await coro
-            mock_update_times.assert_called_once_with(coordinator, sensor, 10)
-
-    @freeze_time("2025-03-10T12:00:00+00:00")
-    async def test_fires_clear_code_on_date_shift_date_based(self, hass) -> None:
-        """Verify async_fire_clear_code is called on date shift with date_based generator."""
-        event = _make_event(
-            start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
-            end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
-        )
-        override = {
-            "slot_code": "1234",
-            "start_time": event.start,
-            "end_time": event.end,
-        }
-        overrides = MagicMock()
-        overrides.ready = True
-        overrides.get_slot_with_name.return_value = override
-        overrides.async_reserve_or_get_slot = AsyncMock(
-            return_value=ReserveResult(10, False, True)
-        )
-        overrides.overrides = {10: override}
-        coordinator = _make_coordinator(
-            data=[event],
-            event_overrides=overrides,
-            code_generator="date_based",
-            should_update_code=True,
-        )
-        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
-        sensor.hass = MagicMock()
-        sensor.async_write_ha_state = MagicMock()
-
-        with patch(
-            "custom_components.rental_control.sensors.calsensor.async_fire_clear_code",
-            new_callable=AsyncMock,
-        ) as mock_clear_code:
-            sensor._handle_coordinator_update()
-            coro = sensor.hass.async_create_task.call_args[0][0]
-            await coro
-            mock_clear_code.assert_called_once_with(coordinator, 10)
-
-    @freeze_time("2025-03-10T12:00:00+00:00")
-    def test_no_override_interactions_when_overrides_none(self, hass) -> None:
-        """Verify no set_code/update_times calls when event_overrides is None."""
+    def test_no_reconciliation_lookup_when_overrides_none(self, hass) -> None:
+        """Verify fingerprint/reconciliation lookup is skipped when no lock configured."""
         event = _make_event()
         coordinator = _make_coordinator(data=[event], event_overrides=None)
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
@@ -1547,154 +1425,44 @@ class TestHandleCoordinatorUpdateOverrides:
         sensor.async_write_ha_state = MagicMock()
 
         with patch(
-            "custom_components.rental_control.sensors.calsensor.async_fire_set_code",
-            new_callable=AsyncMock,
-        ) as mock_set_code:
+            "custom_components.rental_control.sensors.calsensor.make_reservation_fingerprint",
+        ) as mock_fingerprint:
             sensor._handle_coordinator_update()
-            mock_set_code.assert_not_called()
+            mock_fingerprint.assert_not_called()
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    async def test_no_set_code_when_existing_reservation(self, hass) -> None:
-        """Verify set_code is not called when reservation already has a slot."""
+    def test_slot_number_from_reconciliation(self, hass) -> None:
+        """Verify slot_number is read from coordinator reconciliation state."""
         event = _make_event()
-        override = {
-            "slot_code": "1234",
-            "start_time": event.start,
-            "end_time": event.end,
-        }
-        overrides = MagicMock()
-        overrides.ready = True
-        overrides.get_slot_with_name.return_value = override
-        overrides.async_reserve_or_get_slot = AsyncMock(
-            return_value=ReserveResult(10, False, False)
-        )
-        overrides.overrides = {10: override}
-        coordinator = _make_coordinator(data=[event], event_overrides=overrides)
-        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
-        sensor.hass = MagicMock()
-        sensor.async_write_ha_state = MagicMock()
-
-        with patch(
-            "custom_components.rental_control.sensors.calsensor.async_fire_set_code",
-            new_callable=AsyncMock,
-        ) as mock_set_code:
-            sensor._handle_coordinator_update()
-            coro = sensor.hass.async_create_task.call_args[0][0]
-            await coro
-            mock_set_code.assert_not_called()
-
-    @freeze_time("2025-03-15T12:00:00+00:00")
-    async def test_updates_times_not_clear_when_eta_days_zero(self, hass) -> None:
-        """Verify update_times (not clear_code) is called when eta_days is 0.
-
-        When event starts today (eta_days=0), the clear_code branch requires
-        eta_days > 0. With eta_days=0 the condition is false, so update_times
-        is called instead.
-        """
-        event = _make_event(
-            start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
-            end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
-        )
-        override = {
-            "slot_code": "1234",
-            "start_time": event.start,
-            "end_time": event.end,
-        }
-        overrides = MagicMock()
-        overrides.ready = True
-        overrides.get_slot_with_name.return_value = override
-        overrides.async_reserve_or_get_slot = AsyncMock(
-            return_value=ReserveResult(10, False, True)
-        )
-        overrides.overrides = {10: override}
         coordinator = _make_coordinator(
             data=[event],
-            event_overrides=overrides,
-            code_generator="date_based",
-            should_update_code=True,
+            event_overrides=MagicMock(),
+            slot_assignment=12,
         )
-        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
-        sensor.hass = MagicMock()
-        sensor.async_write_ha_state = MagicMock()
-
-        with (
-            patch(
-                "custom_components.rental_control.sensors.calsensor.async_fire_clear_code",
-                new_callable=AsyncMock,
-            ) as mock_clear_code,
-            patch(
-                "custom_components.rental_control.sensors.calsensor.async_fire_update_times",
-                new_callable=AsyncMock,
-            ) as mock_update_times,
-        ):
-            sensor._handle_coordinator_update()
-            coro = sensor.hass.async_create_task.call_args[0][0]
-            await coro
-            mock_clear_code.assert_not_called()
-            mock_update_times.assert_called_once_with(coordinator, sensor, 10)
-
-    @freeze_time("2025-03-10T12:00:00+00:00")
-    async def test_slot_number_set_on_assignment(self, hass) -> None:
-        """Verify slot_number is exposed after slot assignment."""
-        event = _make_event()
-        override = {
-            "slot_code": "4321",
-            "start_time": event.start,
-            "end_time": event.end,
-        }
-        overrides = MagicMock()
-        overrides.ready = True
-        overrides.get_slot_with_name.return_value = override
-        overrides.get_slot_key_by_name.return_value = 12
-        overrides.async_reserve_or_get_slot = AsyncMock(
-            return_value=ReserveResult(12, False, False)
-        )
-        overrides.overrides = {12: override}
-        coordinator = _make_coordinator(data=[event], event_overrides=overrides)
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
         sensor.async_write_ha_state = MagicMock()
 
         sensor._handle_coordinator_update()
 
-        # Sync path sets slot_number from read-only lookup
-        assert sensor.extra_state_attributes["slot_number"] == 12
-
-        # Async path also sets slot_number from result.slot
-        coro = sensor.hass.async_create_task.call_args[0][0]
-        await coro
         assert sensor.extra_state_attributes["slot_number"] == 12
 
     @freeze_time("2025-03-10T12:00:00+00:00")
-    async def test_slot_number_set_after_new_assignment(self, hass) -> None:
-        """Verify slot_number is populated after a new slot assignment."""
+    def test_slot_number_none_when_not_assigned(self, hass) -> None:
+        """Verify slot_number is None when reconciliation has no assignment."""
         event = _make_event()
-        overrides = MagicMock()
-        overrides.ready = True
-        overrides.get_slot_with_name.return_value = None
-        overrides.get_slot_key_by_name.return_value = 0
-        overrides.async_reserve_or_get_slot = AsyncMock(
-            return_value=ReserveResult(10, True, False)
+        coordinator = _make_coordinator(
+            data=[event],
+            event_overrides=MagicMock(),
+            slot_assignment=None,
         )
-        coordinator = _make_coordinator(data=[event], event_overrides=overrides)
         sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
         sensor.hass = MagicMock()
         sensor.async_write_ha_state = MagicMock()
 
-        with patch(
-            "custom_components.rental_control.sensors.calsensor.async_fire_set_code",
-            new_callable=AsyncMock,
-        ):
-            sensor._handle_coordinator_update()
+        sensor._handle_coordinator_update()
 
-            # Sync path: get_slot_key_by_name returned 0, so None
-            assert sensor.extra_state_attributes["slot_number"] is None
-
-            coro = sensor.hass.async_create_task.call_args[0][0]
-            await coro
-
-            # Async path sets slot_number from result.slot
-            assert sensor.extra_state_attributes["slot_number"] == 10
+        assert sensor.extra_state_attributes["slot_number"] is None
 
     def test_slot_number_cleared_when_no_events(self, hass) -> None:
         """Verify slot_number is reset to None when no events."""
@@ -1707,3 +1475,512 @@ class TestHandleCoordinatorUpdateOverrides:
         sensor._handle_coordinator_update()
 
         assert sensor.extra_state_attributes["slot_number"] is None
+
+
+# ---------------------------------------------------------------------------
+# T099: Sensor read-only — prove slot-mutation functions are never called
+# ---------------------------------------------------------------------------
+
+
+class TestSensorReadOnly:
+    """T099: Prove _handle_coordinator_update never calls slot-mutation helpers.
+
+    After the reconciliation transition the sensor is purely read-only.
+    These tests act as regression guards: if any side-effect helper is
+    accidentally re-introduced in _handle_coordinator_update they will fail.
+    """
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_does_not_call_async_reserve_or_get_slot(self, hass) -> None:
+        """Verify async_reserve_or_get_slot is never called during update."""
+        event = _make_event()
+        overrides = MagicMock()
+        overrides.ready = True
+        coordinator = _make_coordinator(data=[event], event_overrides=overrides)
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        overrides.async_reserve_or_get_slot.assert_not_called()
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_does_not_call_async_fire_set_code(self, hass) -> None:
+        """Verify async_fire_set_code is never called during coordinator update."""
+        event = _make_event()
+        coordinator = _make_coordinator(
+            data=[event],
+            event_overrides=MagicMock(),
+            slot_assignment=None,
+        )
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        with patch(
+            "custom_components.rental_control.sensors.calsensor.async_fire_set_code",
+            create=True,
+        ) as mock_set_code:
+            sensor._handle_coordinator_update()
+            mock_set_code.assert_not_called()
+        # No async task should be scheduled either
+        sensor.hass.async_create_task.assert_not_called()
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_does_not_call_async_fire_clear_code(self, hass) -> None:
+        """Verify async_fire_clear_code is never called during coordinator update."""
+        event = _make_event()
+        coordinator = _make_coordinator(
+            data=[event],
+            event_overrides=MagicMock(),
+            slot_assignment=5,
+        )
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        with patch(
+            "custom_components.rental_control.sensors.calsensor.async_fire_clear_code",
+            create=True,
+        ) as mock_clear_code:
+            sensor._handle_coordinator_update()
+            mock_clear_code.assert_not_called()
+        sensor.hass.async_create_task.assert_not_called()
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_does_not_call_async_fire_update_times(self, hass) -> None:
+        """Verify async_fire_update_times is never called during coordinator update."""
+        event = _make_event()
+        coordinator = _make_coordinator(
+            data=[event],
+            event_overrides=MagicMock(),
+            slot_assignment=5,
+        )
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        with patch(
+            "custom_components.rental_control.sensors.calsensor.async_fire_update_times",
+            create=True,
+        ) as mock_update_times:
+            sensor._handle_coordinator_update()
+            mock_update_times.assert_not_called()
+        sensor.hass.async_create_task.assert_not_called()
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_no_async_task_scheduled(self, hass) -> None:
+        """Verify _handle_coordinator_update never schedules an async task."""
+        event = _make_event()
+        overrides = MagicMock()
+        overrides.ready = True
+        coordinator = _make_coordinator(
+            data=[event],
+            event_overrides=overrides,
+            slot_assignment=7,
+            slot_code="1234",
+        )
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        sensor.hass.async_create_task.assert_not_called()
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_no_async_task_when_overrides_none(self, hass) -> None:
+        """Verify no async task is scheduled even when event_overrides is None."""
+        event = _make_event()
+        coordinator = _make_coordinator(data=[event], event_overrides=None)
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        sensor.hass.async_create_task.assert_not_called()
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    async def test_async_handle_slot_assignment_is_noop(self, hass) -> None:
+        """Verify _async_handle_slot_assignment is a harmless no-op."""
+        coordinator = _make_coordinator(data=[], event_overrides=MagicMock())
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+
+        await sensor._async_handle_slot_assignment(
+            slot_name="test",
+            slot_code="1234",
+            start_time=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
+            end_time=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
+            uid=None,
+            prefix="",
+            eta_days=5,
+        )
+        coordinator.event_overrides.async_reserve_or_get_slot.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# T100: event_N attribute regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventNAttributeRegression:
+    """T100: Regression tests for all public event_N sensor attributes.
+
+    Ensures slot_number, slot_code, summary, start, end, ETA, UID,
+    slot_name, and no-reservation state are correctly populated after the
+    read-only reconciliation transition.
+    """
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_summary_attribute(self, hass) -> None:
+        """Verify summary attribute is populated from the event."""
+        event = _make_event(summary="Reserved - Jane Smith")
+        coordinator = _make_coordinator(data=[event])
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        assert sensor.extra_state_attributes["summary"] == "Reserved - Jane Smith"
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_start_and_end_attributes(self, hass) -> None:
+        """Verify start and end attributes are populated from the event."""
+        start = datetime(2025, 4, 1, 15, 0, tzinfo=timezone.utc)
+        end = datetime(2025, 4, 7, 11, 0, tzinfo=timezone.utc)
+        event = _make_event(start=start, end=end)
+        coordinator = _make_coordinator(data=[event])
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["start"] == start
+        assert attrs["end"] == end
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_eta_attributes_populated(self, hass) -> None:
+        """Verify eta_days, eta_hours, and eta_minutes are populated for future events."""
+        start = datetime(2025, 3, 15, 12, 0, tzinfo=timezone.utc)  # 5 days ahead
+        end = datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc)
+        event = _make_event(start=start, end=end)
+        coordinator = _make_coordinator(data=[event])
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["eta_days"] == 5
+        assert attrs["eta_hours"] is not None
+        assert attrs["eta_minutes"] is not None
+
+    @freeze_time("2025-03-20T12:00:00+00:00")
+    def test_eta_attributes_none_for_past_events(self, hass) -> None:
+        """Verify ETA attributes are None for past events."""
+        start = datetime(2025, 3, 15, 12, 0, tzinfo=timezone.utc)
+        end = datetime(2025, 3, 18, 11, 0, tzinfo=timezone.utc)
+        event = _make_event(start=start, end=end)
+        coordinator = _make_coordinator(data=[event])
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["eta_days"] is None
+        assert attrs["eta_hours"] is None
+        assert attrs["eta_minutes"] is None
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_uid_attribute(self, hass) -> None:
+        """Verify uid attribute is populated from the event."""
+        event = _make_event(uid="test-reservation-uid-42")
+        coordinator = _make_coordinator(data=[event])
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        assert sensor.extra_state_attributes["uid"] == "test-reservation-uid-42"
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_uid_none_when_event_has_no_uid(self, hass) -> None:
+        """Verify uid attribute is None when the event has no UID."""
+        event = _make_event(uid=None)
+        coordinator = _make_coordinator(data=[event])
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        assert sensor.extra_state_attributes["uid"] is None
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_slot_name_attribute(self, hass) -> None:
+        """Verify slot_name attribute is populated via get_slot_name."""
+        event = _make_event(summary="Reserved - Alice Wonder")
+        coordinator = _make_coordinator(data=[event])
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        with patch(
+            "custom_components.rental_control.sensors.calsensor.get_slot_name",
+            return_value="Alice Wonder",
+        ):
+            sensor._handle_coordinator_update()
+
+        assert sensor.extra_state_attributes["slot_name"] == "Alice Wonder"
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_slot_number_from_reconciliation_state(self, hass) -> None:
+        """Verify slot_number is read synchronously from reconciliation state."""
+        event = _make_event()
+        coordinator = _make_coordinator(
+            data=[event],
+            event_overrides=MagicMock(),
+            slot_assignment=9,
+        )
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        # slot_number is set synchronously — no async task needed
+        assert sensor.extra_state_attributes["slot_number"] == 9
+        sensor.hass.async_create_task.assert_not_called()
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_slot_code_from_reconciliation_state(self, hass) -> None:
+        """Verify slot_code is read synchronously from reconciliation state."""
+        event = _make_event()
+        coordinator = _make_coordinator(
+            data=[event],
+            event_overrides=MagicMock(),
+            slot_code="9876",
+        )
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        assert sensor.extra_state_attributes["slot_code"] == "9876"
+        sensor.hass.async_create_task.assert_not_called()
+
+    def test_no_reservation_state(self, hass) -> None:
+        """Verify no-reservation state resets all event_N attributes correctly."""
+        coordinator = _make_coordinator(data=[], event_prefix="")
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["summary"] == "No reservation"
+        assert attrs["start"] is None
+        assert attrs["end"] is None
+        assert attrs["uid"] is None
+        assert attrs["eta_days"] is None
+        assert attrs["eta_hours"] is None
+        assert attrs["eta_minutes"] is None
+        assert attrs["slot_name"] is None
+        assert attrs["slot_code"] is None
+        assert attrs["slot_number"] is None
+        assert sensor.state == "No reservation"
+
+    def test_no_reservation_state_with_prefix(self, hass) -> None:
+        """Verify no-reservation state includes event prefix when configured."""
+        coordinator = _make_coordinator(data=[], event_prefix="MyPlace")
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["summary"] == "MyPlace No reservation"
+        assert sensor.state == "MyPlace No reservation"
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_slot_number_cleared_when_no_events(self, hass) -> None:
+        """Verify slot_number is reset to None when event list is empty."""
+        coordinator = _make_coordinator(data=[])
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor._event_attributes["slot_number"] = 7
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        assert sensor.extra_state_attributes["slot_number"] is None
+
+    @freeze_time("2025-03-10T12:00:00+00:00")
+    def test_identity_key_uses_coordinator_entry_id(self, hass) -> None:
+        """Verify reconciliation lookup uses coordinator.entry_id for fingerprinting."""
+        event = _make_event()
+        overrides = MagicMock()
+        coordinator = _make_coordinator(
+            data=[event],
+            event_overrides=overrides,
+            entry_id="specific-entry-id",
+        )
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", 0)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+
+        with patch(
+            "custom_components.rental_control.sensors.calsensor.make_reservation_fingerprint",
+            return_value="fake-key",
+        ) as mock_fp:
+            sensor._handle_coordinator_update()
+
+        # entry_id is always the first arg to make_reservation_fingerprint
+        args = mock_fp.call_args[0]
+        assert args[0] == "specific-entry-id"
+
+
+class TestCodeRegenerationRegression:
+    """T104 regression: Code generation semantics preserved.
+
+    Pins date-based code shift, static-random stability, and
+    date-based fallback when no description is available.
+    """
+
+    def setup_method(self) -> None:
+        """Save RNG state before each test."""
+        self._rng_state = random.getstate()
+
+    def teardown_method(self) -> None:
+        """Restore RNG state after each test."""
+        random.setstate(self._rng_state)
+
+    @staticmethod
+    def _make_sensor(
+        hass,
+        *,
+        code_generator: str,
+        start: datetime,
+        end: datetime,
+        uid: str | None,
+        description: str | None,
+        event_number: int = 0,
+    ) -> RentalControlCalSensor:
+        """Build a sensor with event attributes primed for code generation."""
+        coordinator = _make_coordinator(
+            code_generator=code_generator,
+            code_length=4,
+        )
+        sensor = RentalControlCalSensor(hass, coordinator, f"{NAME} Test", event_number)
+        sensor._event_attributes["start"] = start
+        sensor._event_attributes["end"] = end
+        sensor._event_attributes["uid"] = uid
+        sensor._event_attributes["description"] = description
+        return sensor
+
+    def test_date_based_code_shifts_when_dates_change(self, hass) -> None:
+        """Date-based codes change when reservation dates shift."""
+        sensor_a = self._make_sensor(
+            hass,
+            code_generator="date_based",
+            start=datetime(2025, 1, 15, 16, 0, tzinfo=timezone.utc),
+            end=datetime(2025, 1, 17, 11, 0, tzinfo=timezone.utc),
+            uid="date-a",
+            description="Reservation A",
+        )
+        sensor_b = self._make_sensor(
+            hass,
+            code_generator="date_based",
+            start=datetime(2025, 1, 16, 16, 0, tzinfo=timezone.utc),
+            end=datetime(2025, 1, 18, 11, 0, tzinfo=timezone.utc),
+            uid="date-b",
+            description="Reservation B",
+            event_number=1,
+        )
+
+        assert sensor_a._generate_door_code() != sensor_b._generate_door_code()
+
+    def test_date_based_code_stable_when_dates_unchanged(self, hass) -> None:
+        """Date-based codes stay stable when dates do not change."""
+        sensor_a = self._make_sensor(
+            hass,
+            code_generator="date_based",
+            start=datetime(2025, 1, 15, 16, 0, tzinfo=timezone.utc),
+            end=datetime(2025, 1, 17, 11, 0, tzinfo=timezone.utc),
+            uid="same-a",
+            description="Reservation A",
+        )
+        sensor_b = self._make_sensor(
+            hass,
+            code_generator="date_based",
+            start=datetime(2025, 1, 15, 16, 0, tzinfo=timezone.utc),
+            end=datetime(2025, 1, 17, 11, 0, tzinfo=timezone.utc),
+            uid="same-b",
+            description="Reservation B",
+            event_number=1,
+        )
+
+        assert sensor_a._generate_door_code() == sensor_b._generate_door_code()
+
+    def test_static_random_code_stable_across_refreshes(self, hass) -> None:
+        """Static-random codes are deterministic for the same UID."""
+        sensor = self._make_sensor(
+            hass,
+            code_generator="static_random",
+            start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
+            end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
+            uid="stable-uid",
+            description="Original description",
+        )
+
+        first = sensor._generate_door_code()
+        second = sensor._generate_door_code()
+
+        assert first == second
+
+    def test_static_random_uid_beats_description_for_stability(self, hass) -> None:
+        """UID stability wins even when descriptions change across refreshes."""
+        sensor_a = self._make_sensor(
+            hass,
+            code_generator="static_random",
+            start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
+            end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
+            uid="shared-uid",
+            description="Guest: Alice",
+        )
+        sensor_b = self._make_sensor(
+            hass,
+            code_generator="static_random",
+            start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
+            end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
+            uid="shared-uid",
+            description="Guest: Alice - updated note",
+            event_number=1,
+        )
+
+        assert sensor_a._generate_door_code() == sensor_b._generate_door_code()
+
+    def test_date_based_fallback_when_description_none(self, hass) -> None:
+        """Missing description and UID force date-based generation."""
+        sensor = self._make_sensor(
+            hass,
+            code_generator="static_random",
+            start=datetime(2025, 3, 15, 16, 0, tzinfo=timezone.utc),
+            end=datetime(2025, 3, 20, 11, 0, tzinfo=timezone.utc),
+            uid=None,
+            description=None,
+        )
+
+        assert sensor._generate_door_code() == "1520"

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -1,0 +1,4272 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Unit tests for the reconciliation data models (T007) and identity helpers
+(T008, T079-T082).
+
+Covers construction, default values, and the model-layer validation
+invariants described in specs/012-slot-reconciliation/data-model.md
+for the following types:
+
+- :class:`~custom_components.rental_control.reconciliation.SlotStatus`
+- :class:`~custom_components.rental_control.reconciliation.ActionKind`
+- :class:`~custom_components.rental_control.reconciliation.SlotAction`
+- :class:`~custom_components.rental_control.reconciliation.Reservation`
+- :class:`~custom_components.rental_control.reconciliation.ManagedSlot`
+- :class:`~custom_components.rental_control.reconciliation.PlannedSlot`
+- :class:`~custom_components.rental_control.reconciliation.DesiredPlan`
+- :class:`~custom_components.rental_control.reconciliation.StoredIdentity`
+- :class:`~custom_components.rental_control.reconciliation.StoredActual`
+- :class:`~custom_components.rental_control.reconciliation.SlotMapping`
+
+And the identity fingerprinting / rematch helpers:
+
+- :func:`~custom_components.rental_control.reconciliation.normalize_slot_name_for_fingerprint`
+- :func:`~custom_components.rental_control.reconciliation.make_reservation_fingerprint`
+- :func:`~custom_components.rental_control.reconciliation.extract_booking_aliases`
+- :class:`~custom_components.rental_control.reconciliation.RematchKind`
+- :class:`~custom_components.rental_control.reconciliation.RematchResult`
+- :func:`~custom_components.rental_control.reconciliation.find_reservation_rematch`
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+import pytest
+
+from custom_components.rental_control.reconciliation import FINGERPRINT_VERSION
+from custom_components.rental_control.reconciliation import ActionKind
+from custom_components.rental_control.reconciliation import DesiredPlan
+from custom_components.rental_control.reconciliation import ManagedSlot
+from custom_components.rental_control.reconciliation import PlannedSlot
+from custom_components.rental_control.reconciliation import RematchKind
+from custom_components.rental_control.reconciliation import RematchResult
+from custom_components.rental_control.reconciliation import Reservation
+from custom_components.rental_control.reconciliation import SlotAction
+from custom_components.rental_control.reconciliation import SlotMapping
+from custom_components.rental_control.reconciliation import SlotStatus
+from custom_components.rental_control.reconciliation import StoredActual
+from custom_components.rental_control.reconciliation import StoredIdentity
+from custom_components.rental_control.reconciliation import compute_desired_plan
+from custom_components.rental_control.reconciliation import extract_booking_aliases
+from custom_components.rental_control.reconciliation import find_reservation_rematch
+from custom_components.rental_control.reconciliation import make_reservation_fingerprint
+from custom_components.rental_control.reconciliation import (
+    normalize_slot_name_for_fingerprint,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TZ = timezone.utc
+
+
+def _dt(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    """Return a UTC-aware datetime for test convenience."""
+    return datetime(year, month, day, hour, tzinfo=_TZ)
+
+
+def _make_reservation(
+    *,
+    identity_key: str = "key-abc",
+    start: datetime | None = None,
+    end: datetime | None = None,
+    missing_count: int = 0,
+) -> Reservation:
+    """Return a minimal valid Reservation for use in tests."""
+    return Reservation(
+        identity_key=identity_key,
+        start=start or _dt(2026, 7, 1),
+        end=end or _dt(2026, 7, 8),
+        buffered_start=_dt(2026, 7, 1),
+        buffered_end=_dt(2026, 7, 8),
+        summary="Test Guest",
+        slot_name="Test Guest",
+        display_slot_name="RC Test Guest",
+        slot_code="1234",
+        missing_count=missing_count,
+    )
+
+
+def _make_stored_identity(
+    *,
+    identity_key: str = "key-abc",
+) -> StoredIdentity:
+    """Return a minimal valid StoredIdentity for use in tests."""
+    return StoredIdentity(
+        identity_key=identity_key,
+        summary="Test Guest",
+        slot_name="Test Guest",
+    )
+
+
+def _make_stored_actual(*, slot: int = 5) -> StoredActual:
+    """Return a minimal valid StoredActual for use in tests."""
+    return StoredActual(slot=slot, classification="free")
+
+
+def _make_slot_mapping(
+    *,
+    identity_key: str = "key-abc",
+    slot: int = 5,
+    schema_version: int = 1,
+    missing_count: int = 0,
+) -> SlotMapping:
+    """Return a minimal valid SlotMapping for use in tests."""
+    return SlotMapping(
+        schema_version=schema_version,
+        entry_id="entry-001",
+        identity_key=identity_key,
+        slot=slot,
+        status="occupied",
+        identity=_make_stored_identity(identity_key=identity_key),
+        last_observed_actual=_make_stored_actual(slot=slot),
+        updated_at=_dt(2026, 6, 19),
+        missing_count=missing_count,
+    )
+
+
+def _make_desired_plan(
+    *,
+    plan_id: str = "plan-001",
+    selected: dict[str, int] | None = None,
+) -> DesiredPlan:
+    """Return a minimal valid DesiredPlan for use in tests."""
+    return DesiredPlan(
+        plan_id=plan_id,
+        generated_at=_dt(2026, 6, 19),
+        selected=selected or {},
+    )
+
+
+def _make_managed_slot(
+    *,
+    slot: int = 5,
+    managed: bool = True,
+    status: SlotStatus = SlotStatus.FREE,
+    persisted_identity_key: str | None = None,
+    actual_start: datetime | None = None,
+    actual_end: datetime | None = None,
+    blocked_reason: str | None = None,
+) -> ManagedSlot:
+    """Return a minimal valid ManagedSlot for use in tests."""
+    return ManagedSlot(
+        slot=slot,
+        managed=managed,
+        status=status,
+        persisted_identity_key=persisted_identity_key,
+        actual_start=actual_start,
+        actual_end=actual_end,
+        blocked_reason=blocked_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SlotStatus
+# ---------------------------------------------------------------------------
+
+
+class TestSlotStatus:
+    """Tests for the SlotStatus enumeration."""
+
+    def test_all_expected_values_exist(self) -> None:
+        """All six slot-status values defined in the data model are present."""
+        expected = {
+            "free",
+            "occupied",
+            "pending_clear",
+            "blocked",
+            "phantom",
+            "unknown",
+        }
+        actual = {s.value for s in SlotStatus}
+        assert actual == expected
+
+    def test_value_is_string(self) -> None:
+        """SlotStatus values are plain strings (str, Enum subclass)."""
+        assert isinstance(SlotStatus.FREE, str)
+        assert SlotStatus.FREE == "free"
+
+    def test_free(self) -> None:
+        """SlotStatus.FREE has value 'free'."""
+        assert SlotStatus.FREE.value == "free"
+
+    def test_occupied(self) -> None:
+        """SlotStatus.OCCUPIED has value 'occupied'."""
+        assert SlotStatus.OCCUPIED.value == "occupied"
+
+    def test_pending_clear(self) -> None:
+        """SlotStatus.PENDING_CLEAR has value 'pending_clear'."""
+        assert SlotStatus.PENDING_CLEAR.value == "pending_clear"
+
+    def test_blocked(self) -> None:
+        """SlotStatus.BLOCKED has value 'blocked'."""
+        assert SlotStatus.BLOCKED.value == "blocked"
+
+    def test_phantom(self) -> None:
+        """SlotStatus.PHANTOM has value 'phantom'."""
+        assert SlotStatus.PHANTOM.value == "phantom"
+
+    def test_unknown(self) -> None:
+        """SlotStatus.UNKNOWN has value 'unknown'."""
+        assert SlotStatus.UNKNOWN.value == "unknown"
+
+    def test_roundtrip_from_string(self) -> None:
+        """SlotStatus can be round-tripped from its string value."""
+        assert SlotStatus("occupied") is SlotStatus.OCCUPIED
+
+    def test_member_count(self) -> None:
+        """SlotStatus contains exactly six members."""
+        assert len(SlotStatus) == 6
+
+
+# ---------------------------------------------------------------------------
+# ActionKind
+# ---------------------------------------------------------------------------
+
+
+class TestActionKind:
+    """Tests for the ActionKind enumeration."""
+
+    def test_all_expected_values_exist(self) -> None:
+        """All seven action-kind values defined in the data model are present."""
+        expected = {
+            "noop",
+            "set",
+            "update_times",
+            "clear",
+            "retry_clear",
+            "overwrite_manual_change",
+            "blocked",
+        }
+        actual = {a.value for a in ActionKind}
+        assert actual == expected
+
+    def test_value_is_string(self) -> None:
+        """ActionKind values are plain strings (str, Enum subclass)."""
+        assert isinstance(ActionKind.NOOP, str)
+        assert ActionKind.NOOP == "noop"
+
+    def test_noop(self) -> None:
+        """ActionKind.NOOP has value 'noop'."""
+        assert ActionKind.NOOP.value == "noop"
+
+    def test_set(self) -> None:
+        """ActionKind.SET has value 'set'."""
+        assert ActionKind.SET.value == "set"
+
+    def test_update_times(self) -> None:
+        """ActionKind.UPDATE_TIMES has value 'update_times'."""
+        assert ActionKind.UPDATE_TIMES.value == "update_times"
+
+    def test_clear(self) -> None:
+        """ActionKind.CLEAR has value 'clear'."""
+        assert ActionKind.CLEAR.value == "clear"
+
+    def test_retry_clear(self) -> None:
+        """ActionKind.RETRY_CLEAR has value 'retry_clear'."""
+        assert ActionKind.RETRY_CLEAR.value == "retry_clear"
+
+    def test_overwrite_manual_change(self) -> None:
+        """ActionKind.OVERWRITE_MANUAL_CHANGE has value 'overwrite_manual_change'."""
+        assert ActionKind.OVERWRITE_MANUAL_CHANGE.value == "overwrite_manual_change"
+
+    def test_blocked(self) -> None:
+        """ActionKind.BLOCKED has value 'blocked'."""
+        assert ActionKind.BLOCKED.value == "blocked"
+
+    def test_roundtrip_from_string(self) -> None:
+        """ActionKind can be round-tripped from its string value."""
+        assert ActionKind("clear") is ActionKind.CLEAR
+
+    def test_member_count(self) -> None:
+        """ActionKind contains exactly seven members."""
+        assert len(ActionKind) == 7
+
+
+# ---------------------------------------------------------------------------
+# SlotAction
+# ---------------------------------------------------------------------------
+
+
+class TestSlotAction:
+    """Tests for the SlotAction dataclass."""
+
+    def test_minimal_construction(self) -> None:
+        """SlotAction can be constructed with only required fields."""
+        action = SlotAction(kind=ActionKind.SET, slot=5)
+        assert action.kind is ActionKind.SET
+        assert action.slot == 5
+        assert action.identity_key is None
+        assert action.reason is None
+
+    def test_full_construction(self) -> None:
+        """SlotAction stores all provided optional fields."""
+        action = SlotAction(
+            kind=ActionKind.CLEAR,
+            slot=3,
+            identity_key="key-xyz",
+            reason="reservation expired",
+        )
+        assert action.kind is ActionKind.CLEAR
+        assert action.slot == 3
+        assert action.identity_key == "key-xyz"
+        assert action.reason == "reservation expired"
+
+    def test_noop_action(self) -> None:
+        """A NOOP SlotAction carries no identity or reason."""
+        action = SlotAction(kind=ActionKind.NOOP, slot=7)
+        assert action.kind is ActionKind.NOOP
+        assert action.identity_key is None
+
+    def test_blocked_action_with_reason(self) -> None:
+        """A BLOCKED SlotAction accepts a reason string."""
+        action = SlotAction(
+            kind=ActionKind.BLOCKED,
+            slot=2,
+            reason="pending_clear unconfirmed",
+        )
+        assert action.kind is ActionKind.BLOCKED
+        assert action.reason == "pending_clear unconfirmed"
+
+    def test_slot_code_not_in_repr(self) -> None:
+        """SlotAction repr does not expose sensitive slot_code data."""
+        # SlotAction itself has no slot_code; verify repr is deterministic.
+        action = SlotAction(kind=ActionKind.SET, slot=5, identity_key="k")
+        text = repr(action)
+        assert "SlotAction" in text
+        assert "5" in text
+
+
+# ---------------------------------------------------------------------------
+# Reservation
+# ---------------------------------------------------------------------------
+
+
+class TestReservation:
+    """Tests for the Reservation dataclass construction and validation."""
+
+    def test_minimal_valid_construction(self) -> None:
+        """Reservation accepts all required fields with valid start < end."""
+        r = _make_reservation()
+        assert r.identity_key == "key-abc"
+        assert r.start < r.end
+
+    def test_defaults_for_optional_fields(self) -> None:
+        """Optional Reservation fields default to documented zero-values."""
+        r = _make_reservation()
+        assert r.uid_aliases == set()
+        assert r.booking_aliases == set()
+        assert r.fingerprint_history == set()
+        assert r.eligible is True
+        assert r.protected_active is False
+        assert r.checked_out is False
+        assert r.missing_count == 0
+        assert r.desired_slot is None
+        assert r.overflow_reason is None
+
+    def test_start_equal_end_raises(self) -> None:
+        """Reservation raises ValueError when start equals end."""
+        ts = _dt(2026, 7, 1)
+        with pytest.raises(ValueError, match="start must be strictly before end"):
+            _make_reservation(start=ts, end=ts)
+
+    def test_start_after_end_raises(self) -> None:
+        """Reservation raises ValueError when start is after end."""
+        with pytest.raises(ValueError, match="start must be strictly before end"):
+            _make_reservation(start=_dt(2026, 7, 8), end=_dt(2026, 7, 1))
+
+    def test_negative_missing_count_raises(self) -> None:
+        """Reservation raises ValueError when missing_count is negative."""
+        with pytest.raises(ValueError, match="missing_count must be non-negative"):
+            _make_reservation(missing_count=-1)
+
+    def test_zero_missing_count_is_valid(self) -> None:
+        """Reservation accepts missing_count of zero."""
+        r = _make_reservation(missing_count=0)
+        assert r.missing_count == 0
+
+    def test_missing_count_threshold_values(self) -> None:
+        """Reservation accepts missing_count of 0, 1, 2, and 3."""
+        for count in (0, 1, 2, 3):
+            r = _make_reservation(missing_count=count)
+            assert r.missing_count == count
+
+    def test_slot_code_excluded_from_repr(self) -> None:
+        """slot_code does not appear in Reservation repr output."""
+        r = _make_reservation()
+        r_repr = repr(r)
+        assert "1234" not in r_repr
+
+    def test_uid_aliases_mutable_set(self) -> None:
+        """uid_aliases is an independent mutable set per instance."""
+        r1 = _make_reservation(identity_key="k1")
+        r2 = _make_reservation(identity_key="k2")
+        r1.uid_aliases.add("uid-1")
+        assert "uid-1" not in r2.uid_aliases
+
+    def test_booking_aliases_mutable_set(self) -> None:
+        """booking_aliases is an independent mutable set per instance."""
+        r1 = _make_reservation(identity_key="k1")
+        r2 = _make_reservation(identity_key="k2")
+        r1.booking_aliases.add("BOOK-123")
+        assert "BOOK-123" not in r2.booking_aliases
+
+    def test_fingerprint_history_mutable_set(self) -> None:
+        """fingerprint_history is an independent mutable set per instance."""
+        r1 = _make_reservation(identity_key="k1")
+        r2 = _make_reservation(identity_key="k2")
+        r1.fingerprint_history.add("old-fp")
+        assert "old-fp" not in r2.fingerprint_history
+
+    def test_desired_slot_can_be_set(self) -> None:
+        """desired_slot can be assigned after construction."""
+        r = _make_reservation()
+        r.desired_slot = 4
+        assert r.desired_slot == 4
+
+    def test_overflow_reason_can_be_set(self) -> None:
+        """overflow_reason can be assigned after construction."""
+        r = _make_reservation()
+        r.overflow_reason = "capacity"
+        assert r.overflow_reason == "capacity"
+
+    def test_protected_active_flag(self) -> None:
+        """protected_active can be set to True to mark a checked-in guest."""
+        r = _make_reservation()
+        r.protected_active = True
+        assert r.protected_active is True
+
+
+# ---------------------------------------------------------------------------
+# ManagedSlot
+# ---------------------------------------------------------------------------
+
+
+class TestManagedSlot:
+    """Tests for the ManagedSlot dataclass."""
+
+    def test_minimal_construction(self) -> None:
+        """ManagedSlot can be constructed with slot and managed flag."""
+        ms = ManagedSlot(slot=5, managed=True)
+        assert ms.slot == 5
+        assert ms.managed is True
+
+    def test_default_status_is_unknown(self) -> None:
+        """ManagedSlot.status defaults to SlotStatus.UNKNOWN."""
+        ms = ManagedSlot(slot=5, managed=True)
+        assert ms.status is SlotStatus.UNKNOWN
+
+    def test_defaults_for_all_optional_fields(self) -> None:
+        """All optional ManagedSlot fields default to documented values."""
+        ms = ManagedSlot(slot=3, managed=True)
+        assert ms.actual_name is None
+        assert ms.actual_code_present is None
+        assert ms.actual_start is None
+        assert ms.actual_end is None
+        assert ms.date_range_enabled is None
+        assert ms.enabled is None
+        assert ms.desired_identity_key is None
+        assert ms.persisted_identity_key is None
+        assert ms.blocked_reason is None
+        assert ms.retry_count == 0
+        assert ms.last_operation_id is None
+        assert ms.dirty_during_operation is False
+
+    def test_unmanaged_slot(self) -> None:
+        """ManagedSlot correctly represents an unmanaged slot."""
+        ms = ManagedSlot(slot=1, managed=False)
+        assert ms.managed is False
+
+    def test_status_can_transition(self) -> None:
+        """ManagedSlot.status can be reassigned to reflect transitions."""
+        ms = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+        ms.status = SlotStatus.OCCUPIED
+        assert ms.status is SlotStatus.OCCUPIED
+
+    def test_blocked_slot_stores_reason(self) -> None:
+        """BLOCKED ManagedSlot stores a human-readable blocked_reason."""
+        ms = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.BLOCKED,
+            blocked_reason="clear failed after 3 retries",
+        )
+        assert ms.status is SlotStatus.BLOCKED
+        assert ms.blocked_reason == "clear failed after 3 retries"
+
+    def test_dirty_during_operation_flag(self) -> None:
+        """dirty_during_operation can be set True when callback fires."""
+        ms = ManagedSlot(slot=5, managed=True)
+        ms.dirty_during_operation = True
+        assert ms.dirty_during_operation is True
+
+    def test_retry_count_can_be_incremented(self) -> None:
+        """retry_count can be incremented to track consecutive failures."""
+        ms = ManagedSlot(slot=5, managed=True)
+        ms.retry_count += 1
+        assert ms.retry_count == 1
+
+    def test_all_slot_statuses_assignable(self) -> None:
+        """All SlotStatus values can be assigned to ManagedSlot.status."""
+        ms = ManagedSlot(slot=5, managed=True)
+        for status in SlotStatus:
+            ms.status = status
+            assert ms.status is status
+
+
+# ---------------------------------------------------------------------------
+# PlannedSlot
+# ---------------------------------------------------------------------------
+
+
+class TestPlannedSlot:
+    """Tests for the PlannedSlot dataclass."""
+
+    def test_minimal_construction(self) -> None:
+        """PlannedSlot can be constructed with only required fields."""
+        ps = PlannedSlot(
+            slot=5,
+            desired_identity_key="key-abc",
+            actual_classification="free",
+            action=ActionKind.SET,
+        )
+        assert ps.slot == 5
+        assert ps.desired_identity_key == "key-abc"
+        assert ps.actual_classification == "free"
+        assert ps.action is ActionKind.SET
+
+    def test_defaults_for_optional_fields(self) -> None:
+        """Optional PlannedSlot fields default to documented values."""
+        ps = PlannedSlot(
+            slot=5,
+            desired_identity_key=None,
+            actual_classification="free",
+            action=ActionKind.NOOP,
+        )
+        assert ps.pending_reason is None
+        assert ps.retry_count == 0
+        assert ps.last_error is None
+
+    def test_none_desired_identity_for_empty_slot(self) -> None:
+        """desired_identity_key accepts None for slots that should be empty."""
+        ps = PlannedSlot(
+            slot=5,
+            desired_identity_key=None,
+            actual_classification="occupied",
+            action=ActionKind.CLEAR,
+        )
+        assert ps.desired_identity_key is None
+
+    def test_blocked_action_with_pending_reason(self) -> None:
+        """BLOCKED PlannedSlot stores a pending_reason explanation."""
+        ps = PlannedSlot(
+            slot=5,
+            desired_identity_key="key-abc",
+            actual_classification="unknown",
+            action=ActionKind.BLOCKED,
+            pending_reason="clear unconfirmed",
+        )
+        assert ps.action is ActionKind.BLOCKED
+        assert ps.pending_reason == "clear unconfirmed"
+
+    def test_retry_clear_with_retry_count(self) -> None:
+        """RETRY_CLEAR PlannedSlot carries the slot's current retry count."""
+        ps = PlannedSlot(
+            slot=5,
+            desired_identity_key=None,
+            actual_classification="pending_clear",
+            action=ActionKind.RETRY_CLEAR,
+            retry_count=2,
+            last_error="service call failed",
+        )
+        assert ps.action is ActionKind.RETRY_CLEAR
+        assert ps.retry_count == 2
+        assert ps.last_error == "service call failed"
+
+    def test_all_action_kinds_assignable(self) -> None:
+        """All ActionKind values are valid for PlannedSlot.action."""
+        for kind in ActionKind:
+            ps = PlannedSlot(
+                slot=5,
+                desired_identity_key=None,
+                actual_classification="free",
+                action=kind,
+            )
+            assert ps.action is kind
+
+
+# ---------------------------------------------------------------------------
+# DesiredPlan
+# ---------------------------------------------------------------------------
+
+
+class TestDesiredPlan:
+    """Tests for the DesiredPlan dataclass and its validate() method."""
+
+    def test_minimal_construction(self) -> None:
+        """DesiredPlan can be constructed with only required fields."""
+        plan = _make_desired_plan()
+        assert plan.plan_id == "plan-001"
+        assert plan.generated_at == _dt(2026, 6, 19)
+
+    def test_defaults_for_all_collections(self) -> None:
+        """All DesiredPlan collection fields default to empty containers."""
+        plan = _make_desired_plan()
+        assert plan.selected == {}
+        assert plan.protected == set()
+        assert plan.overflow == {}
+        assert plan.slots == {}
+        assert plan.actions == []
+        assert plan.diagnostics == {}
+
+    def test_collection_defaults_are_independent(self) -> None:
+        """Each DesiredPlan instance has its own collection defaults."""
+        plan_a = _make_desired_plan(plan_id="a")
+        plan_b = _make_desired_plan(plan_id="b")
+        plan_a.selected["k1"] = 5
+        assert "k1" not in plan_b.selected
+
+    def test_validate_empty_plan_returns_no_violations(self) -> None:
+        """An empty DesiredPlan has no invariant violations."""
+        plan = _make_desired_plan()
+        assert plan.validate() == []
+
+    def test_validate_valid_selected_returns_no_violations(self) -> None:
+        """A plan with unique identities and unique slots validates cleanly."""
+        plan = _make_desired_plan(selected={"k1": 5, "k2": 6, "k3": 7})
+        assert plan.validate() == []
+
+    def test_validate_detects_duplicate_slot(self) -> None:
+        """validate() reports when two identity keys map to the same slot."""
+        # Build a dict with a collision by mutating after construction.
+        plan = _make_desired_plan()
+        plan.selected = {"k1": 5, "k2": 5}
+        violations = plan.validate()
+        assert any("Slot 5" in v for v in violations)
+
+    def test_validate_single_entry_no_violations(self) -> None:
+        """A single-entry selected mapping always validates cleanly."""
+        plan = _make_desired_plan(selected={"only-key": 5})
+        assert plan.validate() == []
+
+    def test_protected_set_membership(self) -> None:
+        """protected set correctly reflects checked-in reservations."""
+        plan = _make_desired_plan(selected={"k1": 5})
+        plan.protected.add("k1")
+        assert "k1" in plan.protected
+
+    def test_overflow_records_reason(self) -> None:
+        """overflow dict stores the reason a reservation was not assigned."""
+        plan = _make_desired_plan()
+        plan.overflow["k-extra"] = "capacity"
+        assert plan.overflow["k-extra"] == "capacity"
+
+    def test_actions_list_accepts_slot_actions(self) -> None:
+        """actions list accepts SlotAction instances in order."""
+        plan = _make_desired_plan()
+        action = SlotAction(kind=ActionKind.SET, slot=5, identity_key="k1")
+        plan.actions.append(action)
+        assert len(plan.actions) == 1
+        assert plan.actions[0].kind is ActionKind.SET
+
+    def test_slots_dict_accepts_planned_slots(self) -> None:
+        """slots dict accepts PlannedSlot values keyed by slot number."""
+        plan = _make_desired_plan()
+        ps = PlannedSlot(
+            slot=5,
+            desired_identity_key="k1",
+            actual_classification="free",
+            action=ActionKind.SET,
+        )
+        plan.slots[5] = ps
+        assert plan.slots[5] is ps
+
+    def test_diagnostics_accepts_arbitrary_data(self) -> None:
+        """diagnostics dict accepts any JSON-compatible data."""
+        plan = _make_desired_plan()
+        plan.diagnostics["entry_id"] = "entry-001"
+        plan.diagnostics["max_events"] = 3
+        assert plan.diagnostics["max_events"] == 3
+
+
+# ---------------------------------------------------------------------------
+# StoredIdentity
+# ---------------------------------------------------------------------------
+
+
+class TestStoredIdentity:
+    """Tests for the StoredIdentity dataclass."""
+
+    def test_minimal_construction(self) -> None:
+        """StoredIdentity can be constructed with only required fields."""
+        si = _make_stored_identity()
+        assert si.identity_key == "key-abc"
+        assert si.summary == "Test Guest"
+        assert si.slot_name == "Test Guest"
+
+    def test_defaults_for_list_fields(self) -> None:
+        """uid_aliases and booking_aliases default to empty lists."""
+        si = _make_stored_identity()
+        assert si.uid_aliases == []
+        assert si.booking_aliases == []
+
+    def test_list_defaults_are_independent(self) -> None:
+        """Each StoredIdentity has its own uid_aliases and booking_aliases."""
+        si1 = _make_stored_identity(identity_key="k1")
+        si2 = _make_stored_identity(identity_key="k2")
+        si1.uid_aliases.append("uid-1")
+        assert "uid-1" not in si2.uid_aliases
+
+    def test_with_aliases(self) -> None:
+        """StoredIdentity stores provided alias lists."""
+        si = StoredIdentity(
+            identity_key="k1",
+            summary="Guest A",
+            slot_name="Guest A",
+            uid_aliases=["uid-1", "uid-2"],
+            booking_aliases=["BOOK-001"],
+        )
+        assert si.uid_aliases == ["uid-1", "uid-2"]
+        assert si.booking_aliases == ["BOOK-001"]
+
+
+# ---------------------------------------------------------------------------
+# StoredActual
+# ---------------------------------------------------------------------------
+
+
+class TestStoredActual:
+    """Tests for the StoredActual dataclass."""
+
+    def test_minimal_construction(self) -> None:
+        """StoredActual can be constructed with only required fields."""
+        sa = _make_stored_actual()
+        assert sa.slot == 5
+        assert sa.classification == "free"
+
+    def test_defaults_for_optional_fields(self) -> None:
+        """All optional StoredActual fields default to None."""
+        sa = _make_stored_actual()
+        assert sa.name_state is None
+        assert sa.has_code is None
+        assert sa.start_state is None
+        assert sa.end_state is None
+        assert sa.use_date_range is None
+        assert sa.enabled is None
+
+    def test_raw_pin_not_stored(self) -> None:
+        """StoredActual uses has_code bool, not a raw PIN value."""
+        # The model has no field for raw PIN; has_code is a boolean only.
+        sa = StoredActual(slot=5, classification="occupied", has_code=True)
+        assert sa.has_code is True
+        # Verify no raw PIN attribute exists on the dataclass.
+        assert not hasattr(sa, "pin")
+        assert not hasattr(sa, "pin_code")
+        assert not hasattr(sa, "slot_code")
+
+    def test_full_construction(self) -> None:
+        """StoredActual stores all provided optional fields."""
+        start = _dt(2026, 7, 1)
+        end = _dt(2026, 7, 8)
+        sa = StoredActual(
+            slot=3,
+            classification="occupied",
+            name_state="Alice",
+            has_code=True,
+            start_state=start,
+            end_state=end,
+            use_date_range=True,
+            enabled=True,
+        )
+        assert sa.name_state == "Alice"
+        assert sa.has_code is True
+        assert sa.start_state == start
+        assert sa.end_state == end
+        assert sa.use_date_range is True
+        assert sa.enabled is True
+
+    def test_all_classification_strings_accepted(self) -> None:
+        """StoredActual classification accepts any string value."""
+        for classification in (
+            "free",
+            "occupied",
+            "phantom",
+            "partial_reset",
+            "unknown",
+        ):
+            sa = StoredActual(slot=5, classification=classification)
+            assert sa.classification == classification
+
+
+# ---------------------------------------------------------------------------
+# SlotMapping
+# ---------------------------------------------------------------------------
+
+
+class TestSlotMapping:
+    """Tests for the SlotMapping dataclass and its validation."""
+
+    def test_minimal_construction(self) -> None:
+        """SlotMapping can be constructed with all required fields."""
+        sm = _make_slot_mapping()
+        assert sm.schema_version == 1
+        assert sm.entry_id == "entry-001"
+        assert sm.identity_key == "key-abc"
+        assert sm.slot == 5
+        assert sm.status == "occupied"
+
+    def test_defaults_for_optional_fields(self) -> None:
+        """Optional SlotMapping fields default to documented values."""
+        sm = _make_slot_mapping()
+        assert sm.fingerprint_history == []
+        assert sm.missing_count == 0
+        assert sm.lockname is None
+        assert sm.start_slot == 0
+        assert sm.max_slots == 0
+        assert sm.operation_id is None
+        assert sm.operation_kind is None
+        assert sm.pending_set_since is None
+        assert sm.pending_clear_since is None
+
+    def test_schema_version_below_one_raises(self) -> None:
+        """SlotMapping raises ValueError when schema_version is less than 1."""
+        with pytest.raises(ValueError, match="schema_version must be >= 1"):
+            _make_slot_mapping(schema_version=0)
+
+    def test_schema_version_one_is_valid(self) -> None:
+        """SlotMapping accepts schema_version of 1."""
+        sm = _make_slot_mapping(schema_version=1)
+        assert sm.schema_version == 1
+
+    def test_negative_missing_count_raises(self) -> None:
+        """SlotMapping raises ValueError when missing_count is negative."""
+        with pytest.raises(ValueError, match="missing_count must be non-negative"):
+            _make_slot_mapping(missing_count=-1)
+
+    def test_zero_missing_count_is_valid(self) -> None:
+        """SlotMapping accepts missing_count of zero."""
+        sm = _make_slot_mapping(missing_count=0)
+        assert sm.missing_count == 0
+
+    def test_missing_count_increments_to_three(self) -> None:
+        """SlotMapping accepts missing_count of 1, 2, and 3 (feed-miss cycle)."""
+        for count in (1, 2, 3):
+            sm = _make_slot_mapping(missing_count=count)
+            assert sm.missing_count == count
+
+    def test_pending_set_operation_fields(self) -> None:
+        """SlotMapping stores operation_id and operation_kind for fencing."""
+        sm = _make_slot_mapping()
+        sm.operation_id = "op-001"
+        sm.operation_kind = "set"
+        sm.pending_set_since = _dt(2026, 6, 19)
+        assert sm.operation_id == "op-001"
+        assert sm.operation_kind == "set"
+        assert sm.pending_set_since == _dt(2026, 6, 19)
+
+    def test_pending_clear_operation_fields(self) -> None:
+        """SlotMapping stores pending_clear_since for clear fencing."""
+        sm = _make_slot_mapping()
+        sm.operation_kind = "clear"
+        sm.pending_clear_since = _dt(2026, 6, 19)
+        assert sm.pending_clear_since == _dt(2026, 6, 19)
+
+    def test_fingerprint_history_list(self) -> None:
+        """SlotMapping stores fingerprint history as an ordered list."""
+        sm = _make_slot_mapping()
+        sm.fingerprint_history.append("old-fp-1")
+        sm.fingerprint_history.append("old-fp-2")
+        assert len(sm.fingerprint_history) == 2
+
+    def test_fingerprint_defaults_independent(self) -> None:
+        """Each SlotMapping has its own fingerprint_history list."""
+        sm1 = _make_slot_mapping(identity_key="k1")
+        sm2 = _make_slot_mapping(identity_key="k2")
+        sm1.fingerprint_history.append("fp-a")
+        assert "fp-a" not in sm2.fingerprint_history
+
+    def test_all_valid_status_strings_accepted(self) -> None:
+        """SlotMapping.status accepts all documented status string values."""
+        for status in (
+            "occupied",
+            "pending_set",
+            "pending_clear",
+            "blocked",
+            "overflow",
+        ):
+            sm = _make_slot_mapping()
+            sm.status = status
+            assert sm.status == status
+
+    def test_lockname_can_be_set(self) -> None:
+        """SlotMapping.lockname stores the Keymaster lock scope."""
+        sm = _make_slot_mapping()
+        sm.lockname = "front_door"
+        assert sm.lockname == "front_door"
+
+
+# ---------------------------------------------------------------------------
+# T008: Reservation identity fingerprinting helpers
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSlotNameForFingerprint:
+    """Tests for normalize_slot_name_for_fingerprint (T008)."""
+
+    def test_plain_name_unchanged_content(self) -> None:
+        """A plain all-lowercase name returns the same content."""
+        assert normalize_slot_name_for_fingerprint("alice") == "alice"
+
+    def test_uppercase_casefolded(self) -> None:
+        """Uppercase letters are casefolded to lowercase."""
+        assert normalize_slot_name_for_fingerprint("Alice Guest") == "alice guest"
+
+    def test_all_caps_casefolded(self) -> None:
+        """All-uppercase name is casefolded."""
+        assert normalize_slot_name_for_fingerprint("ALICE GUEST") == "alice guest"
+
+    def test_leading_trailing_spaces_stripped(self) -> None:
+        """Leading and trailing whitespace is stripped."""
+        assert normalize_slot_name_for_fingerprint("  Alice  ") == "alice"
+
+    def test_internal_spaces_preserved(self) -> None:
+        """Internal spaces are preserved after normalization."""
+        result = normalize_slot_name_for_fingerprint("Alice  Guest")
+        assert "  " in result  # internal double-space preserved
+
+    def test_empty_string(self) -> None:
+        """Empty string normalizes to empty string."""
+        assert normalize_slot_name_for_fingerprint("") == ""
+
+    def test_whitespace_only_normalizes_to_empty(self) -> None:
+        """Whitespace-only string normalizes to empty string."""
+        assert normalize_slot_name_for_fingerprint("   ") == ""
+
+    def test_mixed_case_and_spaces(self) -> None:
+        """Mixed case and surrounding spaces normalize consistently."""
+        assert normalize_slot_name_for_fingerprint("  ALICE guest  ") == "alice guest"
+
+    def test_idempotent(self) -> None:
+        """Applying normalization twice yields the same result."""
+        name = "  Alice GUEST  "
+        once = normalize_slot_name_for_fingerprint(name)
+        twice = normalize_slot_name_for_fingerprint(once)
+        assert once == twice
+
+
+class TestMakeReservationFingerprint:
+    """Tests for make_reservation_fingerprint (T008)."""
+
+    def test_returns_64_hex_chars(self) -> None:
+        """Fingerprint is a 64-character lowercase hexadecimal string."""
+        fp = make_reservation_fingerprint(
+            "entry-001",
+            "Alice Guest",
+            _dt(2026, 7, 1),
+            _dt(2026, 7, 8),
+        )
+        assert len(fp) == 64
+        assert fp == fp.lower()
+        assert all(c in "0123456789abcdef" for c in fp)
+
+    def test_deterministic(self) -> None:
+        """Same inputs always produce the same fingerprint."""
+        args = ("entry-001", "Alice Guest", _dt(2026, 7, 1), _dt(2026, 7, 8))
+        assert make_reservation_fingerprint(*args) == make_reservation_fingerprint(
+            *args
+        )
+
+    def test_different_entry_id_yields_different_fingerprint(self) -> None:
+        """Different entry_id produces a different fingerprint."""
+        fp1 = make_reservation_fingerprint(
+            "entry-001", "Alice", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        fp2 = make_reservation_fingerprint(
+            "entry-002", "Alice", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        assert fp1 != fp2
+
+    def test_different_slot_name_yields_different_fingerprint(self) -> None:
+        """Different slot name produces a different fingerprint."""
+        fp1 = make_reservation_fingerprint(
+            "entry-001", "Alice", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        fp2 = make_reservation_fingerprint(
+            "entry-001", "Bob", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        assert fp1 != fp2
+
+    def test_different_start_yields_different_fingerprint(self) -> None:
+        """Different start datetime produces a different fingerprint."""
+        fp1 = make_reservation_fingerprint(
+            "entry-001", "Alice", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        fp2 = make_reservation_fingerprint(
+            "entry-001", "Alice", _dt(2026, 7, 2), _dt(2026, 7, 8)
+        )
+        assert fp1 != fp2
+
+    def test_different_end_yields_different_fingerprint(self) -> None:
+        """Different end datetime produces a different fingerprint."""
+        fp1 = make_reservation_fingerprint(
+            "entry-001", "Alice", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        fp2 = make_reservation_fingerprint(
+            "entry-001", "Alice", _dt(2026, 7, 1), _dt(2026, 7, 9)
+        )
+        assert fp1 != fp2
+
+    def test_uid_independence(self) -> None:
+        """Fingerprint is the same regardless of calendar UID (T079 core).
+
+        This is the fundamental guarantee: UID churn must not invalidate
+        the persisted slot mapping.
+        """
+        fp1 = make_reservation_fingerprint(
+            "entry-001", "Alice Guest", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        fp2 = make_reservation_fingerprint(
+            "entry-001", "Alice Guest", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        # Both represent the same stay; only the UID would differ in the
+        # calendar feed.  The fingerprint must be identical.
+        assert fp1 == fp2
+
+    def test_case_insensitive_name_produces_same_fingerprint(self) -> None:
+        """Names differing only in case produce the same fingerprint."""
+        fp1 = make_reservation_fingerprint(
+            "entry-001", "Alice Guest", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        fp2 = make_reservation_fingerprint(
+            "entry-001", "ALICE GUEST", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        assert fp1 == fp2
+
+    def test_whitespace_trimmed_name_produces_same_fingerprint(self) -> None:
+        """Names differing only in surrounding whitespace produce the same fingerprint."""
+        fp1 = make_reservation_fingerprint(
+            "entry-001", "Alice Guest", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        fp2 = make_reservation_fingerprint(
+            "entry-001", "  Alice Guest  ", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        assert fp1 == fp2
+
+    def test_fingerprint_version_prefix_used(self) -> None:
+        """The fingerprint encodes the FINGERPRINT_VERSION constant."""
+        assert FINGERPRINT_VERSION == "v1"
+        # Verify that changing the version tag changes the fingerprint
+        # (indirectly: the constant is in the canonical string).
+        import hashlib
+
+        name = normalize_slot_name_for_fingerprint("Alice")
+        s = _dt(2026, 7, 1)
+        e = _dt(2026, 7, 8)
+        s_iso = s.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        e_iso = e.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        canonical_v1 = f"v1:entry-001:{name}:{s_iso}:{e_iso}"
+        canonical_v2 = f"v2:entry-001:{name}:{s_iso}:{e_iso}"
+        assert (
+            hashlib.sha256(canonical_v1.encode()).hexdigest()
+            != hashlib.sha256(canonical_v2.encode()).hexdigest()
+        )
+
+    def test_naive_datetime_treated_as_utc(self) -> None:
+        """Naive datetimes and UTC-aware datetimes with same value produce same fingerprint."""
+        naive_start = datetime(2026, 7, 1, 0, 0, 0)
+        aware_start = datetime(2026, 7, 1, 0, 0, 0, tzinfo=_TZ)
+        naive_end = datetime(2026, 7, 8, 0, 0, 0)
+        aware_end = datetime(2026, 7, 8, 0, 0, 0, tzinfo=_TZ)
+        fp_naive = make_reservation_fingerprint(
+            "entry-001", "Alice", naive_start, naive_end
+        )
+        fp_aware = make_reservation_fingerprint(
+            "entry-001", "Alice", aware_start, aware_end
+        )
+        assert fp_naive == fp_aware
+
+    def test_non_utc_timezone_normalized(self) -> None:
+        """Non-UTC timezone-aware datetimes are normalized to UTC before hashing."""
+        from datetime import timedelta
+
+        # UTC+5: 2026-07-01 05:00:00+05:00 == 2026-07-01 00:00:00+00:00
+        plus5 = timezone(timedelta(hours=5))
+        start_plus5 = datetime(2026, 7, 1, 5, 0, 0, tzinfo=plus5)
+        start_utc = datetime(2026, 7, 1, 0, 0, 0, tzinfo=_TZ)
+        end_plus5 = datetime(2026, 7, 8, 5, 0, 0, tzinfo=plus5)
+        end_utc = datetime(2026, 7, 8, 0, 0, 0, tzinfo=_TZ)
+        fp_offset = make_reservation_fingerprint(
+            "entry-001", "Alice", start_plus5, end_plus5
+        )
+        fp_utc = make_reservation_fingerprint("entry-001", "Alice", start_utc, end_utc)
+        assert fp_offset == fp_utc
+
+
+class TestExtractBookingAliases:
+    """Tests for extract_booking_aliases (T008)."""
+
+    def test_no_code_returns_empty_set(self) -> None:
+        """No recognizable confirmation code → empty set."""
+        assert extract_booking_aliases("Alice Guest", "") == set()
+
+    def test_airbnb_code_in_description(self) -> None:
+        """Airbnb confirmation code extracted from description."""
+        aliases = extract_booking_aliases(
+            "Reserved",
+            "Confirmation code: HM5K8X2R9P",
+        )
+        assert "HM5K8X2R9P" in aliases
+
+    def test_airbnb_code_in_summary(self) -> None:
+        """Airbnb confirmation code extracted from summary field."""
+        aliases = extract_booking_aliases("Reserved HM5K8X2R9P", "")
+        assert "HM5K8X2R9P" in aliases
+
+    def test_airbnb_code_format_10_chars(self) -> None:
+        """Airbnb code: exactly 1 uppercase letter + 9 uppercase alphanumeric."""
+        # Valid: ABCDE12345 (letter + 9 alnum)
+        aliases = extract_booking_aliases("Reserved", "code ABCDE12345 end")
+        assert "ABCDE12345" in aliases
+
+    def test_lowercase_code_not_extracted(self) -> None:
+        """Lowercase confirmation codes are not extracted."""
+        assert extract_booking_aliases("Reserved", "code abcde12345 end") == set()
+
+    def test_11_char_code_not_extracted(self) -> None:
+        """Code longer than 10 uppercase alnum chars is not matched."""
+        # 11 uppercase chars → boundary char is uppercase → not matched
+        assert extract_booking_aliases("Reserved", "ABCDE123456") == set()
+
+    def test_multiple_codes_extracted(self) -> None:
+        """Multiple confirmation codes in text are all extracted."""
+        aliases = extract_booking_aliases(
+            "Reserved", "First: HM5K8X2R9P and second: AB3CD4EF5G"
+        )
+        assert "HM5K8X2R9P" in aliases
+        assert "AB3CD4EF5G" in aliases
+
+    def test_empty_description_safe(self) -> None:
+        """Empty description does not raise an error."""
+        assert extract_booking_aliases("Something", "") == set()
+
+    def test_no_code_in_normal_summary(self) -> None:
+        """A normal guest-name summary produces no aliases."""
+        assert extract_booking_aliases("Alice Smith", "Check in at 3pm") == set()
+
+    def test_returns_set_type(self) -> None:
+        """Return type is always a set."""
+        result = extract_booking_aliases("Reserved", "HM5K8X2R9P")
+        assert isinstance(result, set)
+
+
+# ---------------------------------------------------------------------------
+# T008: RematchResult construction
+# ---------------------------------------------------------------------------
+
+
+class TestRematchResult:
+    """Tests for RematchResult dataclass construction (T008)."""
+
+    def test_exact_result_construction(self) -> None:
+        """RematchResult can be constructed for an EXACT match."""
+        r = RematchResult(kind=RematchKind.EXACT, matched_identity_key="key-abc")
+        assert r.kind is RematchKind.EXACT
+        assert r.matched_identity_key == "key-abc"
+        assert r.date_shifted is False
+        assert r.ambiguous_keys == []
+
+    def test_no_match_result(self) -> None:
+        """RematchResult for NO_MATCH has None matched_identity_key."""
+        r = RematchResult(kind=RematchKind.NO_MATCH, matched_identity_key=None)
+        assert r.kind is RematchKind.NO_MATCH
+        assert r.matched_identity_key is None
+
+    def test_uid_alias_result_with_date_shifted(self) -> None:
+        """RematchResult for UID_ALIAS records date_shifted=True."""
+        r = RematchResult(
+            kind=RematchKind.UID_ALIAS,
+            matched_identity_key="old-key",
+            date_shifted=True,
+        )
+        assert r.kind is RematchKind.UID_ALIAS
+        assert r.date_shifted is True
+
+    def test_ambiguous_result_with_keys(self) -> None:
+        """RematchResult for AMBIGUOUS stores all ambiguous candidate keys."""
+        r = RematchResult(
+            kind=RematchKind.AMBIGUOUS,
+            matched_identity_key=None,
+            ambiguous_keys=["key-a", "key-b"],
+        )
+        assert r.kind is RematchKind.AMBIGUOUS
+        assert r.matched_identity_key is None
+        assert "key-a" in r.ambiguous_keys
+        assert "key-b" in r.ambiguous_keys
+
+    def test_rematch_kind_values(self) -> None:
+        """All seven RematchKind values are present."""
+        expected = {
+            "exact",
+            "uid_alias",
+            "booking_alias",
+            "name_time",
+            "continuity",
+            "ambiguous",
+            "no_match",
+        }
+        actual = {k.value for k in RematchKind}
+        assert actual == expected
+
+    def test_rematch_kind_is_string(self) -> None:
+        """RematchKind values are plain strings."""
+        assert isinstance(RematchKind.EXACT, str)
+        assert RematchKind.EXACT == "exact"
+
+
+# ---------------------------------------------------------------------------
+# T079: UID-changed but stable name/start/end mapping retention
+# ---------------------------------------------------------------------------
+
+
+class TestUidChangedStableNameStartEnd:
+    """T079: Fingerprint stability guarantees UID-change tolerance."""
+
+    def test_same_fingerprint_when_uid_changes(self) -> None:
+        """Two reservations with different UIDs but same name/start/end share a fingerprint.
+
+        This is the core guarantee: UID churn must not produce a new
+        identity key, so the persisted slot mapping survives platform
+        UID reissuance without any rematch step.
+        """
+        fp1 = make_reservation_fingerprint(
+            "entry-001", "Alice Guest", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        fp2 = make_reservation_fingerprint(
+            "entry-001", "Alice Guest", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        assert fp1 == fp2
+
+    def test_exact_rematch_when_uid_changes(self) -> None:
+        """Reservation with changed UID but same data finds EXACT rematch (rule 1).
+
+        Because the fingerprint does not include the UID, the new
+        reservation's identity_key is the same as the persisted key and
+        rule 1 fires directly — no alias lookup needed.
+        """
+        entry_id = "entry-001"
+        name = "Alice Guest"
+        start = _dt(2026, 7, 1)
+        end = _dt(2026, 7, 8)
+        fp = make_reservation_fingerprint(entry_id, name, start, end)
+
+        # Persisted mapping uses this fingerprint as its key
+        persisted_mappings = {
+            fp: {
+                "identity_key": fp,
+                "slot": 10,
+                "status": "occupied",
+                "identity": {
+                    "identity_key": fp,
+                    "summary": name,
+                    "slot_name": name,
+                    "uid_aliases": ["old-uid-original"],
+                    "booking_aliases": [],
+                },
+                "fingerprint_history": [],
+                "last_observed_actual": {
+                    "slot": 10,
+                    "classification": "occupied",
+                    "name_state": name,
+                    "has_code": True,
+                    "start_state": None,
+                    "end_state": None,
+                    "use_date_range": None,
+                    "enabled": None,
+                },
+            }
+        }
+
+        # New feed reservation: same data, new UID "new-uid-churn"
+        reservation = _make_reservation(
+            identity_key=fp,  # same fingerprint (UID not in fingerprint)
+            start=start,
+            end=end,
+        )
+        reservation.uid_aliases.add("new-uid-churn")
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.EXACT
+        assert result.matched_identity_key == fp
+
+    def test_different_uid_aliases_do_not_affect_fingerprint_equality(self) -> None:
+        """Adding UIDs to a reservation's uid_aliases does not change its fingerprint."""
+        fp = make_reservation_fingerprint(
+            "entry-001", "Bob Guest", _dt(2026, 8, 1), _dt(2026, 8, 7)
+        )
+        # Construct two reservations with different uid_aliases sets but
+        # same identity_key (fingerprint).
+        r1 = _make_reservation(
+            identity_key=fp, start=_dt(2026, 8, 1), end=_dt(2026, 8, 7)
+        )
+        r1.uid_aliases = {"uid-alpha"}
+
+        r2 = _make_reservation(
+            identity_key=fp, start=_dt(2026, 8, 1), end=_dt(2026, 8, 7)
+        )
+        r2.uid_aliases = {"uid-beta", "uid-gamma"}
+
+        assert r1.identity_key == r2.identity_key
+
+
+# ---------------------------------------------------------------------------
+# T080: UID-match date-shift mapping update and should-update-code interaction
+# ---------------------------------------------------------------------------
+
+
+class TestUidMatchDateShift:
+    """T080: UID alias match with date shift → date_shifted=True."""
+
+    def _make_persisted_with_uid(
+        self,
+        identity_key: str,
+        slot_name: str,
+        uid: str,
+        slot: int = 10,
+    ) -> dict:
+        """Build a minimal persisted mapping with a UID alias."""
+        return {
+            "identity_key": identity_key,
+            "slot": slot,
+            "status": "occupied",
+            "identity": {
+                "identity_key": identity_key,
+                "summary": slot_name,
+                "slot_name": slot_name,
+                "uid_aliases": [uid],
+                "booking_aliases": [],
+            },
+            "fingerprint_history": [],
+            "last_observed_actual": {
+                "slot": slot,
+                "classification": "occupied",
+                "name_state": slot_name,
+                "has_code": True,
+                "start_state": None,
+                "end_state": None,
+                "use_date_range": None,
+                "enabled": None,
+            },
+        }
+
+    def test_uid_alias_match_when_dates_shifted(self) -> None:
+        """UID alias + name match when dates shifted → RematchKind.UID_ALIAS.
+
+        Rule 2 fires when the UID is in the persisted uid_aliases and the
+        normalized names match, but the fingerprint differs (i.e. dates
+        changed since the mapping was persisted).
+        """
+        entry_id = "entry-001"
+        name = "Alice Guest"
+        orig_start = _dt(2026, 7, 1)
+        orig_end = _dt(2026, 7, 8)
+        shared_uid = "uid-platform-abc"
+
+        # Old fingerprint: original dates
+        old_fp = make_reservation_fingerprint(entry_id, name, orig_start, orig_end)
+
+        persisted_mappings = {
+            old_fp: self._make_persisted_with_uid(old_fp, name, shared_uid)
+        }
+
+        # Reservation in new feed: same UID, same name, but dates shifted by 1 day
+        new_start = _dt(2026, 7, 2)
+        new_end = _dt(2026, 7, 9)
+        new_fp = make_reservation_fingerprint(entry_id, name, new_start, new_end)
+        assert new_fp != old_fp  # fingerprint changed due to date shift
+
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=new_start,
+            end=new_end,
+            buffered_start=new_start,
+            buffered_end=new_end,
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="5678",
+        )
+        reservation.uid_aliases.add(shared_uid)
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.UID_ALIAS
+        assert result.matched_identity_key == old_fp
+        assert result.date_shifted is True
+
+    def test_date_shifted_flag_signals_code_update_need(self) -> None:
+        """date_shifted=True in result tells coordinator to consider code update.
+
+        When should_update_code=True (date-based code), the coordinator
+        regenerates the code when date_shifted=True.  When
+        should_update_code=False (static code), only the dates are updated.
+        This test verifies that the rematch result exposes date_shifted
+        so the coordinator can apply its should_update_code policy.
+        """
+        entry_id = "entry-001"
+        name = "Bob Guest"
+        uid = "uid-xyz"
+
+        old_fp = make_reservation_fingerprint(
+            entry_id, name, _dt(2026, 8, 1), _dt(2026, 8, 7)
+        )
+        new_fp = make_reservation_fingerprint(
+            entry_id, name, _dt(2026, 8, 2), _dt(2026, 8, 8)
+        )
+        assert old_fp != new_fp
+
+        persisted_mappings = {old_fp: self._make_persisted_with_uid(old_fp, name, uid)}
+
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=_dt(2026, 8, 2),
+            end=_dt(2026, 8, 8),
+            buffered_start=_dt(2026, 8, 2),
+            buffered_end=_dt(2026, 8, 8),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="9999",
+        )
+        reservation.uid_aliases.add(uid)
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+
+        # date_shifted=True allows coordinator to decide code-update strategy
+        assert result.date_shifted is True
+
+        # Simulate coordinator decision logic:
+        # should_update_code=True → regenerate code (date-based)
+        # should_update_code=False → keep code, update times only
+        should_update_code_true = True
+        should_update_code_false = False
+        assert result.date_shifted and should_update_code_true  # would regenerate
+        assert result.date_shifted and not should_update_code_false  # update times only
+
+    def test_uid_alias_match_requires_name_match(self) -> None:
+        """Rule 2 does not fire if the name does not match despite UID overlap."""
+        entry_id = "entry-001"
+        uid = "uid-shared"
+        old_fp = make_reservation_fingerprint(
+            entry_id, "Alice Guest", _dt(2026, 7, 1), _dt(2026, 7, 8)
+        )
+        persisted_mappings = {
+            old_fp: self._make_persisted_with_uid(old_fp, "Alice Guest", uid)
+        }
+
+        # New reservation has the same UID but a DIFFERENT name
+        new_fp = make_reservation_fingerprint(
+            entry_id, "Bob Guest", _dt(2026, 7, 2), _dt(2026, 7, 9)
+        )
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=_dt(2026, 7, 2),
+            end=_dt(2026, 7, 9),
+            buffered_start=_dt(2026, 7, 2),
+            buffered_end=_dt(2026, 7, 9),
+            summary="Bob Guest",
+            slot_name="Bob Guest",
+            display_slot_name="RC Bob Guest",
+            slot_code="1111",
+        )
+        reservation.uid_aliases.add(uid)
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        # Must not match by UID alias because name differs
+        assert result.kind is not RematchKind.UID_ALIAS
+
+    def test_date_shifted_false_for_exact_match(self) -> None:
+        """date_shifted is False when rule 1 (exact) fires."""
+        entry_id = "entry-001"
+        name = "Carol Guest"
+        fp = make_reservation_fingerprint(
+            entry_id, name, _dt(2026, 9, 1), _dt(2026, 9, 8)
+        )
+        persisted_mappings = {fp: self._make_persisted_with_uid(fp, name, "uid-carol")}
+        reservation = Reservation(
+            identity_key=fp,
+            start=_dt(2026, 9, 1),
+            end=_dt(2026, 9, 8),
+            buffered_start=_dt(2026, 9, 1),
+            buffered_end=_dt(2026, 9, 8),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="2222",
+        )
+        reservation.uid_aliases.add("uid-carol")
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.EXACT
+        assert result.date_shifted is False
+
+
+# ---------------------------------------------------------------------------
+# T081: Conservative continuity rematch
+# ---------------------------------------------------------------------------
+
+
+class TestConservativeContinuityRematch:
+    """T081: Conservative continuity rematch via fingerprint history, booking
+    aliases, normalized name, non-overlap ordering, and actual-slot continuity.
+    """
+
+    def _persisted(
+        self,
+        identity_key: str,
+        slot_name: str,
+        slot: int = 10,
+        fingerprint_history: list[str] | None = None,
+        booking_aliases: list[str] | None = None,
+        uid_aliases: list[str] | None = None,
+        start_iso: str | None = None,
+        end_iso: str | None = None,
+    ) -> dict:
+        """Build a minimal persisted mapping for continuity tests."""
+        return {
+            "identity_key": identity_key,
+            "slot": slot,
+            "status": "occupied",
+            "identity": {
+                "identity_key": identity_key,
+                "summary": slot_name,
+                "slot_name": slot_name,
+                "start": start_iso,
+                "end": end_iso,
+                "uid_aliases": uid_aliases or [],
+                "booking_aliases": booking_aliases or [],
+            },
+            "fingerprint_history": fingerprint_history or [],
+            "last_observed_actual": {
+                "slot": slot,
+                "classification": "occupied",
+                "name_state": slot_name,
+                "has_code": True,
+                "start_state": None,
+                "end_state": None,
+                "use_date_range": None,
+                "enabled": None,
+            },
+        }
+
+    def _reservation(
+        self,
+        identity_key: str,
+        slot_name: str,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        booking_aliases: set[str] | None = None,
+        fingerprint_history: set[str] | None = None,
+    ) -> Reservation:
+        """Build a minimal Reservation for continuity tests."""
+        r = Reservation(
+            identity_key=identity_key,
+            start=start or _dt(2026, 7, 10),
+            end=end or _dt(2026, 7, 17),
+            buffered_start=start or _dt(2026, 7, 10),
+            buffered_end=end or _dt(2026, 7, 17),
+            summary=slot_name,
+            slot_name=slot_name,
+            display_slot_name=f"RC {slot_name}",
+            slot_code="0000",
+        )
+        if booking_aliases:
+            r.booking_aliases = booking_aliases
+        if fingerprint_history:
+            r.fingerprint_history = fingerprint_history
+        return r
+
+    # --- fingerprint history signals ---
+
+    def test_continuity_via_fingerprint_history_in_mapping(self) -> None:
+        """Continuity match when current identity_key is in mapping's fingerprint_history.
+
+        This handles the case where a reservation's dates shifted (new
+        fingerprint) but the persisted mapping kept the old fingerprint
+        as a history entry.
+        """
+        old_fp = "old-fingerprint-aaa"
+        new_fp = "new-fingerprint-bbb"
+        name = "Alice Guest"
+
+        persisted_mappings = {
+            old_fp: self._persisted(
+                old_fp,
+                name,
+                fingerprint_history=[new_fp],  # new fp already recorded
+            )
+        }
+        # New reservation has a completely new key (both UID and dates changed)
+        reservation = self._reservation(new_fp, name)
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.CONTINUITY
+        assert result.matched_identity_key == old_fp
+
+    def test_continuity_via_reservation_fingerprint_history(self) -> None:
+        """Continuity match when old persisted key is in reservation's fingerprint_history.
+
+        This handles the case where the coordinator already moved the old
+        key to the reservation's history before persisting the new one,
+        and a later restart needs to re-identify the mapping.
+        """
+        old_fp = "persisted-key-xyz"
+        new_fp = "new-key-for-this-reservation"
+        name = "Bob Guest"
+
+        persisted_mappings = {old_fp: self._persisted(old_fp, name)}
+        # Reservation remembers its prior persisted key
+        reservation = self._reservation(new_fp, name, fingerprint_history={old_fp})
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.CONTINUITY
+        assert result.matched_identity_key == old_fp
+
+    # --- booking alias signal ---
+
+    def test_continuity_via_booking_alias(self) -> None:
+        """Booking alias overlap + name match recovers the persisted mapping (rule 3).
+
+        When a booking/confirmation alias (e.g. an Airbnb confirmation code)
+        from the current feed reservation matches the persisted mapping's
+        booking_aliases AND the normalized names match, rule 3 fires and
+        returns RematchKind.BOOKING_ALIAS.
+
+        Rule 3 (BOOKING_ALIAS) pre-empts rule 5 (CONTINUITY) because direct
+        alias evidence is considered stronger than the multi-signal continuity
+        check.  The booking_alias signal is also included in rule 5's
+        _is_continuity_compatible as a safety net for future extension, but
+        in practice rule 3 fires first whenever booking aliases overlap.
+        """
+        old_fp = "fp-booking-test"
+        new_fp = "fp-new-booking"
+        name = "Carol Guest"
+        booking_code = "HMABCDE1234"  # Airbnb-style 10-char code
+
+        persisted_mappings = {
+            old_fp: self._persisted(old_fp, name, booking_aliases=[booking_code])
+        }
+        reservation = self._reservation(new_fp, name, booking_aliases={booking_code})
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        # Rule 3 fires first for booking alias + name match; the mapping is
+        # successfully recovered regardless of which rule matched.
+        assert result.kind is RematchKind.BOOKING_ALIAS
+        assert result.matched_identity_key == old_fp
+
+    def test_continuity_booking_alias_requires_name_match(self) -> None:
+        """Booking alias overlap alone is not enough: name must also match."""
+        old_fp = "fp-carol"
+        new_fp = "fp-diana"
+        booking_code = "HM1234567XY"
+
+        persisted_mappings = {
+            old_fp: self._persisted(
+                old_fp, "Carol Guest", booking_aliases=[booking_code]
+            )
+        }
+        # Different name but same booking code (unlikely in reality but tested
+        # to verify the name-required rule)
+        reservation = self._reservation(
+            new_fp, "Diana Guest", booking_aliases={booking_code}
+        )
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        # Name mismatch → no continuity match
+        assert result.kind is RematchKind.NO_MATCH
+
+    # --- actual-slot continuity signal ---
+
+    def test_continuity_via_actual_slot_name(self) -> None:
+        """Continuity match when actual Keymaster slot name matches reservation name."""
+        old_fp = "fp-actual-slot"
+        new_fp = "fp-new-actual"
+        name = "Eve Guest"
+
+        persisted_mappings = {old_fp: self._persisted(old_fp, name, slot=10)}
+        reservation = self._reservation(new_fp, name)
+        # Actual slot 10 has "Eve Guest" programmed
+        actual_slot_names = {10: "Eve Guest"}
+
+        result = find_reservation_rematch(
+            reservation, persisted_mappings, actual_slot_names=actual_slot_names
+        )
+        assert result.kind is RematchKind.CONTINUITY
+        assert result.matched_identity_key == old_fp
+
+    def test_continuity_actual_slot_name_case_insensitive(self) -> None:
+        """Actual slot name comparison is case-insensitive."""
+        old_fp = "fp-case-slot"
+        new_fp = "fp-new-case"
+        name = "Frank Guest"
+
+        persisted_mappings = {old_fp: self._persisted(old_fp, name, slot=11)}
+        reservation = self._reservation(new_fp, name)
+        # Actual name has different case
+        actual_slot_names = {11: "FRANK GUEST"}
+
+        result = find_reservation_rematch(
+            reservation, persisted_mappings, actual_slot_names=actual_slot_names
+        )
+        assert result.kind is RematchKind.CONTINUITY
+        assert result.matched_identity_key == old_fp
+
+    # --- non-overlap ordering (competition check) ---
+
+    def test_continuity_blocked_by_competing_reservation(self) -> None:
+        """Continuity match returns AMBIGUOUS when another reservation competes.
+
+        The non-overlap ordering check: if two current reservations have
+        the same name, they both 'compete' for the same persisted mapping,
+        making the continuity rematch ambiguous.
+        """
+        old_fp = "fp-shared-name"
+        new_fp_1 = "fp-res1"
+        new_fp_2 = "fp-res2"
+        name = "Grace Guest"
+
+        persisted_mappings = {
+            old_fp: self._persisted(old_fp, name, fingerprint_history=[new_fp_1])
+        }
+        reservation1 = self._reservation(new_fp_1, name)
+        reservation2 = self._reservation(
+            new_fp_2, name, start=_dt(2026, 8, 1), end=_dt(2026, 8, 8)
+        )
+        # reservation1 is compatible via fingerprint history; reservation2
+        # competes by name → AMBIGUOUS
+        result = find_reservation_rematch(
+            reservation1,
+            persisted_mappings,
+            current_reservations=[reservation1, reservation2],
+        )
+        assert result.kind is RematchKind.AMBIGUOUS
+
+    def test_continuity_succeeds_without_competing_reservations(self) -> None:
+        """Continuity match returns CONTINUITY when no other reservation competes."""
+        old_fp = "fp-solo-name"
+        new_fp = "fp-new-solo"
+        name = "Henry Guest"
+
+        persisted_mappings = {
+            old_fp: self._persisted(old_fp, name, fingerprint_history=[new_fp])
+        }
+        reservation = self._reservation(new_fp, name)
+        # Only one current reservation with this name → no competition
+        result = find_reservation_rematch(
+            reservation,
+            persisted_mappings,
+            current_reservations=[reservation],
+        )
+        assert result.kind is RematchKind.CONTINUITY
+        assert result.matched_identity_key == old_fp
+
+    def test_continuity_requires_name_match(self) -> None:
+        """Continuity match never fires when names differ."""
+        old_fp = "fp-alice-wrong"
+        new_fp = "fp-bob-new"
+
+        persisted_mappings = {
+            # Alice's mapping has Bob's new fingerprint in its history (edge case)
+            old_fp: self._persisted(old_fp, "Alice Guest", fingerprint_history=[new_fp])
+        }
+        # Bob has the matching fingerprint history entry but different name
+        reservation = self._reservation(new_fp, "Bob Guest")
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.NO_MATCH
+
+    def test_no_match_when_no_signals_present(self) -> None:
+        """NO_MATCH returned when no rule 1-5 criteria are met."""
+        old_fp = "fp-old-unrelated"
+        new_fp = "fp-completely-new"
+
+        persisted_mappings = {old_fp: self._persisted(old_fp, "Other Guest")}
+        reservation = self._reservation(new_fp, "Different Guest")
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.NO_MATCH
+        assert result.matched_identity_key is None
+
+
+# ---------------------------------------------------------------------------
+# T082: Ambiguous continuity rematch diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestAmbiguousRematchDiagnostics:
+    """T082: Two candidates remain compatible → AMBIGUOUS with both keys."""
+
+    def _persisted(
+        self,
+        identity_key: str,
+        slot_name: str,
+        slot: int,
+        fingerprint_history: list[str] | None = None,
+        booking_aliases: list[str] | None = None,
+        start_iso: str | None = None,
+        end_iso: str | None = None,
+    ) -> dict:
+        """Build a minimal persisted mapping for ambiguous tests."""
+        return {
+            "identity_key": identity_key,
+            "slot": slot,
+            "status": "occupied",
+            "identity": {
+                "identity_key": identity_key,
+                "summary": slot_name,
+                "slot_name": slot_name,
+                "start": start_iso,
+                "end": end_iso,
+                "uid_aliases": [],
+                "booking_aliases": booking_aliases or [],
+            },
+            "fingerprint_history": fingerprint_history or [],
+            "last_observed_actual": {
+                "slot": slot,
+                "classification": "occupied",
+                "name_state": slot_name,
+                "has_code": True,
+                "start_state": None,
+                "end_state": None,
+                "use_date_range": None,
+                "enabled": None,
+            },
+        }
+
+    def test_two_continuity_compatible_mappings_return_ambiguous(self) -> None:
+        """AMBIGUOUS returned when two persisted mappings are both compatible.
+
+        Scenario: two different guest stays have the same name (repeat
+        guest) and both persisted mappings have the incoming fingerprint
+        in their history.  The rematch is ambiguous and no mapping is
+        selected.
+        """
+        name = "Repeat Guest"
+        new_fp = "fp-incoming-repeat"
+        old_fp_a = "fp-old-stay-a"
+        old_fp_b = "fp-old-stay-b"
+
+        persisted_mappings = {
+            old_fp_a: self._persisted(
+                old_fp_a, name, slot=10, fingerprint_history=[new_fp]
+            ),
+            old_fp_b: self._persisted(
+                old_fp_b, name, slot=11, fingerprint_history=[new_fp]
+            ),
+        }
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=_dt(2026, 9, 1),
+            end=_dt(2026, 9, 8),
+            buffered_start=_dt(2026, 9, 1),
+            buffered_end=_dt(2026, 9, 8),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.AMBIGUOUS
+        assert result.matched_identity_key is None
+
+    def test_ambiguous_result_exposes_all_candidate_keys(self) -> None:
+        """AMBIGUOUS result's ambiguous_keys contains all compatible candidate keys."""
+        name = "Repeat Guest"
+        new_fp = "fp-repeat-incoming"
+        old_fp_a = "fp-repeat-a"
+        old_fp_b = "fp-repeat-b"
+
+        persisted_mappings = {
+            old_fp_a: self._persisted(
+                old_fp_a, name, slot=10, fingerprint_history=[new_fp]
+            ),
+            old_fp_b: self._persisted(
+                old_fp_b, name, slot=11, fingerprint_history=[new_fp]
+            ),
+        }
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=_dt(2026, 9, 10),
+            end=_dt(2026, 9, 17),
+            buffered_start=_dt(2026, 9, 10),
+            buffered_end=_dt(2026, 9, 17),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.AMBIGUOUS
+        assert old_fp_a in result.ambiguous_keys
+        assert old_fp_b in result.ambiguous_keys
+        assert len(result.ambiguous_keys) == 2
+
+    def test_ambiguous_result_for_booking_alias_overlap_both_candidates(
+        self,
+    ) -> None:
+        """AMBIGUOUS when two mappings share a booking alias with the reservation."""
+        name = "Repeat Guest"
+        new_fp = "fp-booking-ambiguous"
+        old_fp_a = "fp-stay-a-booking"
+        old_fp_b = "fp-stay-b-booking"
+        shared_code = "HMAMBIGUOUS1"
+
+        persisted_mappings = {
+            old_fp_a: self._persisted(
+                old_fp_a, name, slot=10, booking_aliases=[shared_code]
+            ),
+            old_fp_b: self._persisted(
+                old_fp_b, name, slot=11, booking_aliases=[shared_code]
+            ),
+        }
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=_dt(2026, 10, 1),
+            end=_dt(2026, 10, 8),
+            buffered_start=_dt(2026, 10, 1),
+            buffered_end=_dt(2026, 10, 8),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+        reservation.booking_aliases.add(shared_code)
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.AMBIGUOUS
+        assert len(result.ambiguous_keys) == 2
+
+    def test_single_compatible_candidate_returns_continuity_not_ambiguous(
+        self,
+    ) -> None:
+        """Exactly one compatible candidate → CONTINUITY, not AMBIGUOUS."""
+        name = "Solo Guest"
+        new_fp = "fp-solo-incoming"
+        old_fp = "fp-solo-only"
+
+        persisted_mappings = {
+            old_fp: self._persisted(old_fp, name, slot=10, fingerprint_history=[new_fp])
+        }
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=_dt(2026, 10, 1),
+            end=_dt(2026, 10, 8),
+            buffered_start=_dt(2026, 10, 1),
+            buffered_end=_dt(2026, 10, 8),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.CONTINUITY
+        assert result.matched_identity_key == old_fp
+
+    def test_ambiguous_diagnostic_has_no_matched_key(self) -> None:
+        """AMBIGUOUS result never sets a matched_identity_key."""
+        name = "Ambiguous Guest"
+        new_fp = "fp-ambig-incoming"
+
+        persisted_mappings = {
+            f"fp-slot-{i}": self._persisted(
+                f"fp-slot-{i}", name, slot=10 + i, fingerprint_history=[new_fp]
+            )
+            for i in range(3)
+        }
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=_dt(2026, 11, 1),
+            end=_dt(2026, 11, 8),
+            buffered_start=_dt(2026, 11, 1),
+            buffered_end=_dt(2026, 11, 8),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.AMBIGUOUS
+        assert result.matched_identity_key is None
+        assert len(result.ambiguous_keys) == 3
+
+
+# ---------------------------------------------------------------------------
+# T008: find_reservation_rematch – rule priority order
+# ---------------------------------------------------------------------------
+
+
+class TestFindReservationRematchRulePriority:
+    """T008: verify rule precedence and boundary conditions for all six rules."""
+
+    def _persisted(
+        self,
+        key: str,
+        name: str,
+        slot: int = 10,
+        uid_aliases: list[str] | None = None,
+        booking_aliases: list[str] | None = None,
+        fingerprint_history: list[str] | None = None,
+        start_iso: str | None = None,
+        end_iso: str | None = None,
+    ) -> dict:
+        """Build a minimal persisted mapping for rule-priority tests.
+
+        Supports optional start/end ISO strings in the identity dict so
+        that rule 4 (name + exact start/end) scenarios can be tested.
+        """
+        identity: dict = {
+            "identity_key": key,
+            "summary": name,
+            "slot_name": name,
+            "uid_aliases": uid_aliases or [],
+            "booking_aliases": booking_aliases or [],
+        }
+        if start_iso is not None:
+            identity["start"] = start_iso
+        if end_iso is not None:
+            identity["end"] = end_iso
+        return {
+            "identity_key": key,
+            "slot": slot,
+            "status": "occupied",
+            "identity": identity,
+            "fingerprint_history": fingerprint_history or [],
+            "last_observed_actual": {
+                "slot": slot,
+                "classification": "occupied",
+                "name_state": name,
+                "has_code": True,
+                "start_state": None,
+                "end_state": None,
+                "use_date_range": None,
+                "enabled": None,
+            },
+        }
+
+    def _reservation(
+        self,
+        key: str,
+        name: str,
+        uid_aliases: set[str] | None = None,
+        booking_aliases: set[str] | None = None,
+        fingerprint_history: set[str] | None = None,
+    ) -> Reservation:
+        """Build a minimal Reservation for rule-priority tests."""
+        r = Reservation(
+            identity_key=key,
+            start=_dt(2026, 7, 1),
+            end=_dt(2026, 7, 8),
+            buffered_start=_dt(2026, 7, 1),
+            buffered_end=_dt(2026, 7, 8),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+        if uid_aliases:
+            r.uid_aliases = uid_aliases
+        if booking_aliases:
+            r.booking_aliases = booking_aliases
+        if fingerprint_history:
+            r.fingerprint_history = fingerprint_history
+        return r
+
+    def test_rule1_exact_takes_priority_over_rule2(self) -> None:
+        """Rule 1 fires even when UID alias would also match (rule 2 skipped)."""
+        fp = "fp-exact-uid-both"
+        name = "Priority Guest"
+        uid = "uid-matches-both"
+
+        persisted_mappings = {fp: self._persisted(fp, name, uid_aliases=[uid])}
+        reservation = self._reservation(fp, name, uid_aliases={uid})
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.EXACT
+
+    def test_rule2_uid_alias_takes_priority_over_rule3(self) -> None:
+        """Rule 2 fires even when booking alias would also match (rule 3 skipped)."""
+        old_fp = "fp-old-uid-booking"
+        new_fp = "fp-new-uid-booking"
+        name = "Overlap Guest"
+        uid = "uid-matches"
+        book = "HMOVERLAPXX1"
+
+        persisted_mappings = {
+            old_fp: self._persisted(
+                old_fp, name, uid_aliases=[uid], booking_aliases=[book]
+            )
+        }
+        reservation = self._reservation(
+            new_fp, name, uid_aliases={uid}, booking_aliases={book}
+        )
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.UID_ALIAS
+
+    def test_rule3_booking_alias_takes_priority_over_rule4(self) -> None:
+        """Rule 3 fires when booking alias matches, even if name+time also matches."""
+        name = "Booking Guest"
+        book = "HMBOOKING123"
+        start = _dt(2026, 7, 1)
+        end = _dt(2026, 7, 8)
+        old_fp = "fp-booking-priority"
+        new_fp = make_reservation_fingerprint("entry-001", name, start, end)
+        assert old_fp != new_fp  # ensure different so rule 1 doesn't fire
+
+        persisted_mappings = {
+            old_fp: self._persisted(
+                old_fp,
+                name,
+                booking_aliases=[book],
+                start_iso=start.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+                end_iso=end.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+            )
+        }
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+        reservation.booking_aliases.add(book)
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.BOOKING_ALIAS
+
+    def test_rule4_name_time_match(self) -> None:
+        """Rule 4 fires when name, start, and end all match in the identity dict."""
+        name = "Name Time Guest"
+        start = _dt(2026, 7, 1)
+        end = _dt(2026, 7, 8)
+        # Use a non-sha256 old key to simulate migration (rule 1 won't fire)
+        old_fp = "legacy-migration-key-abc"
+        new_fp = make_reservation_fingerprint("entry-001", name, start, end)
+        assert old_fp != new_fp
+
+        persisted_mappings = {
+            old_fp: self._persisted(
+                old_fp,
+                name,
+                start_iso=start.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+                end_iso=end.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+            )
+        }
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.NAME_TIME
+        assert result.matched_identity_key == old_fp
+
+    def test_rule4_requires_matching_dates(self) -> None:
+        """Rule 4 does not fire when dates in the identity dict differ from reservation."""
+        name = "Date Mismatch Guest"
+        old_fp = "legacy-fp-date-diff"
+        new_fp = make_reservation_fingerprint(
+            "entry-001", name, _dt(2026, 7, 2), _dt(2026, 7, 9)
+        )
+
+        persisted_mappings = {
+            old_fp: self._persisted(
+                old_fp,
+                name,
+                start_iso="2026-07-01T00:00:00+00:00",
+                end_iso="2026-07-08T00:00:00+00:00",
+            )
+        }
+        reservation = Reservation(
+            identity_key=new_fp,
+            start=_dt(2026, 7, 2),
+            end=_dt(2026, 7, 9),
+            buffered_start=_dt(2026, 7, 2),
+            buffered_end=_dt(2026, 7, 9),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        # Dates differ → rule 4 does not fire
+        assert result.kind is not RematchKind.NAME_TIME
+
+    def test_rule4_ambiguous_when_multiple_name_time_matches(self) -> None:
+        """Rule 4 fences duplicate name+date candidates as ambiguous."""
+        name = "Duplicate Name Time"
+        start = _dt(2026, 7, 1)
+        end = _dt(2026, 7, 8)
+        reservation = self._reservation("new-fp-name-time", name)
+        persisted_mappings = {
+            "legacy-name-time-a": self._persisted(
+                "legacy-name-time-a",
+                name,
+                slot=10,
+                start_iso=start.isoformat(),
+                end_iso=end.isoformat(),
+            ),
+            "legacy-name-time-b": self._persisted(
+                "legacy-name-time-b",
+                name,
+                slot=11,
+                start_iso=start.isoformat(),
+                end_iso=end.isoformat(),
+            ),
+        }
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+
+        assert result.kind is RematchKind.AMBIGUOUS
+        assert set(result.ambiguous_keys) == set(persisted_mappings)
+
+    def test_non_adopted_rematch_ignores_stale_observed_name(self) -> None:
+        """Observed name fallback cannot rematch a non-adopted mapping."""
+        persisted = self._persisted(
+            "legacy-alice",
+            "Alice",
+            start_iso=_dt(2026, 7, 1).isoformat(),
+            end_iso=_dt(2026, 7, 8).isoformat(),
+        )
+        persisted["last_observed_actual"]["name_state"] = "Bob"
+        reservation = self._reservation("new-bob", "Bob")
+
+        result = find_reservation_rematch(
+            reservation,
+            {"legacy-alice": persisted},
+            actual_slot_names={10: "Bob"},
+        )
+
+        assert result.kind is RematchKind.NO_MATCH
+
+    def test_non_adopted_rematch_ignores_stale_observed_dates(self) -> None:
+        """Observed date fallback cannot rematch a non-adopted mapping."""
+        name = "Repeat Guest"
+        persisted = self._persisted(
+            "legacy-repeat-old",
+            name,
+            start_iso=_dt(2026, 7, 1).isoformat(),
+            end_iso=_dt(2026, 7, 8).isoformat(),
+        )
+        persisted["last_observed_actual"]["start_state"] = _dt(2026, 7, 10).isoformat()
+        persisted["last_observed_actual"]["end_state"] = _dt(2026, 7, 14).isoformat()
+        reservation = Reservation(
+            identity_key="new-repeat",
+            start=_dt(2026, 7, 10),
+            end=_dt(2026, 7, 14),
+            buffered_start=_dt(2026, 7, 10),
+            buffered_end=_dt(2026, 7, 14),
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+
+        result = find_reservation_rematch(reservation, {"legacy-repeat-old": persisted})
+
+        assert result.kind is not RematchKind.NAME_TIME
+
+    def test_empty_persisted_mappings_returns_no_match(self) -> None:
+        """NO_MATCH returned when there are no persisted mappings at all."""
+        reservation = self._reservation("fp-any", "Anyone")
+        result = find_reservation_rematch(reservation, {})
+        assert result.kind is RematchKind.NO_MATCH
+
+    def test_no_match_when_name_differs_across_all_rules(self) -> None:
+        """NO_MATCH when reservation name differs from all persisted mappings."""
+        old_fp = "fp-alice-only"
+        persisted_mappings = {old_fp: self._persisted(old_fp, "Alice Guest")}
+        reservation = self._reservation("fp-bob-new", "Bob Guest")
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.NO_MATCH
+
+    def test_rule5_continuity_fires_before_no_match(self) -> None:
+        """Rule 5 continuity fires when rule 4 identity dates are absent."""
+        old_fp = "fp-continuity-fires"
+        new_fp = "fp-continuity-new"
+        name = "Continuity Guest"
+
+        persisted_mappings = {
+            old_fp: self._persisted(old_fp, name, fingerprint_history=[new_fp])
+        }
+        reservation = self._reservation(new_fp, name)
+
+        result = find_reservation_rematch(reservation, persisted_mappings)
+        assert result.kind is RematchKind.CONTINUITY
+        assert result.matched_identity_key == old_fp
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for compute_desired_plan tests (T024, T025, T036, T037)
+# ---------------------------------------------------------------------------
+
+
+def _res(
+    identity_key: str,
+    start_day: int,
+    *,
+    start_month: int = 7,
+    eligible: bool = True,
+    protected_active: bool = False,
+    checked_out: bool = False,
+    missing_count: int = 0,
+) -> Reservation:
+    """Return a minimal Reservation for desired-plan tests.
+
+    Start is 2026-<start_month>-<start_day> 14:00 UTC;
+    end is 7 days later at 11:00 UTC (using timedelta to handle month boundaries).
+    """
+    from datetime import timedelta
+
+    start = datetime(2026, start_month, start_day, 14, tzinfo=_TZ)
+    end = (start + timedelta(days=7)).replace(hour=11)
+    return Reservation(
+        identity_key=identity_key,
+        start=start,
+        end=end,
+        buffered_start=start,
+        buffered_end=end,
+        summary=f"Guest {identity_key}",
+        slot_name=f"Guest {identity_key}",
+        display_slot_name=f"RC Guest {identity_key}",
+        slot_code="1234",
+        eligible=eligible,
+        protected_active=protected_active,
+        checked_out=checked_out,
+        missing_count=missing_count,
+    )
+
+
+def _free_slot(slot: int) -> ManagedSlot:
+    """Return a FREE managed slot with no persisted reservation."""
+    return _make_managed_slot(slot=slot, status=SlotStatus.FREE)
+
+
+def _occupied_slot(slot: int, persisted_key: str) -> ManagedSlot:
+    """Return an OCCUPIED managed slot with *persisted_key* as the stored identity."""
+    return _make_managed_slot(
+        slot=slot,
+        status=SlotStatus.OCCUPIED,
+        persisted_identity_key=persisted_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T024: Pure soonest-N overflow tests (max_events=3, five eligible reservations)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDesiredPlanSoonestN:
+    """T024: compute_desired_plan selects the earliest max_events reservations."""
+
+    def _five_reservations(self) -> list[Reservation]:
+        """Return five eligible reservations with sequential start dates."""
+        return [
+            _res("r-jul01", 1),  # earliest
+            _res("r-jul08", 8),
+            _res("r-jul15", 15),
+            _res("r-jul22", 22),
+            _res("r-jul29", 29),  # latest
+        ]
+
+    def _three_free_slots(self) -> list[ManagedSlot]:
+        """Return three free managed slots numbered 5, 6, 7."""
+        return [_free_slot(5), _free_slot(6), _free_slot(7)]
+
+    def test_selects_three_earliest_reservations(self) -> None:
+        """With five eligible reservations and max_events=3, the three earliest
+        by start time are selected."""
+        reservations = self._five_reservations()
+        slots = self._three_free_slots()
+
+        plan = compute_desired_plan(
+            reservations,
+            slots,
+            max_events=3,
+            plan_id="p1",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert set(plan.selected.keys()) == {"r-jul01", "r-jul08", "r-jul15"}
+
+    def test_selected_count_equals_max_events(self) -> None:
+        """selected dict has exactly max_events entries when enough eligible exist."""
+        plan = compute_desired_plan(
+            self._five_reservations(),
+            self._three_free_slots(),
+            max_events=3,
+            plan_id="p1",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert len(plan.selected) == 3
+
+    def test_two_latest_are_overflow(self) -> None:
+        """The two latest reservations end up in plan.overflow."""
+        plan = compute_desired_plan(
+            self._five_reservations(),
+            self._three_free_slots(),
+            max_events=3,
+            plan_id="p1",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-jul22" in plan.overflow
+        assert "r-jul29" in plan.overflow
+
+    def test_selected_and_overflow_are_disjoint(self) -> None:
+        """No identity key appears in both selected and overflow."""
+        plan = compute_desired_plan(
+            self._five_reservations(),
+            self._three_free_slots(),
+            max_events=3,
+            plan_id="p1",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert set(plan.selected.keys()).isdisjoint(plan.overflow.keys())
+
+    def test_overflow_reason_is_capacity(self) -> None:
+        """Overflow reservations have reason 'capacity'."""
+        plan = compute_desired_plan(
+            self._five_reservations(),
+            self._three_free_slots(),
+            max_events=3,
+            plan_id="p1",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.overflow["r-jul22"] == "capacity"
+        assert plan.overflow["r-jul29"] == "capacity"
+
+    def test_empty_reservations_returns_empty_plan(self) -> None:
+        """No reservations → empty selected and overflow."""
+        plan = compute_desired_plan(
+            [],
+            self._three_free_slots(),
+            max_events=3,
+            plan_id="p-empty",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.selected == {}
+        assert plan.overflow == {}
+
+    def test_fewer_reservations_than_max_events(self) -> None:
+        """Two eligible reservations and max_events=3 → both selected, no overflow."""
+        reservations = [_res("r-a", 1), _res("r-b", 8)]
+        plan = compute_desired_plan(
+            reservations,
+            self._three_free_slots(),
+            max_events=3,
+            plan_id="p-few",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert len(plan.selected) == 2
+        assert plan.overflow == {}
+
+    def test_selected_slots_are_unique(self) -> None:
+        """Each selected reservation receives a distinct slot number."""
+        plan = compute_desired_plan(
+            self._five_reservations(),
+            self._three_free_slots(),
+            max_events=3,
+            plan_id="p1",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        slot_values = list(plan.selected.values())
+        assert len(slot_values) == len(set(slot_values)), "duplicate slots in selected"
+
+    def test_selected_identity_keys_are_unique(self) -> None:
+        """Each identity key appears at most once in selected."""
+        plan = compute_desired_plan(
+            self._five_reservations(),
+            self._three_free_slots(),
+            max_events=3,
+            plan_id="p1",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert len(plan.selected) == len(set(plan.selected.keys()))
+
+    def test_plan_validate_returns_no_violations(self) -> None:
+        """compute_desired_plan produces a plan that passes its own validate()."""
+        plan = compute_desired_plan(
+            self._five_reservations(),
+            self._three_free_slots(),
+            max_events=3,
+            plan_id="p1",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.validate() == []
+
+    def test_ineligible_reservation_excluded(self) -> None:
+        """Reservations with eligible=False are never selected or overflowed."""
+        reservations = [
+            _res("r-elig", 1),
+            _res("r-inelig", 3, eligible=False),
+        ]
+        plan = compute_desired_plan(
+            reservations,
+            [_free_slot(5), _free_slot(6)],
+            max_events=3,
+            plan_id="p-inelig",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-inelig" not in plan.selected
+        assert "r-inelig" not in plan.overflow
+
+    def test_checked_out_reservation_excluded(self) -> None:
+        """Reservations with checked_out=True are never selected or overflowed."""
+        reservations = [
+            _res("r-active", 1),
+            _res("r-gone", 3, checked_out=True),
+        ]
+        plan = compute_desired_plan(
+            reservations,
+            [_free_slot(5), _free_slot(6)],
+            max_events=3,
+            plan_id="p-checkout",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-gone" not in plan.selected
+        assert "r-gone" not in plan.overflow
+
+    def test_missing_count_three_excluded_unless_protected(self) -> None:
+        """Reservations with missing_count >= 3 are excluded unless protected_active."""
+        r_missing = _res("r-miss", 1, missing_count=3)
+        r_present = _res("r-here", 3)
+        plan = compute_desired_plan(
+            [r_missing, r_present],
+            [_free_slot(5), _free_slot(6)],
+            max_events=3,
+            plan_id="p-miss",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-miss" not in plan.selected
+        assert "r-miss" not in plan.overflow
+        assert "r-here" in plan.selected
+
+    def test_set_actions_generated_for_free_slots(self) -> None:
+        """Selecting a reservation for a FREE slot produces a SET SlotAction."""
+        plan = compute_desired_plan(
+            [_res("r-a", 1)],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p-set",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        set_actions = [a for a in plan.actions if a.kind is ActionKind.SET]
+        assert len(set_actions) == 1
+        assert set_actions[0].slot == 5
+        assert set_actions[0].identity_key == "r-a"
+
+
+# ---------------------------------------------------------------------------
+# T025: No-farther-before-nearer, tie-breaker, churn minimization, overflow rank
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDesiredPlanChurnAndDiagnostics:
+    """T025: determinism, churn minimization, and overflow-rank diagnostics."""
+
+    def test_no_farther_before_nearer(self) -> None:
+        """A farther persisted reservation is replaced by a nearer new reservation.
+
+        Given max_events=1 and a far reservation that was persisted in slot 5,
+        a nearer reservation should be selected and the far one overflowed.
+        """
+        r_near = _res("r-near", 1)  # July 1 — nearer
+        r_far = _res("r-far", 22)  # July 22 — farther
+
+        # Slot 5 is OCCUPIED with r-far as its persisted assignment; slot 6 is FREE.
+        slots = [
+            _occupied_slot(5, "r-far"),
+            _free_slot(6),
+        ]
+
+        plan = compute_desired_plan(
+            [r_near, r_far],
+            slots,
+            max_events=1,
+            plan_id="p-farther",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-near" in plan.selected
+        assert "r-far" in plan.overflow
+        assert plan.overflow["r-far"] == "capacity"
+
+    def test_equal_start_identity_key_tiebreaker(self) -> None:
+        """When two reservations share the same start, identity_key breaks the tie.
+
+        The lexicographically smaller identity_key is preferred (selected)
+        and the larger is overflowed.
+        """
+        same_start = datetime(2026, 7, 10, 14, tzinfo=_TZ)
+        same_end = datetime(2026, 7, 17, 11, tzinfo=_TZ)
+
+        r_zz = Reservation(
+            identity_key="zz-last",
+            start=same_start,
+            end=same_end,
+            buffered_start=same_start,
+            buffered_end=same_end,
+            summary="Guest ZZ",
+            slot_name="Guest ZZ",
+            display_slot_name="RC Guest ZZ",
+            slot_code="9999",
+        )
+        r_aa = Reservation(
+            identity_key="aa-first",
+            start=same_start,
+            end=same_end,
+            buffered_start=same_start,
+            buffered_end=same_end,
+            summary="Guest AA",
+            slot_name="Guest AA",
+            display_slot_name="RC Guest AA",
+            slot_code="1111",
+        )
+
+        plan = compute_desired_plan(
+            [r_zz, r_aa],
+            [_free_slot(5)],
+            max_events=1,
+            plan_id="p-tie",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        # "aa-first" < "zz-last" lexicographically → "aa-first" wins
+        assert "aa-first" in plan.selected
+        assert "zz-last" in plan.overflow
+
+    def test_churn_minimization_keeps_persisted_slot(self) -> None:
+        """A selected reservation keeps its persisted slot rather than moving.
+
+        R1 is persisted in slot 5 (OCCUPIED) and R2 is new.  With slot 5
+        OCCUPIED by R1 and slot 6 FREE, R1 stays in slot 5 and R2 goes to 6.
+        """
+        r1 = _res("r1", 1)
+        r2 = _res("r2", 8)
+
+        ms5 = _make_managed_slot(
+            slot=5,
+            status=SlotStatus.OCCUPIED,
+            persisted_identity_key="r1",
+            actual_start=r1.buffered_start,
+            actual_end=r1.buffered_end,
+        )
+        ms6 = _free_slot(6)
+
+        plan = compute_desired_plan(
+            [r1, r2],
+            [ms5, ms6],
+            max_events=3,
+            plan_id="p-churn",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        # R1 stays in slot 5 (churn minimization)
+        assert plan.selected.get("r1") == 5
+        # R2 goes to slot 6
+        assert plan.selected.get("r2") == 6
+
+    def test_churn_minimization_noop_action_for_same_reservation_same_dates(
+        self,
+    ) -> None:
+        """When persisted slot dates match desired buffered dates, action is NOOP."""
+        r1 = _res("r1", 1)
+        ms5 = _make_managed_slot(
+            slot=5,
+            status=SlotStatus.OCCUPIED,
+            persisted_identity_key="r1",
+            actual_start=r1.buffered_start,
+            actual_end=r1.buffered_end,
+        )
+
+        plan = compute_desired_plan(
+            [r1],
+            [ms5],
+            max_events=3,
+            plan_id="p-noop",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.slots[5].action is ActionKind.NOOP
+        assert ActionKind.NOOP not in [a.kind for a in plan.actions]
+
+    def test_churn_minimization_update_times_when_dates_differ(self) -> None:
+        """When persisted slot dates differ from desired buffered dates, UPDATE_TIMES."""
+        r1 = _res("r1", 1)
+        old_start = datetime(2026, 6, 25, 14, tzinfo=_TZ)
+        old_end = datetime(2026, 7, 2, 11, tzinfo=_TZ)
+        ms5 = _make_managed_slot(
+            slot=5,
+            status=SlotStatus.OCCUPIED,
+            persisted_identity_key="r1",
+            actual_start=old_start,  # different from r1.buffered_start
+            actual_end=old_end,
+        )
+
+        plan = compute_desired_plan(
+            [r1],
+            [ms5],
+            max_events=3,
+            plan_id="p-update",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.slots[5].action is ActionKind.UPDATE_TIMES
+        update_actions = [a for a in plan.actions if a.kind is ActionKind.UPDATE_TIMES]
+        assert len(update_actions) == 1
+
+    def test_overflow_rank_in_diagnostics(self) -> None:
+        """Overflow reservations have rank and reason recorded in diagnostics."""
+        reservations = [
+            _res("r1", 1),
+            _res("r2", 8),
+            _res("r3", 15),
+            _res("r4", 22),  # overflow rank 4
+            _res("r5", 29),  # overflow rank 5
+        ]
+        slots = [_free_slot(5), _free_slot(6), _free_slot(7)]
+
+        plan = compute_desired_plan(
+            reservations,
+            slots,
+            max_events=3,
+            plan_id="p-rank",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        details = plan.diagnostics.get("overflow_details", {})
+        assert "r4" in details
+        assert "r5" in details
+        assert details["r4"]["rank"] == 4
+        assert details["r5"]["rank"] == 5
+        assert details["r4"]["reason"] == "capacity"
+        assert details["r5"]["reason"] == "capacity"
+
+    def test_overflow_rank_start_after_selected_capacity(self) -> None:
+        """Overflow rank numbering begins right after the last selected position."""
+        # max_events=2 → selected positions 1, 2; overflow starts at 3
+        reservations = [_res(f"r{i}", i) for i in range(1, 6)]
+        slots = [_free_slot(5), _free_slot(6)]
+
+        plan = compute_desired_plan(
+            reservations,
+            slots,
+            max_events=2,
+            plan_id="p-rank2",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        details = plan.diagnostics.get("overflow_details", {})
+        # Overflow reservations should have ranks 3, 4, 5
+        ranks = {v["rank"] for v in details.values()}
+        assert ranks == {3, 4, 5}
+
+    def test_pending_clear_slot_not_used_for_assignment(self) -> None:
+        """A PENDING_CLEAR slot is unavailable; reservation assigned to lowest free."""
+        r1 = _res("r1", 1)
+        ms5 = _make_managed_slot(slot=5, status=SlotStatus.PENDING_CLEAR)
+        ms6 = _free_slot(6)
+
+        plan = compute_desired_plan(
+            [r1],
+            [ms5, ms6],
+            max_events=3,
+            plan_id="p-pending",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        # r1 must go to slot 6, not slot 5
+        assert plan.selected.get("r1") == 6
+        assert plan.slots[5].action is ActionKind.RETRY_CLEAR
+
+    def test_blocked_slot_not_used_for_assignment(self) -> None:
+        """A BLOCKED slot is unavailable; reservation assigned to lowest free."""
+        r1 = _res("r1", 1)
+        ms5 = _make_managed_slot(slot=5, status=SlotStatus.BLOCKED)
+        ms6 = _free_slot(6)
+
+        plan = compute_desired_plan(
+            [r1],
+            [ms5, ms6],
+            max_events=3,
+            plan_id="p-blocked",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.selected.get("r1") == 6
+        assert plan.slots[5].action is ActionKind.BLOCKED
+
+    def test_unknown_slot_not_used_for_assignment(self) -> None:
+        """An UNKNOWN slot is unavailable; reservation goes to a free slot."""
+        r1 = _res("r1", 1)
+        ms5 = _make_managed_slot(slot=5, status=SlotStatus.UNKNOWN)
+        ms6 = _free_slot(6)
+
+        plan = compute_desired_plan(
+            [r1],
+            [ms5, ms6],
+            max_events=3,
+            plan_id="p-unknown",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.selected.get("r1") == 6
+        assert plan.slots[5].action is ActionKind.BLOCKED
+
+    def test_occupied_slot_with_no_desired_gets_clear_action(self) -> None:
+        """An OCCUPIED slot with no desired reservation produces a CLEAR action."""
+        # One slot occupied with an old reservation, no eligible reservations
+        ms5 = _occupied_slot(5, "r-old")
+
+        plan = compute_desired_plan(
+            [],
+            [ms5],
+            max_events=3,
+            plan_id="p-clear",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.slots[5].action is ActionKind.CLEAR
+
+
+# ---------------------------------------------------------------------------
+# T036: Active checked-in guest selected before overflow, retains slot
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDesiredPlanProtectedActive:
+    """T036: protected active reservations are always selected first."""
+
+    def test_protected_selected_even_when_capacity_is_full(self) -> None:
+        """A protected active reservation is selected even when non-protected
+        reservations would fill all capacity.
+
+        With max_events=3 and one protected + four non-protected eligible
+        reservations, the plan selects: 1 protected + 2 earliest non-protected.
+        """
+        r_protected = _res("r-prot", 1, protected_active=True)
+        r_np1 = _res("r-np1", 3)  # soonest non-protected
+        r_np2 = _res("r-np2", 10)
+        r_np3 = _res("r-np3", 17)
+        r_np4 = _res("r-np4", 24)
+
+        slots = [_free_slot(5), _free_slot(6), _free_slot(7)]
+
+        plan = compute_desired_plan(
+            [r_protected, r_np1, r_np2, r_np3, r_np4],
+            slots,
+            max_events=3,
+            plan_id="p-prot",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-prot" in plan.selected
+        assert "r-np1" in plan.selected
+        assert "r-np2" in plan.selected
+        # np3 and np4 should be in overflow
+        assert "r-np3" in plan.overflow
+        assert "r-np4" in plan.overflow
+
+    def test_protected_identity_in_plan_protected_set(self) -> None:
+        """Protected reservations appear in plan.protected."""
+        r_prot = _res("r-prot", 1, protected_active=True)
+
+        plan = compute_desired_plan(
+            [r_prot],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p-pset",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-prot" in plan.protected
+
+    def test_non_protected_not_in_plan_protected_set(self) -> None:
+        """Non-protected selected reservations do not appear in plan.protected."""
+        r_np = _res("r-np", 1)
+
+        plan = compute_desired_plan(
+            [r_np],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p-notprot",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-np" not in plan.protected
+
+    def test_protected_retains_persisted_slot(self) -> None:
+        """A protected active reservation retains its persisted slot.
+
+        Even when a non-protected reservation was also in the system,
+        the protected guest keeps its previously-assigned slot.
+        """
+        r_prot = _res("r-prot", 1, protected_active=True)
+        r_np = _res("r-np", 8)
+
+        ms5 = _occupied_slot(5, "r-prot")
+        ms5.actual_start = r_prot.buffered_start
+        ms5.actual_end = r_prot.buffered_end
+        ms6 = _free_slot(6)
+
+        plan = compute_desired_plan(
+            [r_prot, r_np],
+            [ms5, ms6],
+            max_events=3,
+            plan_id="p-retain",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        # Protected reservation stays in slot 5
+        assert plan.selected.get("r-prot") == 5
+        # Non-protected gets slot 6
+        assert plan.selected.get("r-np") == 6
+
+    def test_protected_slot_gets_noop_when_dates_match(self) -> None:
+        """Protected reservation with matching dates produces NOOP for its slot."""
+        r_prot = _res("r-prot", 1, protected_active=True)
+        ms5 = _make_managed_slot(
+            slot=5,
+            status=SlotStatus.OCCUPIED,
+            persisted_identity_key="r-prot",
+            actual_start=r_prot.buffered_start,
+            actual_end=r_prot.buffered_end,
+        )
+
+        plan = compute_desired_plan(
+            [r_prot],
+            [ms5],
+            max_events=3,
+            plan_id="p-prot-noop",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.slots[5].action is ActionKind.NOOP
+
+    def test_protected_pending_clear_slot_is_blocked_not_retried(self) -> None:
+        """A protected active guest in pending-clear is not cleared mid-stay."""
+        r_prot = _res("r-prot", 1, protected_active=True)
+        ms5 = _make_managed_slot(
+            slot=5,
+            status=SlotStatus.PENDING_CLEAR,
+            persisted_identity_key="r-prot",
+            blocked_reason="pending_clear",
+        )
+
+        plan = compute_desired_plan(
+            [r_prot],
+            [ms5],
+            max_events=1,
+            plan_id="p-protected-pending",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.slots[5].action is ActionKind.BLOCKED
+        assert plan.slots[5].pending_reason == "protected_active_pending_clear"
+        assert all(action.kind is not ActionKind.RETRY_CLEAR for action in plan.actions)
+
+    def test_overflow_reservation_reason_is_capacity(self) -> None:
+        """Non-protected reservations overflow with reason 'capacity'."""
+        r_prot = _res("r-prot", 1, protected_active=True)
+        r_np1 = _res("r-np1", 8)
+        r_np2 = _res("r-np2", 15)  # overflows
+
+        slots = [_free_slot(5), _free_slot(6)]  # max capacity = 2
+
+        plan = compute_desired_plan(
+            [r_prot, r_np1, r_np2],
+            slots,
+            max_events=2,
+            plan_id="p-cap-reason",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.overflow.get("r-np2") == "capacity"
+
+    def test_protected_in_selected_not_overflow(self) -> None:
+        """A protected active reservation is never in overflow."""
+        r_prot = _res("r-prot", 1, protected_active=True)
+        r_np1 = _res("r-np1", 2)
+        r_np2 = _res("r-np2", 3)
+
+        # Protected reservation has its own persisted slot; one more free slot.
+        ms_prot = _occupied_slot(5, "r-prot")
+        ms_prot.actual_start = r_prot.buffered_start
+        ms_prot.actual_end = r_prot.buffered_end
+        ms6 = _free_slot(6)
+
+        plan = compute_desired_plan(
+            [r_prot, r_np1, r_np2],
+            [ms_prot, ms6],
+            max_events=2,
+            plan_id="p-prot-notov",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-prot" in plan.selected
+        assert "r-prot" not in plan.overflow
+
+
+# ---------------------------------------------------------------------------
+# T037: Protected guests count against capacity; protection-expiry tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDesiredPlanProtectionCapacity:
+    """T037: protected_active counts against capacity; expiry scenarios."""
+
+    def test_two_protected_reduce_nonprotected_capacity(self) -> None:
+        """Two protected active reservations consume 2 of 3 max_events slots,
+        leaving only 1 slot for non-protected reservations."""
+        r_p1 = _res("r-p1", 1, protected_active=True)
+        r_p2 = _res("r-p2", 2, protected_active=True)
+        r_np1 = _res("r-np1", 5)
+        r_np2 = _res("r-np2", 12)
+        r_np3 = _res("r-np3", 19)
+
+        slots = [_free_slot(5), _free_slot(6), _free_slot(7)]
+
+        plan = compute_desired_plan(
+            [r_p1, r_p2, r_np1, r_np2, r_np3],
+            slots,
+            max_events=3,
+            plan_id="p-2prot",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        # Both protected selected
+        assert "r-p1" in plan.selected
+        assert "r-p2" in plan.selected
+        # Only soonest non-protected fills remaining capacity = max(0, 3-2) = 1
+        assert "r-np1" in plan.selected
+        assert "r-np2" in plan.overflow
+        assert "r-np3" in plan.overflow
+
+    def test_three_protected_fills_all_capacity_no_nonprotected(self) -> None:
+        """Three protected active reservations consume all max_events=3 slots;
+        no non-protected reservation is selected."""
+        protected = [_res(f"r-p{i}", i, protected_active=True) for i in range(1, 4)]
+        non_protected = [_res(f"r-np{i}", i + 5) for i in range(1, 4)]
+
+        slots = [_free_slot(5), _free_slot(6), _free_slot(7)]
+
+        plan = compute_desired_plan(
+            protected + non_protected,
+            slots,
+            max_events=3,
+            plan_id="p-3prot",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        for p in protected:
+            assert p.identity_key in plan.selected
+        for np in non_protected:
+            assert np.identity_key in plan.overflow
+
+    def test_protection_expiry_checked_out_not_selected(self) -> None:
+        """A reservation with checked_out=True loses protection and is excluded
+        from both selected and overflow — it is no longer an eligible candidate."""
+        r_expired = _res("r-exp", 1, checked_out=True)
+        r_active = _res("r-active", 8)
+
+        plan = compute_desired_plan(
+            [r_expired, r_active],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p-expiry",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-exp" not in plan.selected
+        assert "r-exp" not in plan.overflow
+        assert "r-active" in plan.selected
+
+    def test_protection_expiry_not_in_plan_protected_set(self) -> None:
+        """A checked-out reservation does not appear in plan.protected."""
+        r_expired = _res("r-exp", 1, checked_out=True)
+
+        plan = compute_desired_plan(
+            [r_expired],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p-pset-exp",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-exp" not in plan.protected
+
+    def test_missing_count_three_protected_still_selected(self) -> None:
+        """A protected active reservation with missing_count=3 is still selected.
+
+        Protection overrides the feed-miss clearability threshold.
+        """
+        r_prot_miss = _res("r-miss-prot", 1, protected_active=True, missing_count=3)
+
+        plan = compute_desired_plan(
+            [r_prot_miss],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p-miss-prot",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-miss-prot" in plan.selected
+        assert "r-miss-prot" in plan.protected
+
+    def test_missing_count_three_non_protected_excluded(self) -> None:
+        """A non-protected reservation with missing_count=3 is excluded entirely."""
+        r_miss = _res("r-miss", 1, missing_count=3)
+
+        plan = compute_desired_plan(
+            [r_miss],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p-miss-np",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert "r-miss" not in plan.selected
+        assert "r-miss" not in plan.overflow
+
+    def test_protected_set_is_subset_of_selected(self) -> None:
+        """Every identity key in plan.protected is also in plan.selected."""
+        r_prot = _res("r-prot", 1, protected_active=True)
+        r_np = _res("r-np", 8)
+
+        plan = compute_desired_plan(
+            [r_prot, r_np],
+            [_free_slot(5), _free_slot(6)],
+            max_events=3,
+            plan_id="p-pset-sub",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.protected.issubset(plan.selected.keys())
+
+    def test_no_duplicate_slots_with_protected_and_nonprotected(self) -> None:
+        """Protected and non-protected reservations never share a slot."""
+        r_prot = _res("r-prot", 1, protected_active=True)
+        r_np = _res("r-np", 8)
+
+        plan = compute_desired_plan(
+            [r_prot, r_np],
+            [_free_slot(5), _free_slot(6)],
+            max_events=3,
+            plan_id="p-nodupe",
+            generated_at=_dt(2026, 7, 1),
+        )
+
+        assert plan.validate() == []
+
+
+# ---------------------------------------------------------------------------
+# T092: Per-reservation diagnostics in compute_desired_plan
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDesiredPlanDiagnostics:
+    """T092: Verify per-reservation and per-slot diagnostics in plan.diagnostics.
+
+    Checks that plan.diagnostics contains the expected keys and that
+    per-reservation entries expose selected/protected/overflow/missing_count/
+    assigned_slot/uid_aliases/booking_aliases without leaking slot_code.
+    """
+
+    def test_diagnostics_has_plan_id_and_generated_at(self) -> None:
+        """plan.diagnostics contains plan_id and generated_at."""
+        r = _res("r-diag-001", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="test-diag-plan",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["plan_id"] == "test-diag-plan"
+        assert "generated_at" in plan.diagnostics
+
+    def test_diagnostics_has_entry_id_when_provided(self) -> None:
+        """entry_id keyword arg appears in plan.diagnostics."""
+        r = _res("r-entry", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+            entry_id="entry-001",
+        )
+        assert plan.diagnostics["entry_id"] == "entry-001"
+
+    def test_diagnostics_has_lockname_and_start_slot_when_provided(self) -> None:
+        """lockname and start_slot keyword args appear in plan.diagnostics."""
+        r = _res("r-lock", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+            lockname="front_door",
+            start_slot=5,
+        )
+        assert plan.diagnostics["lockname"] == "front_door"
+        assert plan.diagnostics["start_slot"] == 5
+
+    def test_diagnostics_has_reservations_key(self) -> None:
+        """plan.diagnostics['reservations'] is present."""
+        r = _res("r-dict", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert "reservations" in plan.diagnostics
+
+    def test_per_reservation_selected_true_when_assigned(self) -> None:
+        """A reservation in plan.selected has selected=True in diagnostics."""
+        r = _res("r-sel", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["reservations"]["r-sel"]["selected"] is True
+
+    def test_per_reservation_selected_false_when_overflow(self) -> None:
+        """An overflow reservation has selected=False in diagnostics."""
+        reservations = [_res("r-a", 1), _res("r-b", 8), _res("r-c", 15)]
+        plan = compute_desired_plan(
+            reservations,
+            [_free_slot(5), _free_slot(6)],
+            max_events=2,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        # r-c is the third reservation; max_events=2 so it overflows
+        assert plan.diagnostics["reservations"]["r-c"]["selected"] is False
+
+    def test_per_reservation_protected_true_when_active(self) -> None:
+        """A protected active reservation has protected=True in diagnostics."""
+        r_prot = _res("r-prot", 1, protected_active=True)
+        r_np = _res("r-np", 8)
+        plan = compute_desired_plan(
+            [r_prot, r_np],
+            [_free_slot(5), _free_slot(6)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["reservations"]["r-prot"]["protected"] is True
+        assert plan.diagnostics["reservations"]["r-np"]["protected"] is False
+
+    def test_per_reservation_overflow_reason_capacity(self) -> None:
+        """An overflow reservation has overflow_reason='capacity' in diagnostics."""
+        reservations = [_res("r-a", 1), _res("r-b", 8), _res("r-c", 15)]
+        plan = compute_desired_plan(
+            reservations,
+            [_free_slot(5), _free_slot(6)],
+            max_events=2,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["reservations"]["r-c"]["overflow_reason"] == "capacity"
+
+    def test_per_reservation_overflow_reason_none_when_selected(self) -> None:
+        """A selected reservation has overflow_reason=None in diagnostics."""
+        r = _res("r-sel", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["reservations"]["r-sel"]["overflow_reason"] is None
+
+    def test_per_reservation_missing_count(self) -> None:
+        """missing_count is reflected in per-reservation diagnostics."""
+        r = _res("r-miss", 1, missing_count=2)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["reservations"]["r-miss"]["missing_count"] == 2
+
+    def test_per_reservation_assigned_slot_matches_selected(self) -> None:
+        """assigned_slot in diagnostics matches plan.selected."""
+        r = _res("r-as", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["reservations"]["r-as"]["assigned_slot"] == 5
+
+    def test_per_reservation_assigned_slot_none_when_overflow(self) -> None:
+        """Overflow reservations have assigned_slot=None in diagnostics."""
+        reservations = [_res("r-a", 1), _res("r-ov", 8)]
+        plan = compute_desired_plan(
+            reservations,
+            [_free_slot(5)],
+            max_events=1,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["reservations"]["r-ov"]["assigned_slot"] is None
+
+    def test_per_reservation_uid_aliases_present(self) -> None:
+        """uid_aliases are included in per-reservation diagnostics."""
+        from datetime import timedelta
+
+        start = _dt(2026, 7, 1, 14)
+        end = start + timedelta(days=7)
+        r = Reservation(
+            identity_key="r-uid",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Guest UID",
+            slot_name="Guest UID",
+            display_slot_name="RC Guest UID",
+            slot_code="5678",
+            uid_aliases={"uid-abc123"},
+        )
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert "uid-abc123" in plan.diagnostics["reservations"]["r-uid"]["uid_aliases"]
+
+    def test_per_reservation_booking_aliases_present(self) -> None:
+        """booking_aliases are included in per-reservation diagnostics."""
+        from datetime import timedelta
+
+        start = _dt(2026, 7, 1, 14)
+        end = start + timedelta(days=7)
+        r = Reservation(
+            identity_key="r-book",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Guest Book",
+            slot_name="Guest Book",
+            display_slot_name="RC Guest Book",
+            slot_code="5678",
+            booking_aliases={"HMABCDEF1234"},
+        )
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert (
+            "HMABCDEF1234"
+            in plan.diagnostics["reservations"]["r-book"]["booking_aliases"]
+        )
+
+    def test_per_reservation_slot_code_not_in_diagnostics(self) -> None:
+        """slot_code is never exposed in per-reservation diagnostics."""
+        from datetime import timedelta
+
+        start = _dt(2026, 7, 1, 14)
+        end = start + timedelta(days=7)
+        r = Reservation(
+            identity_key="r-code",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Guest Code",
+            slot_name="Guest Code",
+            display_slot_name="RC Guest Code",
+            slot_code="SECRETPIN",
+        )
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        res_diag = plan.diagnostics["reservations"]["r-code"]
+        assert "slot_code" not in res_diag
+        # The secret PIN must not appear anywhere in the diagnostics string
+        assert "SECRETPIN" not in str(plan.diagnostics)
+
+    def test_diagnostics_has_slots_key(self) -> None:
+        """plan.diagnostics['slots'] contains per-slot entries."""
+        r = _res("r-slotkey", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert "slots" in plan.diagnostics
+        assert 5 in plan.diagnostics["slots"]
+
+    def test_per_slot_desired_identity_key(self) -> None:
+        """Per-slot diagnostics includes the desired_identity_key."""
+        r = _res("r-dik", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        slot_diag = plan.diagnostics["slots"][5]
+        assert slot_diag["desired_identity_key"] == "r-dik"
+        assert "actual_classification" in slot_diag
+        assert "action" in slot_diag
+        assert "retry_count" in slot_diag
+
+    def test_per_slot_last_error_from_managed_slot(self) -> None:
+        """last_error from ManagedSlot is carried into per-slot diagnostics."""
+        r = _res("r-err", 1)
+        ms = ManagedSlot(
+            slot=5,
+            managed=True,
+            status=SlotStatus.FREE,
+            last_error="previous set failed",
+        )
+        plan = compute_desired_plan(
+            [r],
+            [ms],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["slots"][5]["last_error"] == "previous set failed"
+
+    def test_per_slot_last_error_none_when_no_error(self) -> None:
+        """last_error is None in diagnostics when ManagedSlot has no error."""
+        r = _res("r-noerr", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert plan.diagnostics["slots"][5]["last_error"] is None
+
+    def test_diagnostics_no_optional_keys_when_not_provided(self) -> None:
+        """entry_id, lockname, start_slot absent when not passed."""
+        r = _res("r-noopt", 1)
+        plan = compute_desired_plan(
+            [r],
+            [_free_slot(5)],
+            max_events=3,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert "entry_id" not in plan.diagnostics
+        assert "lockname" not in plan.diagnostics
+        assert "start_slot" not in plan.diagnostics
+
+    def test_overflow_details_preserved_in_diagnostics(self) -> None:
+        """Existing overflow_details from overflow list survive the merge."""
+        reservations = [_res("r-a", 1), _res("r-b", 8), _res("r-c", 15)]
+        plan = compute_desired_plan(
+            reservations,
+            [_free_slot(5), _free_slot(6)],
+            max_events=2,
+            plan_id="p",
+            generated_at=_dt(2026, 7, 1),
+        )
+        assert "overflow_details" in plan.diagnostics
+        assert "r-c" in plan.diagnostics["overflow_details"]
+
+
+# ---------------------------------------------------------------------------
+# T071: Manual drift overwrite action tests
+# ---------------------------------------------------------------------------
+
+
+class TestManualDriftOverwriteAction:
+    """T071: Tests that compute_desired_plan generates OVERWRITE_MANUAL_CHANGE
+    actions for managed-slot drift while preserving desired reservation identity
+    and excluding raw PIN data from all diagnostics.
+
+    Drift scenarios covered: name, code absence, date-range switch off, and
+    combined field drift.  Pure date-only drift preserves the existing
+    UPDATE_TIMES behaviour.  Unmanaged slots are always ignored.
+    """
+
+    def _drift_res(
+        self,
+        identity_key: str = "r-drift",
+        *,
+        slot_name: str = "Guest Drift",
+        display_slot_name: str = "RC Guest Drift",
+        slot_code: str = "DRIFTPIN",
+    ) -> Reservation:
+        """Return a Reservation suitable for drift tests."""
+        from datetime import timedelta
+
+        s = datetime(2026, 8, 1, 14, tzinfo=_TZ)
+        e = s + timedelta(days=7)
+        return Reservation(
+            identity_key=identity_key,
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary=f"Guest {identity_key}",
+            slot_name=slot_name,
+            display_slot_name=display_slot_name,
+            slot_code=slot_code,
+        )
+
+    def _occupied_drifted_slot(
+        self,
+        slot: int,
+        persisted_key: str,
+        *,
+        actual_name: str | None = None,
+        actual_code_present: bool | None = None,
+        date_range_enabled: bool | None = None,
+        actual_start=None,
+        actual_end=None,
+    ) -> ManagedSlot:
+        """Return an OCCUPIED ManagedSlot with specified observed state."""
+        return ManagedSlot(
+            slot=slot,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name=actual_name,
+            actual_code_present=actual_code_present,
+            date_range_enabled=date_range_enabled,
+            actual_start=actual_start,
+            actual_end=actual_end,
+            persisted_identity_key=persisted_key,
+        )
+
+    def test_name_drift_generates_overwrite_action(self) -> None:
+        """OCCUPIED slot with wrong name → OVERWRITE_MANUAL_CHANGE action."""
+        res = self._drift_res(display_slot_name="RC Guest Drift")
+        ms = self._occupied_drifted_slot(
+            5,
+            "r-drift",
+            actual_name="WRONG NAME",  # differs from display_slot_name
+            actual_code_present=True,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t071-name",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        overwrite_actions = [
+            a for a in plan.actions if a.kind is ActionKind.OVERWRITE_MANUAL_CHANGE
+        ]
+        assert len(overwrite_actions) == 1
+        assert overwrite_actions[0].slot == 5
+
+    def test_overwrite_action_preserves_desired_identity_key(self) -> None:
+        """OVERWRITE_MANUAL_CHANGE action carries the desired reservation's identity."""
+        res = self._drift_res(identity_key="r-preserve-id")
+        ms = self._occupied_drifted_slot(
+            5,
+            "r-preserve-id",
+            actual_name="WRONG NAME",
+            actual_code_present=True,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t071-identity",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        overwrite_actions = [
+            a for a in plan.actions if a.kind is ActionKind.OVERWRITE_MANUAL_CHANGE
+        ]
+        assert overwrite_actions[0].identity_key == "r-preserve-id"
+
+    def test_overwrite_reason_contains_drifted_field_names(self) -> None:
+        """Action reason string lists the drifted field names."""
+        res = self._drift_res(display_slot_name="RC Guest Drift")
+        ms = self._occupied_drifted_slot(
+            5,
+            "r-drift",
+            actual_name="WRONG NAME",
+            actual_code_present=True,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t071-reason",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        overwrite_actions = [
+            a for a in plan.actions if a.kind is ActionKind.OVERWRITE_MANUAL_CHANGE
+        ]
+        assert overwrite_actions[0].reason is not None
+        assert "name" in (overwrite_actions[0].reason or "")
+
+    def test_date_range_switch_off_generates_overwrite_action(self) -> None:
+        """date_range_enabled=False with matching name → OVERWRITE_MANUAL_CHANGE."""
+        res = self._drift_res(display_slot_name="RC Guest Drift")
+        ms = self._occupied_drifted_slot(
+            5,
+            "r-drift",
+            actual_name="RC Guest Drift",  # name matches
+            actual_code_present=True,
+            date_range_enabled=False,  # switch was turned off manually
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t071-switch",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        overwrite_actions = [
+            a for a in plan.actions if a.kind is ActionKind.OVERWRITE_MANUAL_CHANGE
+        ]
+        assert len(overwrite_actions) == 1
+        reason = overwrite_actions[0].reason or ""
+        assert "date_range_enabled" in reason
+
+    def test_pure_date_drift_still_generates_update_times(self) -> None:
+        """When only dates differ (no name/code/switch drift), UPDATE_TIMES is used."""
+        res = self._drift_res()
+        from datetime import timedelta
+
+        old_start = datetime(2026, 7, 25, 14, tzinfo=_TZ)
+        old_end = old_start + timedelta(days=7)
+        ms = self._occupied_drifted_slot(
+            5,
+            "r-drift",
+            actual_name=None,  # no observed name → no name drift check
+            date_range_enabled=None,  # no switch observation
+            actual_start=old_start,
+            actual_end=old_end,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t071-dates",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        update_actions = [a for a in plan.actions if a.kind is ActionKind.UPDATE_TIMES]
+        overwrite_actions = [
+            a for a in plan.actions if a.kind is ActionKind.OVERWRITE_MANUAL_CHANGE
+        ]
+        assert len(update_actions) == 1
+        assert len(overwrite_actions) == 0
+
+    def test_name_and_date_drift_combined_generates_overwrite(self) -> None:
+        """Name drift combined with date drift → OVERWRITE_MANUAL_CHANGE with both fields."""
+        from datetime import timedelta
+
+        res = self._drift_res(display_slot_name="RC Guest Drift")
+        old_start = datetime(2026, 7, 25, 14, tzinfo=_TZ)
+        old_end = old_start + timedelta(days=7)
+        ms = self._occupied_drifted_slot(
+            5,
+            "r-drift",
+            actual_name="WRONG NAME",
+            actual_code_present=True,
+            actual_start=old_start,
+            actual_end=old_end,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t071-combo",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        overwrite_actions = [
+            a for a in plan.actions if a.kind is ActionKind.OVERWRITE_MANUAL_CHANGE
+        ]
+        assert len(overwrite_actions) == 1
+        reason = overwrite_actions[0].reason or ""
+        assert "name" in reason
+        # Dates are also included in the reason for completeness
+        assert "start" in reason or "end" in reason
+
+    def test_diagnostics_includes_drift_fields_for_overwrite_action(self) -> None:
+        """plan.diagnostics['slots'] captures drift_fields for OVERWRITE action."""
+        res = self._drift_res(display_slot_name="RC Guest Drift")
+        ms = self._occupied_drifted_slot(
+            5,
+            "r-drift",
+            actual_name="WRONG NAME",
+            actual_code_present=True,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t071-diag",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        slot_diag = plan.diagnostics["slots"][5]
+        assert slot_diag["action"] == ActionKind.OVERWRITE_MANUAL_CHANGE.value
+        assert "drift_fields" in slot_diag
+        assert "name" in slot_diag["drift_fields"]
+
+    def test_diagnostics_no_raw_pin_in_overwrite_context(self) -> None:
+        """Raw PIN values must not appear anywhere in plan diagnostics."""
+        res = self._drift_res(slot_code="SUPERSECRETPIN")
+        ms = self._occupied_drifted_slot(
+            5,
+            "r-drift",
+            actual_name="WRONG NAME",
+            actual_code_present=True,
+        )
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t071-nopin",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        assert "SUPERSECRETPIN" not in str(plan.diagnostics)
+        assert "slot_code" not in str(plan.diagnostics)
+
+    def test_unmanaged_slot_with_name_drift_is_ignored(self) -> None:
+        """Unmanaged slot with drifted name generates no action whatsoever."""
+        res = self._drift_res()
+        unmanaged = ManagedSlot(
+            slot=3,
+            managed=False,  # outside RC range
+            status=SlotStatus.OCCUPIED,
+            actual_name="WRONG NAME",
+            actual_code_present=True,
+            persisted_identity_key="r-drift",
+        )
+        managed_free = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [res],
+            [unmanaged, managed_free],
+            max_events=3,
+            plan_id="t071-unmanaged",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        # No actions referencing slot 3
+        assert not any(a.slot == 3 for a in plan.actions)
+        assert 3 not in plan.slots
+
+
+# ---------------------------------------------------------------------------
+# T046 – no reservation in two desired slots; no slot with two reservations
+# ---------------------------------------------------------------------------
+
+
+class TestDesiredPlanInvariants:
+    """T046: Invariant tests for compute_desired_plan and DesiredPlan.validate().
+
+    Proves two structural invariants of the desired plan:
+
+    1. No single reservation identity appears in two desired slots
+       (plan.selected maps each identity key to at most one slot).
+    2. No single slot is claimed by two different reservations
+       (plan.selected maps each slot number to at most one identity).
+
+    Both invariants hold by construction because compute_desired_plan uses a
+    dict for slot assignment, but validate() also checks them so that any
+    future bug in the planner produces a clear diagnostic rather than silent
+    double-assignment.
+    """
+
+    _TZ = timezone.utc
+
+    def _mk(self, key: str, day: int) -> Reservation:
+        """Return a minimal Reservation starting on *day* of August 2026."""
+        s = _dt(2026, 8, day)
+        e = _dt(2026, 8, day + 7)
+        return Reservation(
+            identity_key=key,
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary=f"Guest {key}",
+            slot_name=f"Guest {key}",
+            display_slot_name=f"RC Guest {key}",
+            slot_code="INVPIN",
+        )
+
+    def _free(self, slot: int) -> ManagedSlot:
+        """Return a FREE managed slot."""
+        return ManagedSlot(slot=slot, managed=True, status=SlotStatus.FREE)
+
+    # ------------------------------------------------------------------
+    # Invariant 1: no reservation in two desired slots
+    # ------------------------------------------------------------------
+
+    def test_no_reservation_in_two_desired_slots_two_slots(self) -> None:
+        """A reservation can only be selected for one slot, even with two free slots."""
+        r = self._mk("r-once", 1)
+        plan = compute_desired_plan(
+            [r],
+            [self._free(3), self._free(5)],
+            max_events=3,
+            plan_id="t046-one-res",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        # plan.selected must have exactly one entry for r-once
+        assert list(plan.selected.keys()).count("r-once") == 1
+        # validate() must report no violations
+        assert plan.validate() == []
+
+    def test_no_reservation_in_two_desired_slots_many_reservations(self) -> None:
+        """Each of N reservations maps to exactly one slot (N ≤ max_events)."""
+        reservations = [self._mk(f"r-{i}", i + 1) for i in range(3)]
+        slots = [self._free(i + 1) for i in range(3)]
+
+        plan = compute_desired_plan(
+            reservations,
+            slots,
+            max_events=3,
+            plan_id="t046-n-res",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        # Each identity key appears exactly once in selected
+        for res in reservations:
+            assert list(plan.selected.keys()).count(res.identity_key) == 1
+        assert plan.validate() == []
+
+    # ------------------------------------------------------------------
+    # Invariant 2: no slot with two reservations
+    # ------------------------------------------------------------------
+
+    def test_no_slot_with_two_reservations_by_construction(self) -> None:
+        """Two reservations never end up in the same slot."""
+        r1 = self._mk("r-a", 1)
+        r2 = self._mk("r-b", 8)
+
+        plan = compute_desired_plan(
+            [r1, r2],
+            [self._free(3), self._free(5)],
+            max_events=2,
+            plan_id="t046-two-res",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        # Each slot must appear at most once across all selected values
+        slot_values = list(plan.selected.values())
+        assert len(slot_values) == len(set(slot_values))
+        assert plan.validate() == []
+
+    def test_no_slot_with_two_reservations_persisted_conflict(self) -> None:
+        """Two reservations with the same persisted slot still end up in different slots.
+
+        When two reservations both have persisted_identity_key pointing to the
+        same ManagedSlot, _try_assign assigns the first reservation to that slot
+        and the second to a different free slot.  The resulting plan.selected must
+        still have distinct slots for both.
+        """
+        r1 = self._mk("r-first", 1)
+        r2 = self._mk("r-second", 8)
+
+        # Both reservations' persisted identity is on slot 3 (only first wins)
+        slot3 = ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            persisted_identity_key="r-first",  # r-first wins the persisted slot
+            actual_start=r1.buffered_start,
+            actual_end=r1.buffered_end,
+        )
+        slot5 = ManagedSlot(slot=5, managed=True, status=SlotStatus.FREE)
+
+        plan = compute_desired_plan(
+            [r1, r2],
+            [slot3, slot5],
+            max_events=2,
+            plan_id="t046-conflict",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        if "r-first" in plan.selected and "r-second" in plan.selected:
+            assert plan.selected["r-first"] != plan.selected["r-second"]
+        assert plan.validate() == []
+
+    # ------------------------------------------------------------------
+    # validate() mutation tests
+    # ------------------------------------------------------------------
+
+    def test_validate_returns_empty_for_valid_plan(self) -> None:
+        """validate() returns [] when plan.selected has no conflicts."""
+        plan = DesiredPlan(
+            plan_id="t046-valid",
+            generated_at=_dt(2026, 8, 1),
+        )
+        plan.selected = {"r-a": 3, "r-b": 5}
+        assert plan.validate() == []
+
+    def test_validate_detects_slot_collision(self) -> None:
+        """validate() returns a violation when two identity keys map to the same slot.
+
+        This state cannot arise from compute_desired_plan normally, but validate()
+        is available to detect it defensively.
+        """
+        plan = DesiredPlan(
+            plan_id="t046-slot-collision",
+            generated_at=_dt(2026, 8, 1),
+        )
+        # Manually inject a slot collision by building the underlying dict directly
+        plan.selected["r-a"] = 3
+        plan.selected["r-b"] = 3  # same slot — collision
+
+        violations = plan.validate()
+        assert len(violations) >= 1
+        assert any("3" in v for v in violations)
+
+    def test_validate_empty_plan_no_violations(self) -> None:
+        """An empty plan (no selected reservations) validates cleanly."""
+        plan = DesiredPlan(plan_id="t046-empty", generated_at=_dt(2026, 8, 1))
+        assert plan.validate() == []
+
+    def test_invariant_holds_at_capacity(self) -> None:
+        """Invariants hold when reservations exactly fill managed capacity."""
+        reservations = [self._mk(f"r-{i}", i + 1) for i in range(5)]
+        slots = [self._free(i + 1) for i in range(5)]
+
+        plan = compute_desired_plan(
+            reservations,
+            slots,
+            max_events=5,
+            plan_id="t046-full",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        assert plan.validate() == []
+        # Each slot number appears exactly once
+        slot_values = list(plan.selected.values())
+        assert len(slot_values) == len(set(slot_values))
+        # Each identity key appears exactly once
+        key_values = list(plan.selected.keys())
+        assert len(key_values) == len(set(key_values))
+
+
+# ---------------------------------------------------------------------------
+# T089: Feed-miss lifecycle — missing_count tolerance and clearability
+# ---------------------------------------------------------------------------
+
+
+class TestFeedMissLifecycle:
+    """T089: Reservations with missing_count 0–2 remain eligible; missing_count 3
+    makes them clearable (excluded from eligible candidates so the planner
+    generates a CLEAR action for their slot).
+
+    These tests exercise :func:`~.reconciliation._filter_eligible` and the
+    resulting plan actions for the three miss-tolerance states.
+    """
+
+    def _mk(
+        self,
+        key: str,
+        day: int = 1,
+        *,
+        missing_count: int = 0,
+        protected_active: bool = False,
+    ) -> Reservation:
+        """Build a minimal August 2026 Reservation with the given missing_count."""
+        s = _dt(2026, 8, day)
+        e = s + timedelta(days=7)
+        return Reservation(
+            identity_key=key,
+            start=s,
+            end=e,
+            buffered_start=s,
+            buffered_end=e,
+            summary=f"Guest {key}",
+            slot_name=f"Guest {key}",
+            display_slot_name=f"RC Guest {key}",
+            slot_code=f"PIN{key}",
+            missing_count=missing_count,
+            protected_active=protected_active,
+        )
+
+    def _occupied(self, slot: int, key: str, day: int = 1) -> ManagedSlot:
+        """Build an OCCUPIED ManagedSlot keyed to *key*."""
+        s = _dt(2026, 8, day)
+        e = s + timedelta(days=7)
+        return ManagedSlot(
+            slot=slot,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name=f"RC Guest {key}",
+            actual_code_present=True,
+            persisted_identity_key=key,
+            actual_start=s,
+            actual_end=e,
+        )
+
+    # ------------------------------------------------------------------
+    # T089-1: missing_count=0 → still eligible, slot NOOP
+    # ------------------------------------------------------------------
+
+    def test_missing_count_zero_eligible_noop(self) -> None:
+        """T089-1: Reservation with missing_count=0 is eligible; slot stays NOOP."""
+        res = self._mk("r-zero", missing_count=0)
+        slot3 = self._occupied(3, "r-zero")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3],
+            max_events=1,
+            plan_id="t089-zero",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        assert "r-zero" in plan.selected
+        assert plan.selected["r-zero"] == 3
+        noop_actions = [a for a in plan.actions if a.slot == 3]
+        assert all(a.kind is ActionKind.NOOP for a in noop_actions)
+
+    # ------------------------------------------------------------------
+    # T089-2: missing_count=1 → still eligible, slot retained (NOOP)
+    # ------------------------------------------------------------------
+
+    def test_missing_count_one_still_eligible(self) -> None:
+        """T089-2: Reservation with missing_count=1 is eligible; slot retained."""
+        res = self._mk("r-miss1", missing_count=1)
+        slot3 = self._occupied(3, "r-miss1")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3],
+            max_events=1,
+            plan_id="t089-miss1",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        assert "r-miss1" in plan.selected
+        # No CLEAR action for slot 3
+        clear_slot3 = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_slot3) == 0
+
+    # ------------------------------------------------------------------
+    # T089-3: missing_count=2 → still eligible, slot retained (NOOP)
+    # ------------------------------------------------------------------
+
+    def test_missing_count_two_still_eligible(self) -> None:
+        """T089-3: Reservation with missing_count=2 is eligible; slot retained."""
+        res = self._mk("r-miss2", missing_count=2)
+        slot3 = self._occupied(3, "r-miss2")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3],
+            max_events=1,
+            plan_id="t089-miss2",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        assert "r-miss2" in plan.selected
+        clear_slot3 = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_slot3) == 0
+
+    # ------------------------------------------------------------------
+    # T089-4: missing_count=3 → clearable (excluded from eligible)
+    # ------------------------------------------------------------------
+
+    def test_missing_count_three_clearable(self) -> None:
+        """T089-4: Reservation with missing_count=3 is excluded → slot CLEAR.
+
+        When the planner does not see the reservation in the eligible set,
+        the slot it occupies has desired_key=None → CLEAR action generated.
+        """
+        res = self._mk("r-miss3", missing_count=3)
+        slot3 = self._occupied(3, "r-miss3")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3],
+            max_events=1,
+            plan_id="t089-miss3",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        # Reservation is NOT selected (excluded by _filter_eligible)
+        assert "r-miss3" not in plan.selected
+        # Slot 3 must have a CLEAR action
+        clear_slot3 = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_slot3) == 1
+
+    # ------------------------------------------------------------------
+    # T089-5: missing_count=3 with protected_active bypasses exclusion
+    # ------------------------------------------------------------------
+
+    def test_missing_count_three_protected_active_not_cleared(self) -> None:
+        """T089-5: Protected active reservation with missing_count=3 stays assigned.
+
+        An active checked-in guest must never be evicted even if the feed
+        drops the reservation for three cycles.
+        """
+        res = self._mk("r-protected", missing_count=3, protected_active=True)
+        slot3 = self._occupied(3, "r-protected")
+
+        plan = compute_desired_plan(
+            [res],
+            [slot3],
+            max_events=1,
+            plan_id="t089-protected",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        # Protected reservation is still selected despite missing_count=3
+        assert "r-protected" in plan.selected
+        clear_slot3 = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_slot3) == 0
+
+    # ------------------------------------------------------------------
+    # T089-6: transition from count=2 to count=3 clears while a second
+    #         reservation with count=0 survives unaffected
+    # ------------------------------------------------------------------
+
+    def test_third_miss_clears_while_other_reservation_unaffected(self) -> None:
+        """T089-6: Third-miss clearable does not affect coexisting reservations.
+
+        With two slots: one occupied by a reservation on its third miss,
+        one by a reservation with count=0.  The third-miss slot gets CLEAR;
+        the other stays NOOP.
+        """
+        r_clearing = self._mk("r-clearing", day=1, missing_count=3)
+        r_stable = self._mk("r-stable", day=15, missing_count=0)
+
+        slot3_clearing = self._occupied(3, "r-clearing", day=1)
+        slot4_stable = self._occupied(4, "r-stable", day=15)
+
+        plan = compute_desired_plan(
+            [r_clearing, r_stable],
+            [slot3_clearing, slot4_stable],
+            max_events=2,
+            plan_id="t089-two-slots",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        # r-clearing must be cleared
+        assert "r-clearing" not in plan.selected
+        clear_slot3 = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 3
+        ]
+        assert len(clear_slot3) == 1
+
+        # r-stable must stay
+        assert "r-stable" in plan.selected
+        assert plan.selected["r-stable"] == 4
+        clear_slot4 = [
+            a for a in plan.actions if a.kind is ActionKind.CLEAR and a.slot == 4
+        ]
+        assert len(clear_slot4) == 0
+
+    # ------------------------------------------------------------------
+    # T089-7: Reservation constructor rejects negative missing_count
+    # ------------------------------------------------------------------
+
+    def test_reservation_rejects_negative_missing_count(self) -> None:
+        """T089-7: Reservation raises ValueError for negative missing_count."""
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError, match="missing_count"):
+            Reservation(
+                identity_key="bad-key",
+                start=_dt(2026, 8, 1),
+                end=_dt(2026, 8, 8),
+                buffered_start=_dt(2026, 8, 1),
+                buffered_end=_dt(2026, 8, 8),
+                summary="Bad",
+                slot_name="Bad",
+                display_slot_name="RC Bad",
+                slot_code="",
+                missing_count=-1,
+            )

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -2294,6 +2294,39 @@ class TestFindReservationRematchRulePriority:
 
         assert result.kind is not RematchKind.NAME_TIME
 
+    def test_adopted_observed_date_tiebreak_is_continuity(self) -> None:
+        """Observed-date disambiguation remains a continuity rematch."""
+        name = "Repeat Guest"
+        start = _dt(2026, 7, 10)
+        end = _dt(2026, 7, 14)
+        reservation = Reservation(
+            identity_key="new-repeat",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+        first = self._persisted("adopted.entry.slot10", name, slot=10)
+        second = self._persisted("adopted.entry.slot11", name, slot=11)
+        first["last_observed_actual"]["start_state"] = start.isoformat()
+        first["last_observed_actual"]["end_state"] = end.isoformat()
+
+        result = find_reservation_rematch(
+            reservation,
+            {
+                "adopted.entry.slot10": first,
+                "adopted.entry.slot11": second,
+            },
+            actual_slot_names={10: f"RC {name}", 11: f"RC {name}"},
+        )
+
+        assert result.kind is RematchKind.CONTINUITY
+        assert result.matched_identity_key == "adopted.entry.slot10"
+
     def test_empty_persisted_mappings_returns_no_match(self) -> None:
         """NO_MATCH returned when there are no persisted mappings at all."""
         reservation = self._reservation("fp-any", "Anyone")

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
@@ -28,7 +29,9 @@ from custom_components.rental_control.const import DEFAULT_PATH
 from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.const import NAME
 from custom_components.rental_control.util import EventIdentity
+from custom_components.rental_control.util import OperationResult
 from custom_components.rental_control.util import add_call
+from custom_components.rental_control.util import apply_buffer
 from custom_components.rental_control.util import async_fire_clear_code
 from custom_components.rental_control.util import async_fire_set_code
 from custom_components.rental_control.util import async_fire_update_times
@@ -1562,14 +1565,16 @@ class TestAsyncFireSetCode:
         ]
         assert len(name_calls) == 1
 
-    async def test_gather_exception_propagates_for_retry(
+    async def test_gather_exception_returns_failed_result_for_retry(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Verify a failing gather call is logged and re-raised for retry."""
+        """Verify a failing gather call is logged and returned as failed."""
         coordinator = MagicMock()
         coordinator.lockname = "front_door"
         coordinator.event_prefix = ""
         coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
         coordinator.event_overrides.verify_slot_ownership.return_value = True
         coordinator.event_overrides.record_retry_failure.return_value = False
 
@@ -1577,16 +1582,49 @@ class TestAsyncFireSetCode:
         coordinator.hass.services.async_call = AsyncMock(side_effect=error)
 
         event = self._make_event()
-        with (
-            caplog.at_level(
-                logging.ERROR, logger="custom_components.rental_control.util"
-            ),
-            pytest.raises(ServiceNotFound),
+        with caplog.at_level(
+            logging.ERROR, logger="custom_components.rental_control.util"
         ):
-            await async_fire_set_code(coordinator, event, 10)
+            result = await async_fire_set_code(coordinator, event, 10)
 
         assert "Lock slot operation" in caplog.text
+        assert result.failed is True
+        assert result.error is not None
         coordinator.event_overrides.record_retry_failure.assert_called_once_with(10)
+
+    async def test_set_code_flushes_before_verification(self) -> None:
+        """Verify set_code flushes HA jobs before reading state."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides._escalated = {}
+        coordinator.event_overrides.record_retry_success.return_value = None
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.async_block_till_done = AsyncMock()
+        coordinator.hass.states.get.return_value = MagicMock(state="Guest")
+
+        result = await async_fire_set_code(coordinator, self._make_event(), 10)
+
+        coordinator.hass.async_block_till_done.assert_awaited_once()
+        assert result.confirmed is True
+
+    async def test_set_code_cancelled_error_propagates(self) -> None:
+        """Verify set_code does not swallow task cancellation."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.hass.services.async_call = AsyncMock(
+            side_effect=asyncio.CancelledError()
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await async_fire_set_code(coordinator, self._make_event(), 10)
 
 
 # ---------------------------------------------------------------------------
@@ -1668,6 +1706,19 @@ class TestAsyncFireUpdateTimes:
             await async_fire_update_times(coordinator, self._make_event(), 10)
 
         assert "Lock slot operation" in caplog.text
+
+    async def test_cancelled_error_propagates(self) -> None:
+        """Verify update_times does not swallow task cancellation."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock(
+            side_effect=asyncio.CancelledError()
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await async_fire_update_times(coordinator, self._make_event(), 10)
 
 
 # ---------------------------------------------------------------------------
@@ -1790,6 +1841,7 @@ class TestRetryEscalation:
         coordinator.code_buffer_before = 0
         coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = MagicMock(state="Guest")
         coordinator.event_overrides.verify_slot_ownership.return_value = True
         coordinator.event_overrides._escalated = {10: True}
 
@@ -1821,6 +1873,7 @@ class TestRetryEscalation:
         coordinator.code_buffer_before = 0
         coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = MagicMock(state="Guest")
         coordinator.event_overrides.verify_slot_ownership.return_value = True
         coordinator.event_overrides._escalated = {}
 
@@ -1861,15 +1914,14 @@ class TestRetryEscalation:
             "end": "2025-01-17T11:00:00",
         }
 
-        with (
-            patch(
-                "custom_components.rental_control.util.pn_create",
-            ) as mock_create,
-            pytest.raises(Exception, match="service unavailable"),
-        ):
-            await async_fire_set_code(coordinator, event, 10)
+        with patch(
+            "custom_components.rental_control.util.pn_create",
+        ) as mock_create:
+            result = await async_fire_set_code(coordinator, event, 10)
 
         coordinator.event_overrides.record_retry_failure.assert_called_once_with(10)
+        assert result.failed is True
+        assert result.error is not None
         mock_create.assert_called_once()
         call_kwargs = mock_create.call_args
         assert call_kwargs[1]["notification_id"] == "rental_control_slot_10_failure"
@@ -1894,15 +1946,14 @@ class TestRetryEscalation:
             "end": "2025-01-17T11:00:00",
         }
 
-        with (
-            patch(
-                "custom_components.rental_control.util.pn_create",
-            ) as mock_create,
-            pytest.raises(Exception, match="service unavailable"),
-        ):
-            await async_fire_set_code(coordinator, event, 10)
+        with patch(
+            "custom_components.rental_control.util.pn_create",
+        ) as mock_create:
+            result = await async_fire_set_code(coordinator, event, 10)
 
         coordinator.event_overrides.record_retry_failure.assert_called_once_with(10)
+        assert result.failed is True
+        assert result.error is not None
         mock_create.assert_not_called()
 
     async def test_clear_code_records_success_and_dismisses(self) -> None:
@@ -1911,7 +1962,7 @@ class TestRetryEscalation:
         coordinator.name = "Test Rental"
         coordinator.lockname = "front_door"
         coordinator.hass.services.async_call = AsyncMock()
-        coordinator.hass.states.get.return_value = None
+        coordinator.hass.states.get.return_value = MagicMock(state="")
         coordinator.event_overrides.verify_slot_ownership.return_value = True
         coordinator.event_overrides._escalated = {10: True}
 
@@ -1926,6 +1977,55 @@ class TestRetryEscalation:
             notification_id="rental_control_slot_10_clear_failure",
         )
 
+    async def test_set_code_unconfirmed_does_not_reset_retry(self) -> None:
+        """Verify unconfirmed set_code leaves retry tracking intact."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = MagicMock(state="Other")
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides._escalated = {10: True}
+
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": "Guest",
+            "slot_code": "1234",
+            "start": "2025-01-15T16:00:00",
+            "end": "2025-01-17T11:00:00",
+        }
+
+        with patch(
+            "custom_components.rental_control.util.pn_dismiss",
+        ) as mock_dismiss:
+            result = await async_fire_set_code(coordinator, event, 10)
+
+        assert result.unconfirmed is True
+        coordinator.event_overrides.record_retry_success.assert_not_called()
+        mock_dismiss.assert_not_called()
+
+    async def test_clear_code_unconfirmed_does_not_reset_retry(self) -> None:
+        """Verify unconfirmed clear_code leaves retry tracking intact."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = None
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides._escalated = {10: True}
+
+        with patch(
+            "custom_components.rental_control.util.pn_dismiss",
+        ) as mock_dismiss:
+            result = await async_fire_clear_code(coordinator, 10, expected_name="Guest")
+
+        assert result.unconfirmed is True
+        coordinator.event_overrides.record_retry_success.assert_not_called()
+        mock_dismiss.assert_not_called()
+
     async def test_clear_code_failure_escalates(self) -> None:
         """Verify clear_code failure creates notification on escalation."""
         coordinator = MagicMock()
@@ -1938,23 +2038,22 @@ class TestRetryEscalation:
         error = Exception("lock offline")
         coordinator.hass.services.async_call = AsyncMock(side_effect=error)
 
-        with (
-            patch(
-                "custom_components.rental_control.util.pn_create",
-            ) as mock_create,
-            pytest.raises(Exception, match="lock offline"),
-        ):
-            await async_fire_clear_code(coordinator, 10, expected_name="Guest")
+        with patch(
+            "custom_components.rental_control.util.pn_create",
+        ) as mock_create:
+            result = await async_fire_clear_code(coordinator, 10, expected_name="Guest")
 
         coordinator.event_overrides.record_retry_failure.assert_called_once_with(10)
+        assert result.failed is True
+        assert result.error is not None
         mock_create.assert_called_once()
         call_kwargs = mock_create.call_args
         assert (
             call_kwargs[1]["notification_id"] == "rental_control_slot_10_clear_failure"
         )
 
-    async def test_clear_code_failure_reraises(self) -> None:
-        """Verify exception is re-raised after recording failure."""
+    async def test_clear_code_failure_returns_failed_result(self) -> None:
+        """Verify failure is returned after recording retry state."""
         coordinator = MagicMock()
         coordinator.name = "Test Rental"
         coordinator.lockname = "front_door"
@@ -1964,7 +2063,21 @@ class TestRetryEscalation:
         error = RuntimeError("hardware fault")
         coordinator.hass.services.async_call = AsyncMock(side_effect=error)
 
-        with pytest.raises(RuntimeError, match="hardware fault"):
+        result = await async_fire_clear_code(coordinator, 10, expected_name="Guest")
+        assert result.failed is True
+        assert result.error == "hardware fault"
+
+    async def test_clear_code_cancelled_error_propagates(self) -> None:
+        """Verify clear_code does not swallow task cancellation."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.hass.services.async_call = AsyncMock(
+            side_effect=asyncio.CancelledError()
+        )
+
+        with pytest.raises(asyncio.CancelledError):
             await async_fire_clear_code(coordinator, 10, expected_name="Guest")
 
 
@@ -2532,6 +2645,369 @@ class TestBufferInUpdateTimes:
         original_end = datetime(2025, 1, 17, 11, 0, 0)
         event = self._make_event(start=original_start, end=original_end)
         await async_fire_update_times(coordinator, event, 10)
+
+        assert event.extra_state_attributes["start"] == original_start
+        assert event.extra_state_attributes["end"] == original_end
+
+
+class TestAsyncFireClearCodeOperationResult:
+    """Tests for async_fire_clear_code OperationResult outcomes."""
+
+    def _make_coordinator(self) -> MagicMock:
+        """Return a coordinator mock for clear-code tests."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides._escalated = {}
+        return coordinator
+
+    async def test_confirmed_when_name_and_pin_cleared(self) -> None:
+        """Clear is confirmed when both name and PIN entities are cleared."""
+        coordinator = self._make_coordinator()
+
+        def states_get(entity_id: str) -> MagicMock:
+            """Return a cleared mock state for any requested entity."""
+            state = MagicMock()
+            state.state = ""
+            return state
+
+        coordinator.hass.states.get.side_effect = states_get
+
+        with patch(
+            "custom_components.rental_control.util.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await async_fire_clear_code(coordinator, 10, expected_name="Guest")
+
+        assert result == OperationResult(kind="clear", slot=10, confirmed=True)
+
+    async def test_unconfirmed_when_name_state_none(self) -> None:
+        """Clear is unconfirmed when the name entity cannot be read."""
+        coordinator = self._make_coordinator()
+        coordinator.hass.states.get.return_value = None
+
+        with patch(
+            "custom_components.rental_control.util.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await async_fire_clear_code(coordinator, 10, expected_name="Guest")
+
+        assert result.unconfirmed is True
+        assert result.confirmed is False
+
+    async def test_lingering_name_when_name_persists(self) -> None:
+        """Persistent name after reset yields lingering_name."""
+        coordinator = self._make_coordinator()
+
+        def _state(value: str) -> MagicMock:
+            """Return a mock state with the provided value."""
+            state = MagicMock()
+            state.state = value
+            return state
+
+        name_reads = [_state("Ghost"), _state("Ghost")]
+        pin_state = _state("")
+
+        def states_get(entity_id: str) -> MagicMock:
+            """Return persistent name reads and a cleared PIN state."""
+            if entity_id.endswith("_name"):
+                return name_reads.pop(0)
+            return pin_state
+
+        coordinator.hass.states.get.side_effect = states_get
+
+        with patch(
+            "custom_components.rental_control.util.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await async_fire_clear_code(coordinator, 10, expected_name="Guest")
+
+        assert result.unconfirmed is True
+        assert result.lingering_name is True
+        assert result.confirmed is False
+
+    async def test_lingering_pin_when_pin_persists(self) -> None:
+        """Persistent PIN after reset yields lingering_pin."""
+        coordinator = self._make_coordinator()
+
+        def states_get(entity_id: str) -> MagicMock:
+            """Return a cleared name state and lingering PIN state."""
+            state = MagicMock()
+            if entity_id.endswith("_name"):
+                state.state = ""
+            else:
+                state.state = "5678"
+            return state
+
+        coordinator.hass.states.get.side_effect = states_get
+
+        with patch(
+            "custom_components.rental_control.util.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await async_fire_clear_code(coordinator, 10, expected_name="Guest")
+
+        assert result.unconfirmed is True
+        assert result.lingering_pin is True
+        assert result.confirmed is False
+
+    async def test_service_failure_returns_failed(self) -> None:
+        """Button press failure is returned as failed."""
+        coordinator = self._make_coordinator()
+        coordinator.hass.services.async_call = AsyncMock(
+            side_effect=RuntimeError("lock offline")
+        )
+        coordinator.event_overrides.record_retry_failure.return_value = False
+
+        result = await async_fire_clear_code(coordinator, 10, expected_name="Guest")
+
+        assert result.failed is True
+        assert result.error == "lock offline"
+
+    async def test_no_lockname_returns_unconfirmed(self) -> None:
+        """Missing lockname returns an unconfirmed result."""
+        coordinator = self._make_coordinator()
+        coordinator.lockname = ""
+
+        result = await async_fire_clear_code(coordinator, 10)
+
+        assert result.unconfirmed is True
+
+    async def test_ownership_failure_returns_unconfirmed(self) -> None:
+        """Ownership mismatch returns an unconfirmed result."""
+        coordinator = self._make_coordinator()
+        coordinator.event_overrides.verify_slot_ownership.return_value = False
+
+        result = await async_fire_clear_code(coordinator, 10, expected_name="Guest")
+
+        assert result.unconfirmed is True
+
+
+class TestAsyncFireSetCodeOperationResult:
+    """Tests for async_fire_set_code OperationResult outcomes."""
+
+    @staticmethod
+    def _make_event() -> MagicMock:
+        """Return a set-code event payload."""
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": "Guest",
+            "slot_code": "1234",
+            "start": "2025-01-15T16:00:00",
+            "end": "2025-01-17T11:00:00",
+        }
+        return event
+
+    def _make_coordinator(self) -> MagicMock:
+        """Return a coordinator mock for set-code tests."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides._escalated = {}
+        return coordinator
+
+    async def test_confirmed_when_name_matches(self) -> None:
+        """Set is confirmed when the written name can be read back."""
+        coordinator = self._make_coordinator()
+        state = MagicMock()
+        state.state = "Guest"
+        coordinator.hass.states.get.return_value = state
+
+        result = await async_fire_set_code(coordinator, self._make_event(), 10)
+
+        assert result == OperationResult(kind="set", slot=10, confirmed=True)
+
+    async def test_unconfirmed_when_name_state_none(self) -> None:
+        """Set is unconfirmed when the name entity is unreadable."""
+        coordinator = self._make_coordinator()
+        coordinator.hass.states.get.return_value = None
+
+        result = await async_fire_set_code(coordinator, self._make_event(), 10)
+
+        assert result.unconfirmed is True
+
+    async def test_service_failure_returns_failed(self) -> None:
+        """Service failure is returned as failed."""
+        coordinator = self._make_coordinator()
+        coordinator.hass.services.async_call = AsyncMock(
+            side_effect=RuntimeError("service unavailable")
+        )
+        coordinator.event_overrides.record_retry_failure.return_value = False
+
+        result = await async_fire_set_code(coordinator, self._make_event(), 10)
+
+        assert result.failed is True
+        assert result.error == "service unavailable"
+
+    async def test_no_lockname_returns_unconfirmed(self) -> None:
+        """Missing lockname returns an unconfirmed result."""
+        coordinator = self._make_coordinator()
+        coordinator.lockname = ""
+
+        result = await async_fire_set_code(coordinator, self._make_event(), 10)
+
+        assert result.unconfirmed is True
+
+
+class TestAsyncFireUpdateTimesOperationResult:
+    """Tests for async_fire_update_times OperationResult outcomes."""
+
+    @staticmethod
+    def _make_event() -> MagicMock:
+        """Return an update-times event payload."""
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": "Guest",
+            "start": "2025-01-15T16:00:00",
+            "end": "2025-01-17T11:00:00",
+        }
+        return event
+
+    def _make_coordinator(self) -> MagicMock:
+        """Return a coordinator mock for update-times tests."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        return coordinator
+
+    async def test_confirmed_on_success(self) -> None:
+        """Successful service calls return confirmed."""
+        coordinator = self._make_coordinator()
+
+        result = await async_fire_update_times(coordinator, self._make_event(), 10)
+
+        assert result == OperationResult(
+            kind="update_times",
+            slot=10,
+            confirmed=True,
+        )
+
+    async def test_failed_on_service_exception(self) -> None:
+        """Gather failures are returned as failed."""
+        coordinator = self._make_coordinator()
+        coordinator.hass.services.async_call = AsyncMock(
+            side_effect=ServiceNotFound("datetime", "set_value")
+        )
+
+        result = await async_fire_update_times(coordinator, self._make_event(), 10)
+
+        assert result.failed is True
+        assert result.error is not None
+
+    async def test_no_lockname_returns_unconfirmed(self) -> None:
+        """Missing lockname returns an unconfirmed result."""
+        coordinator = self._make_coordinator()
+        coordinator.lockname = ""
+
+        result = await async_fire_update_times(coordinator, self._make_event(), 10)
+
+        assert result.unconfirmed is True
+
+
+class TestBufferRegressionSemantics:
+    """T102 regression: Lock-code buffer semantics preserved after reconciliation.
+
+    These tests pin the apply_buffer behaviour: the buffered window
+    sent to Keymaster differs from the original event window, and the
+    original event attributes are never mutated.
+    """
+
+    @staticmethod
+    def _make_coordinator() -> MagicMock:
+        """Return a coordinator mock for buffered set-code tests."""
+        from zoneinfo import ZoneInfo
+
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.timezone = ZoneInfo("America/New_York")
+        coordinator.trim_names = False
+        coordinator.max_name_length = 0
+        coordinator.event_prefix = ""
+        coordinator.code_buffer_before = 30
+        coordinator.code_buffer_after = 15
+        coordinator.hass.services.async_call = AsyncMock()
+        state = MagicMock()
+        state.state = "Guest"
+        coordinator.hass.states.get.return_value = state
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides._escalated = {}
+        return coordinator
+
+    def test_apply_buffer_zero_returns_inputs_unchanged(self) -> None:
+        """Zero-minute buffers return the original objects unchanged."""
+        rc = MagicMock()
+        start = datetime(2025, 1, 15, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2025, 1, 17, 11, 0, tzinfo=dt_util.UTC)
+
+        buffered_start, buffered_end = apply_buffer(start, end, 0, 0, rc)
+
+        assert buffered_start is start
+        assert buffered_end is end
+
+    def test_apply_buffer_before_shifts_start_only(self) -> None:
+        """Before-buffer moves only the start backward."""
+        rc = MagicMock()
+        start = datetime(2025, 1, 15, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2025, 1, 17, 11, 0, tzinfo=dt_util.UTC)
+
+        buffered_start, buffered_end = apply_buffer(start, end, 60, 0, rc)
+
+        assert buffered_start == start - timedelta(minutes=60)
+        assert buffered_end == end
+
+    def test_apply_buffer_after_extends_end_only(self) -> None:
+        """After-buffer moves only the end forward."""
+        rc = MagicMock()
+        start = datetime(2025, 1, 15, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2025, 1, 17, 11, 0, tzinfo=dt_util.UTC)
+
+        buffered_start, buffered_end = apply_buffer(start, end, 0, 30, rc)
+
+        assert buffered_start == start
+        assert buffered_end == end + timedelta(minutes=30)
+
+    def test_apply_buffer_converts_date_to_datetime(self) -> None:
+        """Date-only values are normalised before buffer arithmetic."""
+        from zoneinfo import ZoneInfo
+
+        rc = MagicMock()
+        rc.timezone = ZoneInfo("America/New_York")
+
+        buffered_start, buffered_end = apply_buffer(
+            date(2025, 1, 15),
+            date(2025, 1, 17),
+            30,
+            15,
+            rc,
+        )
+
+        assert buffered_start == datetime(2025, 1, 14, 23, 30, tzinfo=rc.timezone)
+        assert buffered_end == datetime(2025, 1, 17, 0, 15, tzinfo=rc.timezone)
+
+    async def test_set_code_event_attributes_unchanged_after_buffer(self) -> None:
+        """Buffered writes do not mutate the original event attributes."""
+        coordinator = self._make_coordinator()
+        original_start = datetime(2025, 1, 15, 16, 0, tzinfo=dt_util.UTC)
+        original_end = datetime(2025, 1, 17, 11, 0, tzinfo=dt_util.UTC)
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": "Guest",
+            "slot_code": "1234",
+            "start": original_start,
+            "end": original_end,
+        }
+
+        await async_fire_set_code(coordinator, event, 10)
 
         assert event.extra_state_attributes["start"] == original_start
         assert event.extra_state_attributes["end"] == original_end


### PR DESCRIPTION
## Summary

This is the 3.5.1 forward-fix for the production 3.5.0 slot-reconciliation regression. It does not revert the redesign.

## Incident

3.5.0 can brick production lock-code management in two ways:

1. First-upgrade adoption stores existing Keymaster occupants as synthetic adopted identities. At scale, trimmed names, duplicate guest names, missing aliases, and missing date evidence can prevent rematch. The planner then treats the still-populated adopted slots as stale and clears working codes.
2. Failed or unconfirmed clears persist pending_clear fences. After restart, the fences reload, adoption is skipped because mappings exist, and the planner refuses to assign fenced slots forever, producing no-free-slot overflow for every reservation.

## Fix invariants

- Preserve adopted-but-unrematched occupied slots. A failed adoption rematch no longer produces a stale CLEAR for a populated adopted slot.
- Harden adoption rematch with trimmed/prefixed display-name matching and adopted observed date ranges, including buffered Keymaster dates, while keeping ambiguous non-adopted rematches fenced.
- Self-heal already-wedged 3.5.0 stores on upgrade: confirmed-blank pending_clear slots release their stale fence and become free so current reservations are programmed again.
- Keep the legitimate fence: unreadable slots and slots physically holding a name or PIN remain fenced and are not reused.

## Safety

Documented manual time-of-day and door-code overrides are preserved. #571/#572 drift safeguards remain intact. This PR intentionally does not reopen #589 and does not tag or cut the release.

## Validation

- Reproduction tests fail on current main and pass with this fix.
- Full suite with coverage: 1333 passed, 94.62% coverage.
- Targeted coordinator/event override/refresh/concurrency/util suite: 550 passed.
- Ruff and pre-commit pass.
- Code-review and rubber-duck safety reviews are clean.