### PR TITLE
Fix(reconcile): Preserve stale coded slots

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -22,6 +22,7 @@ from collections.abc import Mapping
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
+from datetime import timezone
 import logging
 import random
 import re
@@ -108,6 +109,7 @@ from .reconciliation import compute_desired_plan
 from .reconciliation import extract_booking_aliases
 from .reconciliation import find_reservation_rematch
 from .reconciliation import make_reservation_fingerprint
+from .reconciliation import normalize_slot_name_for_fingerprint
 from .util import OperationResult
 from .util import add_call
 from .util import apply_buffer
@@ -855,7 +857,178 @@ Please update Keymaster to at least v0.1.0-b0
 
         return code if code is not None else self._generate_date_based_code(start, end)
 
-    def _build_reservations(self, calendar: list[CalendarEvent]) -> list[_Reservation]:
+    def _merge_observed_slots_into_mappings(
+        self, managed_slots: list[_ManagedSlot]
+    ) -> None:
+        """Refresh persisted actual snapshots from current physical slots.
+
+        Store mappings loaded on restart may contain stale
+        ``last_observed_actual`` snapshots.  Before rematching current
+        calendar reservations, physical Keymaster state must be allowed to
+        win over those stale snapshots so populated slots can be reclaimed
+        rather than stale-cleared.
+        """
+        persisted: dict[str, Any] = self._slot_mappings.get("mappings", {})
+        for ms in managed_slots:
+            if ms.persisted_identity_key is None:
+                continue
+            mapping = persisted.get(ms.persisted_identity_key)
+            if mapping is None:
+                continue
+            mapping["last_observed_actual"] = {
+                "slot": ms.slot,
+                "classification": ms.status.value,
+                "name_state": ms.actual_name,
+                "has_code": ms.actual_code_present,
+                "start_state": _store_datetime(ms.actual_start),
+                "end_state": _store_datetime(ms.actual_end),
+                "use_date_range": ms.date_range_enabled,
+                "enabled": ms.enabled,
+            }
+
+    @staticmethod
+    def _observed_value_as_datetime(value: Any) -> datetime | None:
+        """Return a datetime for an observed Store value, if parseable."""
+        if isinstance(value, datetime):
+            parsed = value
+        elif isinstance(value, str):
+            parsed = dt.parse_datetime(value)
+            if not isinstance(parsed, datetime):
+                return None
+        else:
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def _physical_mapping_matches_reservation(
+        mapping: dict[str, Any],
+        reservation: _Reservation,
+        actual_slot_names: dict[int, str],
+    ) -> bool:
+        """Return whether fresh physical state identifies a reservation."""
+        if not RentalControlCoordinator._physical_mapping_name_matches_reservation(
+            mapping, reservation, actual_slot_names
+        ):
+            return False
+
+        actual = mapping.get("last_observed_actual", {})
+        if not isinstance(actual, dict):
+            return True
+        actual_start = RentalControlCoordinator._observed_value_as_datetime(
+            actual.get("start_state")
+        )
+        actual_end = RentalControlCoordinator._observed_value_as_datetime(
+            actual.get("end_state")
+        )
+        if actual_start is None or actual_end is None:
+            return True
+        return (
+            actual_start == reservation.buffered_start
+            and actual_end == reservation.buffered_end
+        )
+
+    @staticmethod
+    def _physical_mapping_name_matches_reservation(
+        mapping: dict[str, Any],
+        reservation: _Reservation,
+        actual_slot_names: dict[int, str],
+    ) -> bool:
+        """Return whether a fresh physical slot name matches a reservation."""
+        slot_num = mapping.get("slot")
+        if not isinstance(slot_num, int):
+            return False
+        actual_name = actual_slot_names.get(slot_num)
+        if not actual_name:
+            return False
+        actual_name_form = normalize_slot_name_for_fingerprint(actual_name)
+        reservation_name_forms = {
+            normalize_slot_name_for_fingerprint(reservation.slot_name),
+            normalize_slot_name_for_fingerprint(reservation.display_slot_name),
+        }
+        if actual_name_form not in reservation_name_forms:
+            return False
+        return True
+
+    @staticmethod
+    def _remap_observed_mappings_to_physical_reservations(
+        persisted: dict[str, Any],
+        current_reservations: list[_Reservation],
+        actual_slot_names: dict[int, str],
+        observed_mapping_keys: set[str],
+    ) -> set[str]:
+        """Atomically re-key stale Store mappings to current physical occupants."""
+        remap: dict[str, str] = {}
+        target_counts: dict[str, int] = {}
+        for mapping_key in observed_mapping_keys:
+            mapping = persisted.get(mapping_key)
+            if not isinstance(mapping, dict):
+                continue
+            matches = [
+                res.identity_key
+                for res in current_reservations
+                if RentalControlCoordinator._physical_mapping_matches_reservation(
+                    mapping, res, actual_slot_names
+                )
+            ]
+            if len(matches) != 1:
+                continue
+            target_key = matches[0]
+            remap[mapping_key] = target_key
+            target_counts[target_key] = target_counts.get(target_key, 0) + 1
+
+        remap = {
+            source: target
+            for source, target in remap.items()
+            if target_counts.get(target) == 1
+        }
+        if not remap:
+            return observed_mapping_keys
+
+        sources = set(remap)
+        safe_remap = {
+            source: target
+            for source, target in remap.items()
+            if target not in persisted
+            or target in sources
+            or target == source
+            or target not in observed_mapping_keys
+        }
+        if not safe_remap:
+            return observed_mapping_keys
+
+        original_items = list(persisted.items())
+        rebuilt: dict[str, Any] = {}
+        replaced_stale_targets = {
+            target
+            for source, target in safe_remap.items()
+            if target != source and target in persisted and target not in sources
+        }
+        for source_key, mapping in original_items:
+            if source_key in replaced_stale_targets:
+                continue
+            target_key = safe_remap.get(source_key, source_key)
+            if target_key in rebuilt:
+                return observed_mapping_keys
+            if target_key != source_key:
+                history = set(mapping.get("fingerprint_history", []))
+                history.add(source_key)
+                mapping["fingerprint_history"] = sorted(history)
+                identity = mapping.setdefault("identity", {})
+                if isinstance(identity, dict):
+                    identity["identity_key"] = target_key
+            rebuilt[target_key] = mapping
+
+        persisted.clear()
+        persisted.update(rebuilt)
+        return {safe_remap.get(key, key) for key in observed_mapping_keys}
+
+    def _build_reservations(
+        self,
+        calendar: list[CalendarEvent],
+        managed_slots: list[_ManagedSlot] | None = None,
+    ) -> list[_Reservation]:
         """Convert parsed CalendarEvent objects to Reservation objects.
 
         Produces one :class:`~.reconciliation.Reservation` per calendar
@@ -873,6 +1046,9 @@ Please update Keymaster to at least v0.1.0-b0
         Args:
             calendar: Parsed and sorted calendar events from the current
                 refresh cycle.
+            managed_slots: Optional current physical slot observations.
+                When provided, observed names are treated as fresh
+                physical facts for rematching stale persisted mappings.
 
         Returns:
             List of :class:`~.reconciliation.Reservation` objects ready
@@ -887,12 +1063,25 @@ Please update Keymaster to at least v0.1.0-b0
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
         reservations: list[_Reservation] = []
         actual_slot_names: dict[int, str] = {}
-        for persisted_mapping in persisted.values():
-            slot_num = persisted_mapping.get("slot")
-            actual = persisted_mapping.get("last_observed_actual")
-            actual_name = actual.get("name_state") if isinstance(actual, dict) else None
-            if isinstance(slot_num, int) and isinstance(actual_name, str):
-                actual_slot_names[slot_num] = actual_name
+        observed_mapping_keys: set[str] = set()
+        if managed_slots is not None:
+            for ms in managed_slots:
+                if ms.actual_name is not None:
+                    actual_slot_names[ms.slot] = ms.actual_name
+                physical_present = (
+                    bool(ms.actual_name) or ms.actual_code_present is True
+                )
+                if ms.persisted_identity_key is not None and physical_present:
+                    observed_mapping_keys.add(ms.persisted_identity_key)
+        else:
+            for persisted_mapping in persisted.values():
+                slot_num = persisted_mapping.get("slot")
+                actual = persisted_mapping.get("last_observed_actual")
+                actual_name = (
+                    actual.get("name_state") if isinstance(actual, dict) else None
+                )
+                if isinstance(slot_num, int) and isinstance(actual_name, str):
+                    actual_slot_names[slot_num] = actual_name
         current_reservations_for_rematch: list[_Reservation] = []
         for event in calendar:
             slot_name = get_slot_name(
@@ -904,6 +1093,23 @@ Please update Keymaster to at least v0.1.0-b0
                 continue
             rematch_start: datetime = event.start  # type: ignore[assignment]
             rematch_end: datetime = event.end  # type: ignore[assignment]
+            rematch_buffered_start_raw, rematch_buffered_end_raw = apply_buffer(
+                rematch_start,
+                rematch_end,
+                self.code_buffer_before,
+                self.code_buffer_after,
+                self,
+            )
+            rematch_buffered_start: datetime = (
+                rematch_buffered_start_raw
+                if isinstance(rematch_buffered_start_raw, datetime)
+                else rematch_start
+            )
+            rematch_buffered_end: datetime = (
+                rematch_buffered_end_raw
+                if isinstance(rematch_buffered_end_raw, datetime)
+                else rematch_end
+            )
             uid = normalize_uid(getattr(event, "uid", None))
             display_slot_name = _format_display_slot_name(
                 slot_name, prefix, self.trim_names, self.max_name_length
@@ -916,8 +1122,8 @@ Please update Keymaster to at least v0.1.0-b0
                         ),
                         start=rematch_start,
                         end=rematch_end,
-                        buffered_start=rematch_start,
-                        buffered_end=rematch_end,
+                        buffered_start=rematch_buffered_start,
+                        buffered_end=rematch_buffered_end,
                         summary=event.summary,
                         slot_name=slot_name,
                         display_slot_name=display_slot_name,
@@ -930,6 +1136,13 @@ Please update Keymaster to at least v0.1.0-b0
                 )
             except ValueError:
                 continue
+
+        observed_mapping_keys = self._remap_observed_mappings_to_physical_reservations(
+            persisted,
+            current_reservations_for_rematch,
+            actual_slot_names,
+            observed_mapping_keys,
+        )
 
         for event in calendar:
             slot_name = get_slot_name(
@@ -988,10 +1201,47 @@ Please update Keymaster to at least v0.1.0-b0
                 persisted,
                 current_reservations=current_reservations_for_rematch,
                 actual_slot_names=actual_slot_names,
+                observed_mapping_keys=observed_mapping_keys,
             )
             matched_key = rematch.matched_identity_key
             if matched_key is not None and matched_key != identity_key:
+                if identity_key in persisted and identity_key in observed_mapping_keys:
+                    target_mapping = persisted.pop(identity_key)
+                    target_slot = target_mapping.get("slot")
+                    preserved_key = f"observed.{self._entry_id}.slot{target_slot}"
+                    if preserved_key in persisted and preserved_key != matched_key:
+                        persisted[identity_key] = target_mapping
+                        mapping = persisted.get(identity_key, {})
+                        _LOGGER.warning(
+                            "Reservation %s rematch to %s blocked because "
+                            "fresh observed target %s could not be preserved",
+                            identity_key,
+                            matched_key,
+                            preserved_key,
+                        )
+                        matched_key = None
+                    else:
+                        target_identity = target_mapping.setdefault("identity", {})
+                        if isinstance(target_identity, dict):
+                            target_identity["identity_key"] = preserved_key
+                            actual = target_mapping.get("last_observed_actual", {})
+                            actual_name = (
+                                actual.get("name_state")
+                                if isinstance(actual, dict)
+                                else None
+                            )
+                            if isinstance(actual_name, str) and actual_name:
+                                target_identity["summary"] = actual_name
+                                target_identity["slot_name"] = actual_name
+                        persisted[preserved_key] = target_mapping
+                        observed_mapping_keys.remove(identity_key)
+                        observed_mapping_keys.add(preserved_key)
+
+            if matched_key is not None and matched_key != identity_key:
                 mapping = persisted.pop(matched_key)
+                if matched_key in observed_mapping_keys:
+                    observed_mapping_keys.remove(matched_key)
+                    observed_mapping_keys.add(identity_key)
                 history = set(mapping.get("fingerprint_history", []))
                 history.add(matched_key)
                 mapping["fingerprint_history"] = sorted(history)
@@ -1001,6 +1251,32 @@ Please update Keymaster to at least v0.1.0-b0
                 persisted[identity_key] = mapping
             else:
                 mapping = persisted.get(identity_key, {})
+                if (
+                    mapping
+                    and identity_key in observed_mapping_keys
+                    and not self._physical_mapping_name_matches_reservation(
+                        mapping, provisional, actual_slot_names
+                    )
+                ):
+                    target_mapping = persisted.pop(identity_key)
+                    target_slot = target_mapping.get("slot")
+                    preserved_key = f"observed.{self._entry_id}.slot{target_slot}"
+                    target_identity = target_mapping.setdefault("identity", {})
+                    if isinstance(target_identity, dict):
+                        target_identity["identity_key"] = preserved_key
+                        actual = target_mapping.get("last_observed_actual", {})
+                        actual_name = (
+                            actual.get("name_state")
+                            if isinstance(actual, dict)
+                            else None
+                        )
+                        if isinstance(actual_name, str) and actual_name:
+                            target_identity["summary"] = actual_name
+                            target_identity["slot_name"] = actual_name
+                    persisted[preserved_key] = target_mapping
+                    observed_mapping_keys.remove(identity_key)
+                    observed_mapping_keys.add(preserved_key)
+                    mapping = {}
                 if rematch.kind.value == "ambiguous":
                     _LOGGER.warning(
                         "Reservation %s has ambiguous persisted rematch candidates: %s",
@@ -1055,7 +1331,9 @@ Please update Keymaster to at least v0.1.0-b0
         # Build ghost reservations for occupied slots absent from this feed cycle.
         if self.event_overrides is not None:
             current_keys: set[str] = {r.identity_key for r in reservations}
-            ghost_list = self._build_ghost_reservations(current_keys, persisted, prefix)
+            ghost_list = self._build_ghost_reservations(
+                current_keys, persisted, prefix, observed_mapping_keys
+            )
             reservations.extend(ghost_list)
 
         return reservations
@@ -1065,6 +1343,7 @@ Please update Keymaster to at least v0.1.0-b0
         current_keys: set[str],
         persisted: dict[str, Any],
         prefix: str,
+        observed_mapping_keys: set[str] | None = None,
     ) -> list[_Reservation]:
         """Build synthetic Reservations for assigned slots absent from the feed.
 
