### PR TITLE
Fix(reconcile): Treat unknown slot state as empty

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -114,6 +114,8 @@ from .util import apply_buffer
 from .util import async_fire_clear_code
 from .util import check_gather_results
 from .util import get_slot_name
+from .util import is_cleared_keymaster_text_state as _is_blank_keymaster_text
+from .util import is_unreadable_keymaster_text_state
 from .util import normalize_uid
 from .util import trim_name
 
@@ -130,14 +132,9 @@ def _store_datetime(value: Any) -> Any:
     return value
 
 
-def _is_blank_keymaster_text(value: str | None) -> bool:
-    """Return whether a Keymaster text state is confirmed blank."""
-    return value == ""
-
-
-def _is_unreadable_keymaster_text(value: str | None) -> bool:
-    """Return whether a Keymaster text state is unreadable."""
-    return value in ("unknown", "unavailable")
+def _adopted_slot_placeholder(slot: int) -> str:
+    """Return a safe placeholder name for a code-bearing unnamed slot."""
+    return f"Adopted Slot {slot}"
 
 
 def _format_display_slot_name(
@@ -452,8 +449,10 @@ Please update Keymaster to at least v0.1.0-b0
             _LOGGER.debug("Slot code: '%s'", slot_code)
             if slot_code is None:
                 continue
+            if is_unreadable_keymaster_text_state(slot_code.state):
+                continue
             slot_code_value = (
-                "" if slot_code.state in ("unknown", "unavailable") else slot_code.state
+                "" if _is_blank_keymaster_text(slot_code.state) else slot_code.state
             )
 
             slot_name = self.hass.states.get(
@@ -462,8 +461,10 @@ Please update Keymaster to at least v0.1.0-b0
             _LOGGER.debug("Slot name: '%s'", slot_name)
             if slot_name is None:
                 continue
+            if is_unreadable_keymaster_text_state(slot_name.state):
+                continue
             slot_name_value = (
-                "" if slot_name.state in ("unknown", "unavailable") else slot_name.state
+                "" if _is_blank_keymaster_text(slot_name.state) else slot_name.state
             )
 
             use_date_range = self.hass.states.get(
@@ -472,14 +473,14 @@ Please update Keymaster to at least v0.1.0-b0
 
             if (
                 slot_name_value
-                and slot_code.state == ""
+                and _is_blank_keymaster_text(slot_code.state)
                 and not slot_code_value
                 and (use_date_range is None or use_date_range.state == "off")
             ):
                 # Partially-reset slot: name persists but code was cleared
-                # and date-range limits are off.  Only trigger when the raw
-                # PIN state is explicitly empty, not when it is
-                # unknown/unavailable (entity not yet loaded).
+                # and date-range limits are off.  Keymaster reset exposes
+                # Null as HA "unknown"; "unavailable" was skipped above
+                # because that state is not evidence that the code cleared.
                 _LOGGER.warning(
                     "Slot %d has name '%s' but no code; forcing "
                     "reset (Keymaster may not have fully cleared "
@@ -498,6 +499,13 @@ Please update Keymaster to at least v0.1.0-b0
                 # reaches max_slots and ready becomes True.
                 slot_name_value = ""
                 slot_code_value = ""
+            elif slot_code_value and not slot_name_value:
+                _LOGGER.warning(
+                    "Slot %d has a code but no readable name; marking it "
+                    "occupied with a placeholder to avoid reuse",
+                    i,
+                )
+                slot_name_value = _adopted_slot_placeholder(i)
 
             if use_date_range and use_date_range.state == "on":
                 start_time_state = self.hass.states.get(
@@ -662,25 +670,27 @@ Please update Keymaster to at least v0.1.0-b0
             )
             if name_state is None:
                 continue
-            name_value = (
-                ""
-                if name_state.state in ("unknown", "unavailable")
-                else name_state.state
-            )
-            if not name_value:
+            if is_unreadable_keymaster_text_state(name_state.state):
                 continue
+            name_value = (
+                "" if _is_blank_keymaster_text(name_state.state) else name_state.state
+            )
 
             code_state = self.hass.states.get(
                 f"{TEXT}.{self.lockname}_code_slot_{i}_pin"
             )
             has_code = False
             if code_state is not None:
+                if is_unreadable_keymaster_text_state(code_state.state):
+                    continue
                 code_value = (
                     ""
-                    if code_state.state in ("unknown", "unavailable")
+                    if _is_blank_keymaster_text(code_state.state)
                     else code_state.state
                 )
                 has_code = bool(code_value)
+            if not name_value and not has_code:
+                continue
 
             use_date_range_state = self.hass.states.get(
                 f"{SWITCH}.{self.lockname}_code_slot_{i}_use_date_range_limits"
@@ -702,7 +712,7 @@ Please update Keymaster to at least v0.1.0-b0
                 if end_dt_state is not None:
                     actual_end = dt.parse_datetime(end_dt_state.state)
 
-            slot_name = name_value
+            slot_name = name_value or _adopted_slot_placeholder(i)
             if prefix and slot_name.startswith(prefix):
                 slot_name = slot_name[len(prefix) :]
 
@@ -1387,17 +1397,15 @@ Please update Keymaster to at least v0.1.0-b0
             name_empty = _is_blank_keymaster_text(name_state.state)
             code_empty = _is_blank_keymaster_text(code_state.state)
             physically_empty = name_empty and code_empty
-            unreadable = _is_unreadable_keymaster_text(
+            unreadable = is_unreadable_keymaster_text_state(
                 name_state.state
-            ) or _is_unreadable_keymaster_text(code_state.state)
+            ) or is_unreadable_keymaster_text_state(code_state.state)
 
             if not physically_empty and unreadable:
-                status = (
-                    _SlotStatus.PENDING_CLEAR
-                    if i in pending_clear
-                    else _SlotStatus.UNKNOWN
+                status = _SlotStatus.UNKNOWN
+                blocked_reason = (
+                    "pending_clear_unreadable" if i in pending_clear else None
                 )
-                blocked_reason = "pending_clear" if i in pending_clear else None
                 ms = _ManagedSlot(
                     slot=i,
                     managed=True,
@@ -1481,7 +1489,7 @@ Please update Keymaster to at least v0.1.0-b0
             elif persisted_status == SLOT_STATUS_BLOCKED:
                 status = _SlotStatus.BLOCKED
                 blocked_reason = SLOT_STATUS_BLOCKED
-            elif name_value and has_code:
+            elif has_code:
                 status = _SlotStatus.OCCUPIED
                 blocked_reason = None
             elif persisted_status == SLOT_STATUS_PENDING_SET:

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -44,6 +44,8 @@ from homeassistant.components.text import DOMAIN as TEXT
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.const import SERVICE_RELOAD
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import Event
 from homeassistant.core import EventStateChangedData
 from homeassistant.core import HomeAssistant
@@ -59,6 +61,35 @@ from .const import EARLY_CHECKOUT_GRACE_MINUTES
 from .const import NAME
 
 _LOGGER = logging.getLogger(__name__)
+_CLEARED_KEYMASTER_TEXT_STATES = frozenset(("", str(STATE_UNKNOWN).casefold()))
+_UNREADABLE_KEYMASTER_TEXT_STATE = str(STATE_UNAVAILABLE).casefold()
+
+
+def _keymaster_text_state_token(value: Any) -> str | None:
+    """Return a canonical comparison token for a Keymaster text state."""
+    if value is None:
+        return None
+    return str(value).strip().casefold()
+
+
+def is_cleared_keymaster_text_state(value: Any) -> bool:
+    """Return whether a Keymaster text state is confirmed cleared."""
+    token = _keymaster_text_state_token(value)
+    return token is None or token in _CLEARED_KEYMASTER_TEXT_STATES
+
+
+def is_unreadable_keymaster_text_state(value: Any) -> bool:
+    """Return whether a Keymaster text state is unreadable."""
+    return _keymaster_text_state_token(value) == _UNREADABLE_KEYMASTER_TEXT_STATE
+
+
+def normalize_keymaster_text_state(value: Any) -> str | None:
+    """Return normalized text state, or ``None`` when it is unreadable."""
+    if is_unreadable_keymaster_text_state(value):
+        return None
+    if is_cleared_keymaster_text_state(value):
+        return ""
+    return str(value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -256,7 +287,9 @@ async def async_fire_clear_code(
     name_state = hass.states.get(name_entity)
     if name_state is None:
         unconfirmed = True
-    elif name_state.state not in ("", "unknown", "unavailable"):
+    elif is_unreadable_keymaster_text_state(name_state.state):
+        unconfirmed = True
+    elif not is_cleared_keymaster_text_state(name_state.state):
         _LOGGER.warning(
             "Slot %d name '%s' persisted after reset; "
             "forcing name clear via text.set_value",
@@ -281,13 +314,17 @@ async def async_fire_clear_code(
         name_state = hass.states.get(name_entity)
         if name_state is None:
             unconfirmed = True
-        elif name_state.state not in ("", "unknown", "unavailable"):
+        elif is_unreadable_keymaster_text_state(name_state.state):
+            unconfirmed = True
+        elif not is_cleared_keymaster_text_state(name_state.state):
             lingering_name = True
 
     pin_state = hass.states.get(pin_entity)
     if pin_state is None:
         unconfirmed = True
-    elif pin_state.state not in ("", "unknown", "unavailable"):
+    elif is_unreadable_keymaster_text_state(pin_state.state):
+        unconfirmed = True
+    elif not is_cleared_keymaster_text_state(pin_state.state):
         lingering_pin = True
 
     if lingering_name or lingering_pin:
@@ -873,27 +910,30 @@ async def handle_state_change(
     if slot_code is None:
         return
     if event_has_new_value and entity_id == slot_code_entity_id:
-        slot_code_value = (
-            "" if event_new_value in ("unknown", "unavailable") else event_new_value
-        )
+        slot_code_value = normalize_keymaster_text_state(event_new_value)
     elif event_has_new_value and existing_override is not None:
         slot_code_value = str(existing_override["slot_code"])
     else:
-        slot_code_value = (
-            "" if slot_code.state in ("unknown", "unavailable") else slot_code.state
-        )
+        slot_code_value = normalize_keymaster_text_state(slot_code.state)
+    if slot_code_value is None:
+        return
     if slot_name is None:
         return
     if event_has_new_value and entity_id == slot_name_entity_id:
-        slot_name_value = (
-            "" if event_new_value in ("unknown", "unavailable") else event_new_value
-        )
+        slot_name_value = normalize_keymaster_text_state(event_new_value)
     elif event_has_new_value and existing_override is not None:
         slot_name_value = str(existing_override["slot_name"])
     else:
-        slot_name_value = (
-            "" if slot_name.state in ("unknown", "unavailable") else slot_name.state
+        slot_name_value = normalize_keymaster_text_state(slot_name.state)
+    if slot_name_value is None:
+        return
+    if slot_code_value and not slot_name_value:
+        _LOGGER.warning(
+            "Ignoring Keymaster slot %s state change with a code but no "
+            "readable name; keeping the slot out of the free pool.",
+            slot_num,
         )
+        return
 
     start_time = dt.start_of_local_day()
     end_time = dt.start_of_local_day()

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1041,7 +1041,37 @@ class TestSlotBootstrapping:
         hass: HomeAssistant,
         mock_config_entry: MockConfigEntry,
     ) -> None:
-        """Verify unknown/unavailable states are converted to empty strings."""
+        """Verify unknown slot states are converted to empty strings."""
+        mock_config_entry.add_to_hass(hass)
+
+        with patch.object(
+            dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY
+        ):
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            coordinator.lockname = "front_door"
+            mock_overrides = MagicMock()
+            mock_overrides.ready = False
+            mock_overrides.async_check_overrides = AsyncMock()
+            coordinator.event_overrides = mock_overrides
+            mock_update = AsyncMock()
+            object.__setattr__(coordinator, "update_event_overrides", mock_update)
+
+            hass.states.async_set("text.front_door_code_slot_10_pin", "unknown")
+            hass.states.async_set("text.front_door_code_slot_10_name", "unknown")
+
+            await coordinator.async_setup_keymaster_overrides()
+
+        mock_update.assert_awaited_once()
+        call_args = mock_update.call_args[0]
+        assert call_args[1] == ""
+        assert call_args[2] == ""
+
+    async def test_bootstrap_skips_unavailable_slot_states(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify unavailable slot states are not assumed empty."""
         mock_config_entry.add_to_hass(hass)
 
         with patch.object(
@@ -1061,10 +1091,37 @@ class TestSlotBootstrapping:
 
             await coordinator.async_setup_keymaster_overrides()
 
+        mock_update.assert_not_awaited()
+
+    async def test_bootstrap_marks_unnamed_real_pin_occupied(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Verify a real PIN with cleared name is not bootstrapped as free."""
+        mock_config_entry.add_to_hass(hass)
+
+        with patch.object(
+            dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY
+        ):
+            coordinator = RentalControlCoordinator(hass, mock_config_entry)
+            coordinator.lockname = "front_door"
+            mock_overrides = MagicMock()
+            mock_overrides.ready = False
+            mock_overrides.async_check_overrides = AsyncMock()
+            coordinator.event_overrides = mock_overrides
+            mock_update = AsyncMock()
+            object.__setattr__(coordinator, "update_event_overrides", mock_update)
+
+            hass.states.async_set("text.front_door_code_slot_10_pin", "9876")
+            hass.states.async_set("text.front_door_code_slot_10_name", "unknown")
+
+            await coordinator.async_setup_keymaster_overrides()
+
         mock_update.assert_awaited_once()
         call_args = mock_update.call_args[0]
-        assert call_args[1] == ""
-        assert call_args[2] == ""
+        assert call_args[1] == "9876"
+        assert call_args[2] == "Adopted Slot 10"
 
 
 # ---------------------------------------------------------------------------
@@ -1218,12 +1275,12 @@ class TestPartialSlotResetDetection:
         assert call_args[1] == ""
         assert call_args[2] == ""
 
-    async def test_startup_skips_reset_when_pin_unknown(
+    async def test_startup_resets_when_pin_unknown(
         self,
         hass: HomeAssistant,
         mock_config_entry: MockConfigEntry,
     ) -> None:
-        """Verify unknown PIN state does not trigger force-reset."""
+        """Verify retained name with unknown PIN triggers force-reset."""
         mock_config_entry.add_to_hass(hass)
 
         with patch.object(
@@ -1247,8 +1304,8 @@ class TestPartialSlotResetDetection:
             ) as mock_clear:
                 await coordinator.async_setup_keymaster_overrides()
 
-        mock_clear.assert_not_awaited()
-        # Normal load path with normalized empty code
+        mock_clear.assert_awaited_once_with(coordinator, 10)
+        # Normal load path with normalized empty code after the reset.
         mock_update.assert_awaited_once()
 
 
@@ -5332,10 +5389,414 @@ class TestCoordinatorPersistenceUpdate:
             assert set(plan.selected) == {"new-10", "new-11"}
             assert sorted(plan.selected.values()) == [10, 11]
 
+    async def test_wedge_self_heals_when_slots_are_unknown(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Keymaster Null reset states self-heal across coordinator restarts."""
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry(max_events=2)
+        entry.add_to_hass(hass)
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        store_mappings = {}
+        for slot in (10, 11):
+            key = f"wedged-unknown-{slot}"
+            mapping = self._make_occupied_mapping(key, f"Old Guest {slot}", slot)
+            mapping["status"] = "pending_clear"
+            mapping["operation_id"] = f"clear-token-{slot}"
+            mapping["operation_kind"] = "clear"
+            mapping["pending_clear_since"] = "2026-08-01T00:00:00+00:00"
+            store_mappings[key] = mapping
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_name", "unknown")
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_pin", "unknown")
+
+        events = []
+        for index, (slot, guest) in enumerate(
+            ((10, "Recovered Unknown A"), (11, "Recovered Unknown B"))
+        ):
+            event = MagicMock()
+            event.summary = guest
+            event.description = ""
+            event.start = start + timedelta(days=index * 7)
+            event.end = end + timedelta(days=index * 7)
+            event.uid = f"unknown-uid-{slot}"
+            events.append(event)
+
+        for restart in range(2):
+            coordinator = RentalControlCoordinator(hass, entry)
+            coordinator._slot_mappings = {
+                "schema_version": 1,
+                "entry_id": entry.entry_id,
+                "mappings": {key: dict(value) for key, value in store_mappings.items()},
+                "blocked_slots": {},
+            }
+            assert coordinator.event_overrides is not None
+            coordinator.event_overrides.load_persisted_mappings(
+                coordinator._slot_mappings["mappings"]
+            )
+            reservations = coordinator._build_reservations(events)
+            observed = coordinator._observe_managed_slots()
+
+            assert all(slot.status is SlotStatus.FREE for slot in observed)
+            assert coordinator.event_overrides.pending_clear_slots == {}
+
+            plan = compute_desired_plan(
+                reservations,
+                observed,
+                max_events=2,
+                plan_id=f"unknown-reset-recovery-{restart}",
+                generated_at=start,
+            )
+            assert plan.overflow == {}
+            assert sorted(plan.selected.values()) == [10, 11]
+
+            with patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new_callable=AsyncMock,
+                return_value=OperationResult(kind="set", slot=10, confirmed=True),
+            ) as mock_set:
+                await coordinator.event_overrides.async_apply_plan(
+                    coordinator, plan, {res.identity_key: res for res in reservations}
+                )
+
+            assert mock_set.call_count == 2
+
+    def test_wedge_self_heals_when_unknown_state_mixed_case(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Mixed-case Keymaster unknown reset states self-heal to free."""
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        entry = self._make_persist_entry(max_events=1)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        mapping = self._make_occupied_mapping(
+            "wedged-mixed-case-unknown", "Old Guest", 10
+        )
+        mapping["status"] = "pending_clear"
+        mapping["operation_id"] = "clear-token"
+        mapping["operation_kind"] = "clear"
+        mapping["pending_clear_since"] = "2026-08-01T00:00:00+00:00"
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {"wedged-mixed-case-unknown": mapping},
+            "blocked_slots": {},
+        }
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Unknown")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "UNKNOWN")
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        reservation = Reservation(
+            identity_key="new-mixed-case-unknown",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="New Guest",
+            slot_code="1234",
+        )
+
+        observed = coordinator._observe_managed_slots()
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        plan = compute_desired_plan(
+            [reservation],
+            observed,
+            max_events=1,
+            plan_id="mixed-case-unknown-reset",
+            generated_at=start,
+        )
+
+        assert slot10.status is SlotStatus.FREE
+        assert coordinator.event_overrides.pending_clear_slots == {}
+        assert plan.overflow == {}
+        assert plan.selected == {"new-mixed-case-unknown": 10}
+
+    async def test_wedge_self_heals_with_mixed_unknown_and_empty(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Mixed Keymaster Null and blank reset states all become free."""
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+        from custom_components.rental_control.util import OperationResult
+
+        entry = self._make_persist_entry(max_events=3)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {},
+            "blocked_slots": {},
+        }
+        reset_states = {
+            10: ("unknown", "unknown"),
+            11: ("", ""),
+            12: ("unknown", ""),
+        }
+        for slot, (name_state, pin_state) in reset_states.items():
+            key = f"wedged-mixed-{slot}"
+            mapping = self._make_occupied_mapping(key, f"Old Guest {slot}", slot)
+            mapping["status"] = "pending_clear"
+            mapping["operation_id"] = f"clear-token-{slot}"
+            mapping["operation_kind"] = "clear"
+            mapping["pending_clear_since"] = "2026-08-01T00:00:00+00:00"
+            coordinator._slot_mappings["mappings"][key] = mapping
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_name", name_state)
+            hass.states.async_set(f"text.test_lock_code_slot_{slot}_pin", pin_state)
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+
+        events = []
+        for index, slot in enumerate(reset_states):
+            event = MagicMock()
+            event.summary = f"Mixed Reset Guest {slot}"
+            event.description = ""
+            event.start = start + timedelta(days=index * 7)
+            event.end = end + timedelta(days=index * 7)
+            event.uid = f"mixed-reset-{slot}"
+            events.append(event)
+
+        reservations = coordinator._build_reservations(events)
+        observed = coordinator._observe_managed_slots()
+
+        assert all(slot.status is SlotStatus.FREE for slot in observed)
+        assert coordinator.event_overrides.pending_clear_slots == {}
+
+        plan = compute_desired_plan(
+            reservations,
+            observed,
+            max_events=3,
+            plan_id="mixed-reset-recovery",
+            generated_at=start,
+        )
+        assert plan.overflow == {}
+        assert sorted(plan.selected.values()) == [10, 11, 12]
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            new_callable=AsyncMock,
+            return_value=OperationResult(kind="set", slot=10, confirmed=True),
+        ) as mock_set:
+            await coordinator.event_overrides.async_apply_plan(
+                coordinator, plan, {res.identity_key: res for res in reservations}
+            )
+
+        assert mock_set.call_count == 3
+
+    def test_slot_with_unknown_pin_not_treated_as_occupied(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """A Null-reset slot is free, not occupied, when PIN is unknown."""
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        entry = self._make_persist_entry(max_events=1)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        hass.states.async_set("text.test_lock_code_slot_10_name", "unknown")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "unknown")
+
+        observed = coordinator._observe_managed_slots()
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+
+        assert slot10.status is SlotStatus.FREE
+        assert slot10.actual_code_present is False
+        assert coordinator.event_overrides is not None
+        actual_state = coordinator.event_overrides.get_actual_state(10)
+        assert actual_state is not None
+        assert actual_state["has_code"] is False
+
+        reservation = Reservation(
+            identity_key="new-unknown-pin",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="New Guest",
+            slot_code="1234",
+        )
+        plan = compute_desired_plan(
+            [reservation],
+            observed,
+            max_events=1,
+            plan_id="unknown-pin-free",
+            generated_at=start,
+        )
+
+        assert plan.overflow == {}
+        assert plan.selected == {"new-unknown-pin": 10}
+
+    def test_slot_with_real_pin_stays_fenced(self, hass: "HomeAssistant") -> None:
+        """A pending-clear slot with a real PIN remains fenced."""
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        entry = self._make_persist_entry(max_events=1)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        mapping = self._make_occupied_mapping("real-pin", "Old Guest", 10)
+        mapping["status"] = "pending_clear"
+        mapping["operation_id"] = "clear-token"
+        mapping["operation_kind"] = "clear"
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {"real-pin": mapping},
+            "blocked_slots": {},
+        }
+        hass.states.async_set("text.test_lock_code_slot_10_name", "unknown")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "9876")
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+
+        observed = coordinator._observe_managed_slots()
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+
+        assert slot10.status is SlotStatus.PENDING_CLEAR
+        assert slot10.actual_code_present is True
+
+        reservation = Reservation(
+            identity_key="new-real-pin",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="New Guest",
+            slot_code="1234",
+        )
+        plan = compute_desired_plan(
+            [reservation],
+            observed,
+            max_events=1,
+            plan_id="real-pin-fenced",
+            generated_at=start,
+        )
+
+        assert plan.selected == {}
+        assert plan.overflow == {"new-real-pin": "no_free_slot"}
+
+    async def test_adoption_fences_unnamed_real_pin(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Adoption records a real PIN with cleared name as occupied."""
+        entry = self._make_persist_entry(max_events=1)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {}
+        hass.states.async_set("text.test_lock_code_slot_10_name", "unknown")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "9876")
+
+        await coordinator.async_adopt_keymaster_slots()
+
+        mappings = coordinator._slot_mappings["mappings"]
+        mapping = mappings[f"adopted.{entry.entry_id}.slot10"]
+        assert mapping["status"] == "occupied"
+        assert mapping["identity"]["slot_name"] == "Adopted Slot 10"
+        assert mapping["last_observed_actual"]["has_code"] is True
+
+    def test_unavailable_slot_not_freed(self, hass: "HomeAssistant") -> None:
+        """Unavailable pending-clear slots stay fenced until reset states load."""
+        from custom_components.rental_control.reconciliation import Reservation
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        entry = self._make_persist_entry(max_events=1)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        mapping = self._make_occupied_mapping("unavailable-slot", "Old Guest", 10)
+        mapping["status"] = "pending_clear"
+        mapping["operation_id"] = "clear-token"
+        mapping["operation_kind"] = "clear"
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {"unavailable-slot": mapping},
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        reservation = Reservation(
+            identity_key="new-after-unavailable",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="New Guest",
+            slot_name="New Guest",
+            display_slot_name="New Guest",
+            slot_code="1234",
+        )
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Unavailable")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "UNAVAILABLE")
+        observed = coordinator._observe_managed_slots()
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        assert slot10.status is SlotStatus.UNKNOWN
+        plan = compute_desired_plan(
+            [reservation],
+            observed,
+            max_events=1,
+            plan_id="unavailable-stays-fenced",
+            generated_at=start,
+        )
+        assert plan.selected == {}
+        assert plan.overflow == {"new-after-unavailable": "no_free_slot"}
+        from custom_components.rental_control.reconciliation import ActionKind
+
+        assert plan.slots[10].action is ActionKind.BLOCKED
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Unknown")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "")
+        observed = coordinator._observe_managed_slots()
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        assert slot10.status is SlotStatus.FREE
+        plan = compute_desired_plan(
+            [reservation],
+            observed,
+            max_events=1,
+            plan_id="unavailable-recovers",
+            generated_at=start,
+        )
+        assert plan.overflow == {}
+        assert plan.selected == {"new-after-unavailable": 10}
+
     def test_pending_clear_stays_fenced_when_state_unreadable(
         self, hass: "HomeAssistant"
     ) -> None:
-        """Pending-clear slots are not freed from unknown/unavailable states."""
+        """Pending-clear slots are not freed from unavailable states."""
+        from custom_components.rental_control.reconciliation import ActionKind
         from custom_components.rental_control.reconciliation import Reservation
         from custom_components.rental_control.reconciliation import SlotStatus
         from custom_components.rental_control.reconciliation import compute_desired_plan
@@ -5355,8 +5816,8 @@ class TestCoordinatorPersistenceUpdate:
             "mappings": {"wedged-unknown": mapping},
             "blocked_slots": {},
         }
-        hass.states.async_set("text.test_lock_code_slot_10_name", "unknown")
-        hass.states.async_set("text.test_lock_code_slot_10_pin", "unavailable")
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Unknown")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "Unavailable")
         assert coordinator.event_overrides is not None
         coordinator.event_overrides.load_persisted_mappings(
             coordinator._slot_mappings["mappings"]
@@ -5364,7 +5825,7 @@ class TestCoordinatorPersistenceUpdate:
 
         observed = coordinator._observe_managed_slots()
         slot10 = next(slot for slot in observed if slot.slot == 10)
-        assert slot10.status is SlotStatus.PENDING_CLEAR
+        assert slot10.status is SlotStatus.UNKNOWN
 
         reservation = Reservation(
             identity_key="new-unreadable",
@@ -5387,6 +5848,7 @@ class TestCoordinatorPersistenceUpdate:
 
         assert plan.selected == {}
         assert plan.overflow == {"new-unreadable": "no_free_slot"}
+        assert plan.slots[10].action is ActionKind.BLOCKED
 
     def test_adoption_rematch_uses_buffered_observed_dates(
         self, hass: "HomeAssistant"

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -924,8 +924,8 @@ class TestHandleStateChangeStateMutation:
         call_args = mock_coordinator.update_event_overrides.call_args
         assert call_args[0][1] == ""  # slot_code_value should be ""
 
-    async def test_unavailable_slot_name_not_mutated(self) -> None:
-        """Verify State.state is not mutated when slot_name is 'unavailable'.
+    async def test_unavailable_slot_name_not_assumed_empty(self) -> None:
+        """Verify unavailable slot_name state is not assumed empty.
 
         The original code directly set slot_name.state = "" which mutates
         Home Assistant internal State objects. The fix uses local variables.
@@ -973,10 +973,52 @@ class TestHandleStateChangeStateMutation:
 
         # State object must NOT have been mutated
         assert mock_slot_name_state.state == "unavailable"
-        # But update_event_overrides should have been called with ""
-        mock_coordinator.update_event_overrides.assert_awaited_once()
-        call_args = mock_coordinator.update_event_overrides.call_args
-        assert call_args[0][2] == ""  # slot_name_value should be ""
+        mock_coordinator.update_event_overrides.assert_not_awaited()
+
+    async def test_real_pin_without_name_not_marked_free(self) -> None:
+        """Verify a real PIN with cleared name does not clear the override."""
+        lockname = "test_lock"
+        slot_num = 10
+        mock_slot_code_state = MagicMock()
+        mock_slot_code_state.state = "9876"
+        mock_slot_name_state = MagicMock()
+        mock_slot_name_state.state = "unknown"
+        mock_slot_enabled = MagicMock()
+        mock_slot_enabled.state = "on"
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.lockname = lockname
+        mock_coordinator.trim_names = False
+        mock_coordinator.event_overrides = MagicMock()
+        mock_coordinator.event_overrides.async_check_overrides = AsyncMock()
+        mock_coordinator.update_event_overrides = AsyncMock()
+
+        def states_get(entity_id: str) -> MagicMock | None:
+            """Return mock states for various entities."""
+            if "enabled" in entity_id:
+                return mock_slot_enabled
+            if "pin" in entity_id:
+                return mock_slot_code_state
+            if "name" in entity_id:
+                return mock_slot_name_state
+            if "use_date_range" in entity_id:
+                return None
+            return None
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_id": {COORDINATOR: mock_coordinator}}}
+        hass.states.get = states_get
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_id"
+
+        event = MagicMock(spec=Event)
+        event.data = {"entity_id": f"switch.{lockname}_code_slot_{slot_num}_enabled"}
+
+        with patch("custom_components.rental_control.util.asyncio.sleep"):
+            await handle_state_change(hass, config_entry, event)
+
+        mock_coordinator.update_event_overrides.assert_not_awaited()
 
     async def test_trim_preserve_guest_starting_with_prefix(self) -> None:
         """Verify no double prefix stripping when guest name starts with prefix.
@@ -1387,14 +1429,15 @@ class TestClearCodePostClearVerification:
         name_state.state = "unknown"
         coordinator.hass.states.get.return_value = name_state
 
-        await async_fire_clear_code(coordinator, 10)
+        result = await async_fire_clear_code(coordinator, 10)
 
         coordinator.hass.services.async_call.assert_awaited_once()
+        assert result.confirmed is True
 
     async def test_clear_code_skips_unavailable_name_state(
         self,
     ) -> None:
-        """Verify no force-clear when name state is 'unavailable'."""
+        """Verify unavailable name state leaves the clear unconfirmed."""
         coordinator = MagicMock()
         coordinator.name = "Test Rental"
         coordinator.lockname = "front_door"
@@ -1404,9 +1447,36 @@ class TestClearCodePostClearVerification:
         name_state.state = "unavailable"
         coordinator.hass.states.get.return_value = name_state
 
-        await async_fire_clear_code(coordinator, 10)
+        result = await async_fire_clear_code(coordinator, 10)
 
         coordinator.hass.services.async_call.assert_awaited_once()
+        assert result.unconfirmed is True
+
+    async def test_clear_code_keeps_real_pin_unconfirmed(
+        self,
+    ) -> None:
+        """Verify a real PIN prevents clear confirmation with unknown name."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.hass.services.async_call = AsyncMock()
+
+        name_state = MagicMock()
+        name_state.state = "unknown"
+        pin_state = MagicMock()
+        pin_state.state = "9876"
+
+        def states_get(entity_id: str) -> MagicMock:
+            """Return name or PIN state for the clear confirmation."""
+            return pin_state if entity_id.endswith("_pin") else name_state
+
+        coordinator.hass.states.get.side_effect = states_get
+
+        result = await async_fire_clear_code(coordinator, 10)
+
+        coordinator.hass.services.async_call.assert_awaited_once()
+        assert result.unconfirmed is True
+        assert result.lingering_pin is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Production incident

Production systems with managed Keymaster slots stuck in persisted `pending_clear` fences are overflowing every selected reservation because reset slots read as Home Assistant `unknown`, not only as empty strings.

## Root cause

Keymaster reset writes Null text values. Home Assistant exposes those Nulls as `STATE_UNKNOWN` / `"unknown"`. The 3.5.1 self-heal only considered `""` physically empty, so real reset slots with `unknown` name/PIN stayed fenced forever.

## Fix

- Treat `""`, `STATE_UNKNOWN`, and Python `None` as cleared Keymaster text values.
- Normalize all Keymaster text-state checks with `str(value).strip().casefold()`, so `Unknown`, `UNKNOWN`, and whitespace variants behave consistently.
- Apply the shared helpers consistently in coordinator slot observation, pending-clear self-heal, bootstrap, adoption, util clear-confirmation, and state-change handling.
- Keep real PIN strings fenced/occupied even when the name is blank or `unknown` to avoid double-programming.
- Preserve phantom retained-name handling by treating blank/unknown PIN as cleared and resetting/fencing accordingly.

## Conservative unavailable handling

`STATE_UNAVAILABLE` remains unreadable, not empty, after the same trim/casefold normalization. Unavailable pending-clear slots are blocked until the entity resolves to a real cleared state; this avoids freeing a slot that may still physically hold a code.

## Tests

New reproduction tests drive real HA state strings through coordinator observation and reconciliation: all-`unknown` resets across restart, mixed `unknown`/empty resets, mixed-case `Unknown`/`UNKNOWN` resets, unknown PIN not occupied, real PIN safety, unavailable blocking/recovery, plus bootstrap/adoption/state-change guards.