@@ -1088,6 +1367,8 @@ Please update Keymaster to at least v0.1.0-b0
                 here are reflected directly in the coordinator's live
                 store dict.
             prefix: Computed event-prefix string (e.g. ``"RC "``).
+            observed_mapping_keys: Mapping keys whose observed actual
+                state came from the current physical Keymaster read.
 
         Returns:
             List of ghost :class:`~.reconciliation.Reservation` objects
@@ -1129,6 +1410,35 @@ Please update Keymaster to at least v0.1.0-b0
 
             # Recover dates from the last observed Keymaster state.
             last_actual = mapping.get("last_observed_actual", {})
+            actual_name = last_actual.get("name_state")
+            if (
+                observed_mapping_keys is not None
+                and key in observed_mapping_keys
+                and isinstance(actual_name, str)
+                and slot_name
+                and normalize_slot_name_for_fingerprint(actual_name)
+                not in {
+                    normalize_slot_name_for_fingerprint(slot_name),
+                    normalize_slot_name_for_fingerprint(
+                        _format_display_slot_name(
+                            slot_name,
+                            prefix,
+                            self.trim_names,
+                            self.max_name_length,
+                        )
+                    ),
+                }
+            ):
+                _LOGGER.debug(
+                    "Ghost reservation %s: physical name %r differs from "
+                    "persisted identity %r; preserving slot as unmatched with "
+                    "missing_count=%d",
+                    key,
+                    actual_name,
+                    slot_name,
+                    new_mc,
+                )
+                continue
             start_raw = last_actual.get("start_state")
             end_raw = last_actual.get("end_state")
 
@@ -1469,6 +1779,14 @@ Please update Keymaster to at least v0.1.0-b0
                 if persisted_mapping is not None
                 else None
             )
+            persisted_missing_raw = (
+                persisted_mapping.get("missing_count", 0)
+                if persisted_mapping is not None
+                else 0
+            )
+            persisted_missing_count = (
+                persisted_missing_raw if isinstance(persisted_missing_raw, int) else 0
+            )
             if physically_empty and i in pending_clear:
                 self.event_overrides.release_pending_clear_slot(i)
                 for key in [
@@ -1482,6 +1800,7 @@ Please update Keymaster to at least v0.1.0-b0
                 persisted_key = None
                 persisted_mapping = None
                 persisted_status = None
+                persisted_missing_count = 0
 
             if i in pending_clear:
                 status = _SlotStatus.PENDING_CLEAR
@@ -1514,6 +1833,13 @@ Please update Keymaster to at least v0.1.0-b0
                 enabled=enabled,
                 persisted_identity_key=persisted_key,
                 blocked_reason=blocked_reason,
+                preserve_unmatched=(
+                    status is _SlotStatus.OCCUPIED
+                    and persisted_status
+                    in (SLOT_STATUS_OCCUPIED, SLOT_STATUS_PENDING_SET)
+                    and (bool(name_value) or has_code)
+                    and persisted_missing_count < 3
+                ),
                 last_error=self.event_overrides.get_last_slot_error(i),
             )
             slots.append(ms)
@@ -1693,7 +2019,12 @@ Please update Keymaster to at least v0.1.0-b0
 
         if self.event_overrides:
             try:
-                reservations = self._build_reservations(new_calendar)
+                self.event_overrides.load_persisted_mappings(
+                    self._slot_mappings.get("mappings", {})
+                )
+                observed_slots = self._observe_managed_slots()
+                self._merge_observed_slots_into_mappings(observed_slots)
+                reservations = self._build_reservations(new_calendar, observed_slots)
                 self.event_overrides.load_persisted_mappings(
                     self._slot_mappings.get("mappings", {})
                 )

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -282,6 +282,11 @@ class ManagedSlot:
         persisted_identity_key: Previously stored reservation for this
             slot.
         blocked_reason: Reason the slot cannot be reused.
+        preserve_unmatched: True when a populated physical slot with a
+            persisted owner should be fenced if it cannot be matched to a
+            current reservation yet.  This extends the adopted-slot
+            preservation invariant to freshly observed stale Store mappings
+            while their missing-count tolerance has not expired.
         retry_count: Consecutive failed physical operations for this
             slot.
         last_operation_id: Reconcile operation token used to classify
@@ -306,6 +311,7 @@ class ManagedSlot:
     desired_identity_key: str | None = None
     persisted_identity_key: str | None = None
     blocked_reason: str | None = None
+    preserve_unmatched: bool = False
     retry_count: int = 0
     last_operation_id: str | None = None
     dirty_during_operation: bool = False
@@ -825,6 +831,40 @@ def _is_adopted_mapping(mapping_key: str, mapping: dict[str, Any]) -> bool:
     )
 
 
+def _should_include_observed_mapping(
+    mapping_key: str,
+    mapping: dict[str, Any],
+    observed_mapping_keys: set[str] | None,
+) -> bool:
+    """Return whether observed physical fields may participate in rematch."""
+    return _is_adopted_mapping(mapping_key, mapping) or (
+        observed_mapping_keys is not None and mapping_key in observed_mapping_keys
+    )
+
+
+def _fresh_observed_name_conflicts(
+    reservation: Reservation,
+    mapping_key: str,
+    mapping: dict[str, Any],
+    actual_slot_names: dict[int, str] | None,
+    observed_mapping_keys: set[str] | None,
+) -> bool:
+    """Return whether a fresh physical slot name contradicts an exact mapping."""
+    if observed_mapping_keys is None or mapping_key not in observed_mapping_keys:
+        return False
+    if actual_slot_names is None:
+        return False
+    slot_num: int | None = mapping.get("slot")
+    if slot_num is None:
+        return False
+    actual_name = actual_slot_names.get(slot_num)
+    if not actual_name:
+        return False
+    return normalize_slot_name_for_fingerprint(
+        actual_name
+    ) not in _normalized_name_forms(reservation)
+
+
 def _as_utc_datetime(value: Any) -> datetime | None:
     """Parse a stored datetime value and normalize it to UTC."""
     if isinstance(value, datetime):
@@ -887,6 +927,7 @@ def _is_continuity_compatible(
     mapping_key: str,
     mapping: dict[str, Any],
     actual_slot_names: dict[int, str] | None,
+    observed_mapping_keys: set[str] | None,
 ) -> bool:
     """Return ``True`` if *mapping* is continuity-compatible with *reservation*.
 
@@ -909,6 +950,8 @@ def _is_continuity_compatible(
         mapping: Raw Store mapping dict.
         actual_slot_names: Optional mapping of slot number → current
             Keymaster slot name for actual-slot continuity checks.
+        observed_mapping_keys: Mapping keys whose observed state was
+            refreshed from physical Keymaster entities this cycle.
 
     Returns:
         ``True`` if the mapping is continuity-compatible with the
@@ -918,7 +961,9 @@ def _is_continuity_compatible(
         mapping,
         reservation,
         actual_slot_names,
-        include_observed=_is_adopted_mapping(mapping_key, mapping),
+        include_observed=_should_include_observed_mapping(
+            mapping_key, mapping, observed_mapping_keys
+        ),
     ):
         return False
 
@@ -957,6 +1002,7 @@ def _has_competing_reservation(
     persisted_mappings: dict[str, dict[str, Any]],
     current_reservations: list[Reservation] | None,
     this_reservation: Reservation,
+    observed_mapping_keys: set[str] | None,
 ) -> bool:
     """Return ``True`` if another current reservation also matches *candidate_key*.
 
@@ -971,6 +1017,8 @@ def _has_competing_reservation(
         current_reservations: All current reservations being reconciled.
         this_reservation: The reservation being matched (excluded from
             the competition check).
+        observed_mapping_keys: Mapping keys whose observed state was
+            refreshed from physical Keymaster entities this cycle.
 
     Returns:
         ``True`` if at least one other current reservation competes for
@@ -979,7 +1027,9 @@ def _has_competing_reservation(
     if current_reservations is None:
         return False
     candidate_mapping = persisted_mappings.get(candidate_key, {})
-    include_observed = _is_adopted_mapping(candidate_key, candidate_mapping)
+    include_observed = _should_include_observed_mapping(
+        candidate_key, candidate_mapping, observed_mapping_keys
+    )
     candidate_dates_match_this = _mapping_dates_match_reservation(
         candidate_mapping,
         this_reservation,
@@ -1008,6 +1058,7 @@ def find_reservation_rematch(
     persisted_mappings: dict[str, dict[str, Any]],
     current_reservations: list[Reservation] | None = None,
     actual_slot_names: dict[int, str] | None = None,
+    observed_mapping_keys: set[str] | None = None,
 ) -> RematchResult:
     """Find the best identity rematch for *reservation* in *persisted_mappings*.
 
@@ -1051,16 +1102,46 @@ def find_reservation_rematch(
         actual_slot_names: Mapping of Keymaster slot number to the
             currently observed slot name entity state.  Provides the
             actual-slot continuity signal in rule 5.  Optional.
+        observed_mapping_keys: Persisted mapping keys whose
+            ``last_observed_actual`` fields were refreshed from current
+            physical Keymaster state in this reconciliation cycle.
+            Observed fields for other non-adopted mappings are ignored
+            to avoid trusting stale Store snapshots.
 
     Returns:
         A :class:`RematchResult` describing the best match found.
     """
     # Rule 1: exact primary fingerprint match
     if reservation.identity_key in persisted_mappings:
-        return RematchResult(
-            kind=RematchKind.EXACT,
-            matched_identity_key=reservation.identity_key,
+        exact_mapping = persisted_mappings[reservation.identity_key]
+        if not _fresh_observed_name_conflicts(
+            reservation,
+            reservation.identity_key,
+            exact_mapping,
+            actual_slot_names,
+            observed_mapping_keys,
+        ):
+            return RematchResult(
+                kind=RematchKind.EXACT,
+                matched_identity_key=reservation.identity_key,
+            )
+        _LOGGER.debug(
+            "Exact persisted mapping %s skipped because current physical "
+            "slot name conflicts with the reservation",
+            reservation.identity_key,
         )
+
+    candidate_mappings = [
+        (mapping_key, mapping)
+        for mapping_key, mapping in persisted_mappings.items()
+        if not _fresh_observed_name_conflicts(
+            reservation,
+            mapping_key,
+            mapping,
+            actual_slot_names,
+            observed_mapping_keys,
+        )
+    ]
 
     # Rule 2: UID alias + normalized name match
     # If a UID alias matches but rule 1 did not fire, the fingerprint must
@@ -1068,7 +1149,7 @@ def find_reservation_rematch(
     # end, and entry_id is constant per instance, different fingerprint with
     # matching name means the dates shifted → date_shifted=True always.
     uid_matches: list[str] = []
-    for mapping_key, mapping in persisted_mappings.items():
+    for mapping_key, mapping in candidate_mappings:
         persisted_uids: set[str] = set(
             _get_nested(mapping, "identity", "uid_aliases") or []
         )
@@ -1077,7 +1158,9 @@ def find_reservation_rematch(
                 mapping,
                 reservation,
                 actual_slot_names,
-                include_observed=_is_adopted_mapping(mapping_key, mapping),
+                include_observed=_should_include_observed_mapping(
+                    mapping_key, mapping, observed_mapping_keys
+                ),
             ):
                 uid_matches.append(mapping_key)
 
@@ -1098,7 +1181,7 @@ def find_reservation_rematch(
     # Collect all matches to detect ambiguous scenarios (e.g. duplicate
     # booking codes across two persisted mappings).
     booking_matches: list[str] = []
-    for mapping_key, mapping in persisted_mappings.items():
+    for mapping_key, mapping in candidate_mappings:
         persisted_booking: set[str] = set(
             _get_nested(mapping, "identity", "booking_aliases") or []
         )
@@ -1107,7 +1190,9 @@ def find_reservation_rematch(
                 mapping,
                 reservation,
                 actual_slot_names,
-                include_observed=_is_adopted_mapping(mapping_key, mapping),
+                include_observed=_should_include_observed_mapping(
+                    mapping_key, mapping, observed_mapping_keys
+                ),
             ):
                 booking_matches.append(mapping_key)
 
@@ -1125,12 +1210,14 @@ def find_reservation_rematch(
 
     # Rule 4: name + exact start/end stored in identity dict
     name_time_matches: list[str] = []
-    for mapping_key, mapping in persisted_mappings.items():
+    for mapping_key, mapping in candidate_mappings:
         if not _mapping_name_matches_reservation(
             mapping,
             reservation,
             actual_slot_names,
-            include_observed=_is_adopted_mapping(mapping_key, mapping),
+            include_observed=_should_include_observed_mapping(
+                mapping_key, mapping, observed_mapping_keys
+            ),
         ):
             continue
         if _mapping_dates_match_reservation(
@@ -1154,12 +1241,13 @@ def find_reservation_rematch(
     # Rule 5: conservative continuity rematch
     candidates: list[str] = [
         mapping_key
-        for mapping_key, mapping in persisted_mappings.items()
+        for mapping_key, mapping in candidate_mappings
         if _is_continuity_compatible(
             reservation,
             mapping_key,
             mapping,
             actual_slot_names,
+            observed_mapping_keys,
         )
     ]
 
@@ -1169,6 +1257,7 @@ def find_reservation_rematch(
             persisted_mappings,
             current_reservations,
             reservation,
+            observed_mapping_keys,
         ):
             return RematchResult(
                 kind=RematchKind.CONTINUITY,
@@ -1188,8 +1277,8 @@ def find_reservation_rematch(
             if _mapping_dates_match_reservation(
                 persisted_mappings[candidate],
                 reservation,
-                include_observed=_is_adopted_mapping(
-                    candidate, persisted_mappings[candidate]
+                include_observed=_should_include_observed_mapping(
+                    candidate, persisted_mappings[candidate], observed_mapping_keys
                 ),
             )
         ]
@@ -1391,12 +1480,26 @@ def _build_slot_action(
     if desired_key is None:
         if ms.status is SlotStatus.FREE:
             return ActionKind.NOOP, None
+        persisted_res = (
+            res_by_key.get(ms.persisted_identity_key)
+            if ms.persisted_identity_key is not None
+            else None
+        )
         if (
             ms.status is SlotStatus.OCCUPIED
             and ms.persisted_identity_key is not None
-            and ms.persisted_identity_key.startswith("adopted.")
+            and not (persisted_res is not None and persisted_res.checked_out)
+            and (
+                ms.persisted_identity_key.startswith("adopted.")
+                or ms.preserve_unmatched
+            )
         ):
-            return ActionKind.BLOCKED, "adopted_unmatched"
+            reason = (
+                "adopted_unmatched"
+                if ms.persisted_identity_key.startswith("adopted.")
+                else "persisted_unmatched_physical"
+            )
+            return ActionKind.BLOCKED, reason
         return ActionKind.CLEAR, None
 
     desired_res = res_by_key.get(desired_key)
@@ -1675,7 +1778,11 @@ def compute_desired_plan(
         if not ms.managed:
             continue
         desired_key = slot_to_identity.get(ms.slot)
-        action, pending_reason = _build_slot_action(ms, desired_key, res_by_key)
+        if ms.slot in _non_canonical_slots:
+            action = ActionKind.CLEAR
+            pending_reason = None
+        else:
+            action, pending_reason = _build_slot_action(ms, desired_key, res_by_key)
         if (
             action is ActionKind.RETRY_CLEAR
             and ms.persisted_identity_key in plan.protected

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -4424,6 +4424,838 @@ class TestStoreFirstUpgradeMigration:
         assert 10 in eo2.pending_clear_slots, "Fence should be restored after restart"
 
 
+class TestStaleStorePhysicalReconciliation:
+    """Regression tests for stale Store mappings over real Keymaster state."""
+
+    def _make_lock_entry(
+        self,
+        entry_id: str = "stale_store_entry",
+        lockname: str = "stale_lock",
+        start_slot: int = 6,
+        max_events: int = 2,
+        event_prefix: str | None = None,
+        trim_names: bool = False,
+        max_name_length: int = 40,
+    ) -> MockConfigEntry:
+        """Create a config entry with a Keymaster lock for stale-store tests."""
+        data = {
+            "name": "Stale Store Rental",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "UTC",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            "start_slot": start_slot,
+            "max_events": max_events,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "honor_event_times": False,
+            "keymaster_entry_id": lockname,
+            "code_buffer_before": 0,
+            "code_buffer_after": 0,
+            "trim_names": trim_names,
+            "max_name_length": max_name_length,
+        }
+        if event_prefix is not None:
+            data["event_prefix"] = event_prefix
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Stale Store Rental",
+            version=10,
+            unique_id=f"stale-store-{entry_id}",
+            data=data,
+            entry_id=entry_id,
+        )
+
+    @staticmethod
+    def _set_physical_slot(
+        hass: HomeAssistant,
+        *,
+        lockname: str = "stale_lock",
+        slot: int,
+        name: str,
+        pin: str,
+        start: datetime,
+        end: datetime,
+    ) -> None:
+        """Set Keymaster entity states exactly as HA exposes real slots."""
+        hass.states.async_set(f"text.{lockname}_code_slot_{slot}_name", name)
+        hass.states.async_set(f"text.{lockname}_code_slot_{slot}_pin", pin)
+        hass.states.async_set(
+            f"switch.{lockname}_code_slot_{slot}_use_date_range_limits", "on"
+        )
+        hass.states.async_set(f"switch.{lockname}_code_slot_{slot}_enabled", "on")
+        hass.states.async_set(
+            f"datetime.{lockname}_code_slot_{slot}_date_range_start",
+            start.isoformat(),
+        )
+        hass.states.async_set(
+            f"datetime.{lockname}_code_slot_{slot}_date_range_end",
+            end.isoformat(),
+        )
+
+    @staticmethod
+    def _stale_mapping(
+        *,
+        identity_key: str,
+        slot: int,
+        stale_name: str,
+        missing_count: int = 0,
+    ) -> dict[str, Any]:
+        """Build a stale persisted mapping whose observed state is not useful."""
+        return {
+            "slot": slot,
+            "status": "occupied",
+            "operation_id": None,
+            "operation_kind": None,
+            "identity": {
+                "identity_key": identity_key,
+                "summary": stale_name,
+                "slot_name": stale_name,
+                "uid_aliases": [],
+                "booking_aliases": [],
+            },
+            "missing_count": missing_count,
+            "pending_set_since": None,
+            "pending_clear_since": None,
+            "fingerprint_history": [],
+            "updated_at": "2026-06-01T00:00:00+00:00",
+            "last_observed_actual": {
+                "slot": slot,
+                "classification": "occupied",
+                "name_state": stale_name,
+                "has_code": True,
+                "start_state": None,
+                "end_state": None,
+                "use_date_range": True,
+                "enabled": True,
+            },
+        }
+
+    @staticmethod
+    async def _confirmed_clear(_coordinator: Any, slot: int, **_kwargs: Any) -> Any:
+        """Return a confirmed clear OperationResult for patched service calls."""
+        from custom_components.rental_control.util import OperationResult
+
+        return OperationResult(kind="clear", slot=slot, confirmed=True)
+
+    async def test_stale_store_does_not_wipe_populated_slots_on_load(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Stale Store identities must not clear populated physical slots."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_lock_entry()
+        entry.add_to_hass(hass)
+
+        start_a = datetime(2026, 7, 1, 16, 0, tzinfo=dt_util.UTC)
+        end_a = datetime(2026, 7, 5, 11, 0, tzinfo=dt_util.UTC)
+        start_b = datetime(2026, 7, 6, 16, 0, tzinfo=dt_util.UTC)
+        end_b = datetime(2026, 7, 10, 11, 0, tzinfo=dt_util.UTC)
+        self._set_physical_slot(
+            hass, slot=6, name="Alice Guest", pin="1234", start=start_a, end=end_a
+        )
+        self._set_physical_slot(
+            hass, slot=7, name="Bob Guest", pin="5678", start=start_b, end=end_b
+        )
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                "stale-alice": self._stale_mapping(
+                    identity_key="stale-alice",
+                    slot=6,
+                    stale_name="Former Alice",
+                ),
+                "stale-bob": self._stale_mapping(
+                    identity_key="stale-bob",
+                    slot=7,
+                    stale_name="Former Bob",
+                ),
+            },
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        await coordinator.async_setup_keymaster_overrides()
+
+        events = [
+            CalendarEvent(start=start_a, end=end_a, summary="Alice Guest", uid="uid-a"),
+            CalendarEvent(start=start_b, end=end_b, summary="Bob Guest", uid="uid-b"),
+        ]
+        alice_key = make_reservation_fingerprint(
+            entry.entry_id, "Alice Guest", start_a, end_a
+        )
+        bob_key = make_reservation_fingerprint(
+            entry.entry_id, "Bob Guest", start_b, end_b
+        )
+
+        with (
+            patch.object(
+                dt_util, "now", return_value=datetime(2026, 6, 21, tzinfo=dt_util.UTC)
+            ),
+            patch.object(
+                dt_util,
+                "start_of_local_day",
+                return_value=datetime(2026, 6, 21, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                coordinator, "_async_fetch_calendar", new=AsyncMock(return_value=events)
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(side_effect=self._confirmed_clear),
+            ) as clear_mock,
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(),
+            ) as set_mock,
+        ):
+            await coordinator._async_update_data()
+
+        cleared_slots = [call.args[1] for call in clear_mock.await_args_list]
+        assert 6 not in cleared_slots
+        assert 7 not in cleared_slots
+        set_mock.assert_not_awaited()
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.overflow == {}
+        assert coordinator._latest_plan.selected[alice_key] == 6
+        assert coordinator._latest_plan.selected[bob_key] == 7
+        assert hass.states.get("text.stale_lock_code_slot_6_pin").state == "1234"  # type: ignore[union-attr]
+        assert hass.states.get("text.stale_lock_code_slot_7_pin").state == "5678"  # type: ignore[union-attr]
+
+    async def test_stale_store_current_reservations_reclaim_slots(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Current reservations reclaim the slots their codes occupy."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_lock_entry(entry_id="stale_store_reclaim")
+        entry.add_to_hass(hass)
+
+        start = datetime(2026, 8, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 8, 4, 11, 0, tzinfo=dt_util.UTC)
+        self._set_physical_slot(
+            hass, slot=6, name="Carol Guest", pin="2468", start=start, end=end
+        )
+        self._set_physical_slot(
+            hass,
+            slot=7,
+            name="Other Occupant",
+            pin="1357",
+            start=start + timedelta(days=5),
+            end=end + timedelta(days=5),
+        )
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                "stale-carol": self._stale_mapping(
+                    identity_key="stale-carol",
+                    slot=6,
+                    stale_name="Old Carol",
+                ),
+                "stale-other": self._stale_mapping(
+                    identity_key="stale-other",
+                    slot=7,
+                    stale_name="Old Other",
+                ),
+            },
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        await coordinator.async_setup_keymaster_overrides()
+
+        event = CalendarEvent(start=start, end=end, summary="Carol Guest", uid="uid-c")
+        current_key = make_reservation_fingerprint(
+            entry.entry_id, "Carol Guest", start, end
+        )
+
+        with (
+            patch.object(
+                dt_util, "now", return_value=datetime(2026, 7, 1, tzinfo=dt_util.UTC)
+            ),
+            patch.object(
+                dt_util,
+                "start_of_local_day",
+                return_value=datetime(2026, 7, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                coordinator,
+                "_async_fetch_calendar",
+                new=AsyncMock(return_value=[event]),
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(side_effect=self._confirmed_clear),
+            ) as clear_mock,
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(),
+            ) as set_mock,
+        ):
+            await coordinator._async_update_data()
+
+        clear_mock.assert_not_awaited()
+        set_mock.assert_not_awaited()
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected[current_key] == 6
+        mappings = coordinator._slot_mappings["mappings"]
+        assert mappings[current_key]["slot"] == 6
+        assert "stale-carol" not in mappings
+
+    async def test_genuine_departure_still_clears_after_miss_tolerance(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A truly departed persisted mapping still clears on the third miss."""
+        entry = self._make_lock_entry(entry_id="stale_store_departed", max_events=1)
+        entry.add_to_hass(hass)
+
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 9, 5, 11, 0, tzinfo=dt_util.UTC)
+        self._set_physical_slot(
+            hass, slot=6, name="Departed Guest", pin="7777", start=start, end=end
+        )
+
+        mapping = self._stale_mapping(
+            identity_key="departed-key",
+            slot=6,
+            stale_name="Departed Guest",
+            missing_count=2,
+        )
+        mapping["last_observed_actual"]["start_state"] = start.isoformat()
+        mapping["last_observed_actual"]["end_state"] = end.isoformat()
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {"departed-key": mapping},
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        await coordinator.async_setup_keymaster_overrides()
+
+        with (
+            patch.object(
+                dt_util, "now", return_value=datetime(2026, 8, 1, tzinfo=dt_util.UTC)
+            ),
+            patch.object(
+                dt_util,
+                "start_of_local_day",
+                return_value=datetime(2026, 8, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                coordinator, "_async_fetch_calendar", new=AsyncMock(return_value=[])
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(side_effect=self._confirmed_clear),
+            ) as clear_mock,
+        ):
+            await coordinator._async_update_data()
+
+        clear_mock.assert_awaited()
+        assert any(call.args[1] == 6 for call in clear_mock.await_args_list)
+
+    async def test_coded_slot_is_not_reassigned_to_different_reservation(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A coded slot is never handed to a different reservation."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_lock_entry(entry_id="stale_store_no_double", max_events=1)
+        entry.add_to_hass(hass)
+
+        occupied_start = datetime(2026, 10, 1, 16, 0, tzinfo=dt_util.UTC)
+        occupied_end = datetime(2026, 10, 5, 11, 0, tzinfo=dt_util.UTC)
+        self._set_physical_slot(
+            hass,
+            slot=6,
+            name="Occupied Stranger",
+            pin="8888",
+            start=occupied_start,
+            end=occupied_end,
+        )
+
+        new_start = datetime(2026, 10, 6, 16, 0, tzinfo=dt_util.UTC)
+        new_end = datetime(2026, 10, 10, 11, 0, tzinfo=dt_util.UTC)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                "stale-stranger": self._stale_mapping(
+                    identity_key="stale-stranger",
+                    slot=6,
+                    stale_name="Old Stranger",
+                )
+            },
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        await coordinator.async_setup_keymaster_overrides()
+
+        event = CalendarEvent(start=new_start, end=new_end, summary="New Guest")
+        new_key = make_reservation_fingerprint(
+            entry.entry_id, "New Guest", new_start, new_end
+        )
+
+        with (
+            patch.object(
+                dt_util, "now", return_value=datetime(2026, 9, 1, tzinfo=dt_util.UTC)
+            ),
+            patch.object(
+                dt_util,
+                "start_of_local_day",
+                return_value=datetime(2026, 9, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                coordinator,
+                "_async_fetch_calendar",
+                new=AsyncMock(return_value=[event]),
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(side_effect=self._confirmed_clear),
+            ) as clear_mock,
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(),
+            ) as set_mock,
+        ):
+            await coordinator._async_update_data()
+
+        clear_mock.assert_not_awaited()
+        set_mock.assert_not_awaited()
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected.get(new_key) is None
+        assert coordinator._latest_plan.overflow[new_key] == "no_free_slot"
+
+    async def test_exact_store_identity_yields_to_conflicting_physical_slot(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Fresh physical names win over exact but stale Store slot claims."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_lock_entry(entry_id="stale_store_exact_swap")
+        entry.add_to_hass(hass)
+
+        alice_start = datetime(2026, 11, 1, 16, 0, tzinfo=dt_util.UTC)
+        alice_end = datetime(2026, 11, 5, 11, 0, tzinfo=dt_util.UTC)
+        bob_start = datetime(2026, 11, 6, 16, 0, tzinfo=dt_util.UTC)
+        bob_end = datetime(2026, 11, 10, 11, 0, tzinfo=dt_util.UTC)
+        alice_key = make_reservation_fingerprint(
+            entry.entry_id, "Alice Guest", alice_start, alice_end
+        )
+        bob_key = make_reservation_fingerprint(
+            entry.entry_id, "Bob Guest", bob_start, bob_end
+        )
+
+        self._set_physical_slot(
+            hass, slot=6, name="Bob Guest", pin="5678", start=bob_start, end=bob_end
+        )
+        self._set_physical_slot(
+            hass,
+            slot=7,
+            name="Alice Guest",
+            pin="1234",
+            start=alice_start,
+            end=alice_end,
+        )
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                alice_key: self._stale_mapping(
+                    identity_key=alice_key,
+                    slot=6,
+                    stale_name="Alice Guest",
+                ),
+                bob_key: self._stale_mapping(
+                    identity_key=bob_key,
+                    slot=7,
+                    stale_name="Bob Guest",
+                ),
+            },
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        await coordinator.async_setup_keymaster_overrides()
+
+        events = [
+            CalendarEvent(
+                start=alice_start, end=alice_end, summary="Alice Guest", uid="uid-a"
+            ),
+            CalendarEvent(
+                start=bob_start, end=bob_end, summary="Bob Guest", uid="uid-b"
+            ),
+        ]
+        with (
+            patch.object(
+                dt_util,
+                "now",
+                return_value=datetime(2026, 10, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                dt_util,
+                "start_of_local_day",
+                return_value=datetime(2026, 10, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                coordinator, "_async_fetch_calendar", new=AsyncMock(return_value=events)
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(side_effect=self._confirmed_clear),
+            ) as clear_mock,
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(),
+            ) as set_mock,
+        ):
+            await coordinator._async_update_data()
+
+        clear_mock.assert_not_awaited()
+        set_mock.assert_not_awaited()
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected[alice_key] == 7
+        assert coordinator._latest_plan.selected[bob_key] == 6
+
+    async def test_exact_conflict_without_rematch_is_quarantined(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Exact Store key with different physical occupant is not overwritten."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_lock_entry(entry_id="stale_store_exact_conflict")
+        entry.add_to_hass(hass)
+
+        alice_start = datetime(2027, 2, 1, 16, 0, tzinfo=dt_util.UTC)
+        alice_end = datetime(2027, 2, 5, 11, 0, tzinfo=dt_util.UTC)
+        stranger_start = datetime(2027, 2, 6, 16, 0, tzinfo=dt_util.UTC)
+        stranger_end = datetime(2027, 2, 10, 11, 0, tzinfo=dt_util.UTC)
+        alice_key = make_reservation_fingerprint(
+            entry.entry_id, "Alice Guest", alice_start, alice_end
+        )
+        self._set_physical_slot(
+            hass,
+            slot=6,
+            name="Occupied Stranger",
+            pin="8888",
+            start=stranger_start,
+            end=stranger_end,
+        )
+        hass.states.async_set("text.stale_lock_code_slot_7_name", "")
+        hass.states.async_set("text.stale_lock_code_slot_7_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                alice_key: self._stale_mapping(
+                    identity_key=alice_key,
+                    slot=6,
+                    stale_name="Alice Guest",
+                )
+            },
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        await coordinator.async_setup_keymaster_overrides()
+
+        event = CalendarEvent(start=alice_start, end=alice_end, summary="Alice Guest")
+        with (
+            patch.object(
+                dt_util,
+                "now",
+                return_value=datetime(2027, 1, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                dt_util,
+                "start_of_local_day",
+                return_value=datetime(2027, 1, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                coordinator,
+                "_async_fetch_calendar",
+                new=AsyncMock(return_value=[event]),
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(side_effect=self._confirmed_clear),
+            ) as clear_mock,
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(),
+            ) as set_mock,
+        ):
+            await coordinator._async_update_data()
+
+        clear_mock.assert_not_awaited()
+        set_slots = [call.args[1] for call in set_mock.await_args_list]
+        assert 6 not in set_slots
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected[alice_key] == 7
+        assert any(
+            mapping["slot"] == 6 and key.startswith("observed.")
+            for key, mapping in coordinator._slot_mappings["mappings"].items()
+        )
+
+    async def test_physical_reclaim_replaces_stale_empty_exact_mapping(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Fresh occupied physical mapping replaces same-key stale empty slot."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_lock_entry(entry_id="stale_store_empty_target")
+        entry.add_to_hass(hass)
+
+        start = datetime(2026, 12, 1, 16, 0, tzinfo=dt_util.UTC)
+        end = datetime(2026, 12, 5, 11, 0, tzinfo=dt_util.UTC)
+        current_key = make_reservation_fingerprint(
+            entry.entry_id, "Alice Guest", start, end
+        )
+        self._set_physical_slot(
+            hass, slot=6, name="Alice Guest", pin="1234", start=start, end=end
+        )
+        hass.states.async_set("text.stale_lock_code_slot_7_name", "")
+        hass.states.async_set("text.stale_lock_code_slot_7_pin", "")
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                "stale-alice": self._stale_mapping(
+                    identity_key="stale-alice",
+                    slot=6,
+                    stale_name="Old Alice",
+                ),
+                current_key: self._stale_mapping(
+                    identity_key=current_key,
+                    slot=7,
+                    stale_name="Alice Guest",
+                ),
+            },
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        await coordinator.async_setup_keymaster_overrides()
+
+        event = CalendarEvent(start=start, end=end, summary="Alice Guest")
+        with (
+            patch.object(
+                dt_util,
+                "now",
+                return_value=datetime(2026, 11, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                dt_util,
+                "start_of_local_day",
+                return_value=datetime(2026, 11, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                coordinator,
+                "_async_fetch_calendar",
+                new=AsyncMock(return_value=[event]),
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(side_effect=self._confirmed_clear),
+            ) as clear_mock,
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(),
+            ) as set_mock,
+        ):
+            await coordinator._async_update_data()
+
+        clear_mock.assert_not_awaited()
+        set_mock.assert_not_awaited()
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected[current_key] == 6
+        assert coordinator._slot_mappings["mappings"][current_key]["slot"] == 6
+        assert "stale-alice" not in coordinator._slot_mappings["mappings"]
+
+    async def test_rematch_preserves_conflicting_fresh_target_mapping(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Rematch does not orphan a fresh occupied target-key mapping."""
+        from custom_components.rental_control.reconciliation import (
+            make_reservation_fingerprint,
+        )
+
+        entry = self._make_lock_entry(entry_id="stale_store_fresh_target")
+        entry.add_to_hass(hass)
+
+        alice_start = datetime(2027, 1, 1, 16, 0, tzinfo=dt_util.UTC)
+        alice_end = datetime(2027, 1, 5, 11, 0, tzinfo=dt_util.UTC)
+        charlie_start = datetime(2027, 1, 6, 16, 0, tzinfo=dt_util.UTC)
+        charlie_end = datetime(2027, 1, 10, 11, 0, tzinfo=dt_util.UTC)
+        alice_key = make_reservation_fingerprint(
+            entry.entry_id, "Alice Guest", alice_start, alice_end
+        )
+        self._set_physical_slot(
+            hass,
+            slot=6,
+            name="Alice Guest",
+            pin="1234",
+            start=alice_start,
+            end=alice_end,
+        )
+        self._set_physical_slot(
+            hass,
+            slot=7,
+            name="Charlie Guest",
+            pin="9999",
+            start=charlie_start,
+            end=charlie_end,
+        )
+
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {
+            "schema_version": 1,
+            "entry_id": entry.entry_id,
+            "mappings": {
+                "stale-alice": self._stale_mapping(
+                    identity_key="stale-alice",
+                    slot=6,
+                    stale_name="Old Alice",
+                ),
+                alice_key: self._stale_mapping(
+                    identity_key=alice_key,
+                    slot=7,
+                    stale_name="Alice Guest",
+                ),
+            },
+            "blocked_slots": {},
+        }
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings(
+            coordinator._slot_mappings["mappings"]
+        )
+        await coordinator.async_setup_keymaster_overrides()
+
+        event = CalendarEvent(start=alice_start, end=alice_end, summary="Alice Guest")
+        with (
+            patch.object(
+                dt_util,
+                "now",
+                return_value=datetime(2026, 12, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                dt_util,
+                "start_of_local_day",
+                return_value=datetime(2026, 12, 1, tzinfo=dt_util.UTC),
+            ),
+            patch.object(
+                coordinator,
+                "_async_fetch_calendar",
+                new=AsyncMock(return_value=[event]),
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(side_effect=self._confirmed_clear),
+            ) as clear_mock,
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                new=AsyncMock(),
+            ) as set_mock,
+        ):
+            await coordinator._async_update_data()
+
+        clear_mock.assert_not_awaited()
+        set_mock.assert_not_awaited()
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected[alice_key] == 6
+        mappings = coordinator._slot_mappings["mappings"]
+        assert mappings[alice_key]["slot"] == 6
+        assert any(
+            mapping["slot"] == 7 and key.startswith("observed.")
+            for key, mapping in mappings.items()
+        )
+
+    def test_trimmed_prefixed_physical_name_does_not_skip_ghost(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Trimmed Keymaster display names do not look like ghost conflicts."""
+        entry = self._make_lock_entry(
+            entry_id="stale_store_trimmed_ghost",
+            event_prefix="RC",
+            trim_names=True,
+            max_name_length=12,
+        )
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        mapping = self._stale_mapping(
+            identity_key="trimmed-key",
+            slot=6,
+            stale_name="Alexandria Longguest",
+        )
+        mapping["last_observed_actual"]["name_state"] = "RC Alexandri"
+        mapping["last_observed_actual"]["start_state"] = "2027-03-01T16:00:00+00:00"
+        mapping["last_observed_actual"]["end_state"] = "2027-03-05T11:00:00+00:00"
+        persisted = {"trimmed-key": mapping}
+
+        ghosts = coordinator._build_ghost_reservations(
+            set(),
+            persisted,
+            "RC ",
+            {"trimmed-key"},
+        )
+
+        assert len(ghosts) == 1
+        assert ghosts[0].identity_key == "trimmed-key"
+
+    def test_observed_datetime_values_normalize_to_utc(self) -> None:
+        """Naive observed datetimes normalize before remap comparisons."""
+        parsed = RentalControlCoordinator._observed_value_as_datetime(
+            "2027-03-01T16:00:00"
+        )
+
+        assert parsed == datetime(2027, 3, 1, 16, 0, tzinfo=dt_util.UTC)
+
+
 class TestCoordinatorReconciliation:
     """Tests for coordinator-owned reconciliation (T028/T043)."""
 

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -2294,6 +2294,39 @@ class TestFindReservationRematchRulePriority:
 
         assert result.kind is not RematchKind.NAME_TIME
 
+    def test_fresh_physical_name_conflict_excludes_mapping(self) -> None:
+        """A fresh physical name conflict excludes a mapping from all rules."""
+        name = "Alice Guest"
+        start = _dt(2026, 7, 1)
+        end = _dt(2026, 7, 8)
+        persisted = self._persisted(
+            "alice-key",
+            name,
+            start_iso=start.isoformat(),
+            end_iso=end.isoformat(),
+        )
+        persisted["last_observed_actual"]["name_state"] = "Occupied Stranger"
+        reservation = Reservation(
+            identity_key="alice-key",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary=name,
+            slot_name=name,
+            display_slot_name=f"RC {name}",
+            slot_code="0000",
+        )
+
+        result = find_reservation_rematch(
+            reservation,
+            {"alice-key": persisted},
+            actual_slot_names={10: "Occupied Stranger"},
+            observed_mapping_keys={"alice-key"},
+        )
+
+        assert result.kind is RematchKind.NO_MATCH
+
     def test_adopted_observed_date_tiebreak_is_continuity(self) -> None:
         """Observed-date disambiguation remains a continuity rematch."""
         name = "Repeat Guest"
@@ -3658,6 +3691,60 @@ class TestManualDriftOverwriteAction:
         ]
         assert len(overwrite_actions) == 1
         assert overwrite_actions[0].slot == 5
+
+    def test_checked_out_persisted_slot_is_clearable(self) -> None:
+        """Checked-out reservations bypass unmatched physical preservation."""
+        res = self._drift_res(identity_key="r-checked-out")
+        res.checked_out = True
+        ms = self._occupied_drifted_slot(
+            5,
+            "r-checked-out",
+            actual_name="RC Guest Drift",
+            actual_code_present=True,
+        )
+        ms.preserve_unmatched = True
+
+        plan = compute_desired_plan(
+            [res],
+            [ms],
+            max_events=3,
+            plan_id="t071-checked-out",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        clear_actions = [a for a in plan.actions if a.kind is ActionKind.CLEAR]
+        assert len(clear_actions) == 1
+        assert clear_actions[0].slot == 5
+
+    def test_duplicate_noncanonical_clear_overrides_preserve(self) -> None:
+        """Duplicate-collapse still clears non-canonical preserved slots."""
+        first = self._occupied_drifted_slot(
+            5,
+            "r-dup",
+            actual_name="RC Guest Drift",
+            actual_code_present=True,
+        )
+        second = self._occupied_drifted_slot(
+            6,
+            "r-dup",
+            actual_name="RC Guest Drift",
+            actual_code_present=True,
+        )
+        first.preserve_unmatched = True
+        second.preserve_unmatched = True
+
+        plan = compute_desired_plan(
+            [],
+            [first, second],
+            max_events=3,
+            plan_id="t071-dup-preserve",
+            generated_at=_dt(2026, 8, 1),
+        )
+
+        clear_actions = [a for a in plan.actions if a.kind is ActionKind.CLEAR]
+        assert len(clear_actions) == 1
+        assert clear_actions[0].slot == 6
+        assert clear_actions[0].reason == "duplicate_non_canonical"
 
     def test_overwrite_action_preserves_desired_identity_key(self) -> None:
         """OVERWRITE_MANUAL_CHANGE action carries the desired reservation's identity."""


### PR DESCRIPTION
## Production incident

Upgrades from broken 3.5.0/3.5.1 systems can restart with a stale persisted Store while physical Keymaster slots still contain real working codes. The first refresh logged production evidence like:

```
WARNING [reconciliation] Overflow: reservation <hash> selected but no free managed slot available
WARNING [event_overrides] Stale correction: clearing slot 6 (expired or absent reservation)
... slots 7,8,9,10 ...
```

That caused a transient one-time wipe/churn window until a later refresh reassigned the same deterministic codes.

## Root cause

The persisted-Store startup path loaded mappings and trusted them. It did not extend Invariant A to stale persisted identities, so populated physical slots whose Store identity no longer matched the current calendar could be treated as stale instead of re-adopted/rematched.

## Fix

- Observe physical Keymaster slots before reservation rematch/planning.
- Merge fresh physical actuals into persisted mapping snapshots.
- Atomically remap stale Store keys to current reservations when physical name/date proves continuity.
- Exclude fresh physical name conflicts from all rematch rules and quarantine conflicting occupied mappings instead of overwriting them.
- Preserve unmatched populated slots only within the normal missing-count lifecycle; checked-out and third-miss genuine departures still clear.
- Keep empty/unknown/pending-clear self-heal and duplicate-collapse behavior intact.

Clearing `slot_mappings` manually is no longer required on upgrade.

## Validation

- Repro tests first failed on main with Overflow + Stale correction clearing populated slots.
- `uv run pytest tests/unit/test_coordinator.py tests/unit/test_event_overrides.py tests/unit/test_slot_reconciliation.py tests/integration/test_refresh_cycle.py tests/unit/test_util.py -q`
- `uv run pytest tests/ -q`
- `uv run coverage run -m pytest tests/ -q && uv run coverage report --fail-under=85` (95%)
- `uv run ruff check custom_components/ tests/`
- `uv run pre-commit run --all-files`

## Review

Local code-review and rubber-duck sub-agents found edge cases around exact conflicts, checked-out lifecycle, stale empty target mappings, duplicate collapse, and trimmed names. Those findings are addressed in this PR.

DO NOT MERGE until maintainer review completes.