### PR TITLE
Fix(reconcile): Refresh when slots become readable

### DIFF
--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -26,8 +26,15 @@ from homeassistant.components.switch import DOMAIN as SWITCH
 from homeassistant.components.text import DOMAIN as TEXT
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import CALLBACK_TYPE
+from homeassistant.core import Event
+from homeassistant.core import EventStateChangedData
 from homeassistant.core import HomeAssistant
+from homeassistant.core import State
+from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import CONF_CREATION_DATETIME
@@ -48,6 +55,8 @@ from .util import get_entry_data
 from .util import handle_state_change
 
 _LOGGER = logging.getLogger(__name__)
+_STARTUP_READABILITY_REFRESH_DELAY = 1.5
+_STARTUP_READABILITY_WATCHDOG = 10 * 60
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -93,6 +102,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # first refresh so overrides are checked against the initial data
     await coordinator.async_setup_keymaster_overrides()
 
+    startup_slots_unreadable, _ = _needs_startup_readability_refresh(hass, coordinator)
+
     # Perform first data refresh before platform setup to guarantee
     # coordinator.data is populated when entities are created
     try:
@@ -104,6 +115,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         COORDINATOR: coordinator,
         UNSUB_LISTENERS: [],
     }
+
+    async_arm_startup_readability_refresh(
+        hass,
+        config_entry,
+        coordinator,
+        startup_slots_unreadable=startup_slots_unreadable,
+    )
 
     # Start listeners if needed
     await async_start_listener(hass, config_entry)
@@ -153,8 +171,8 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         await async_reload_package_platforms(hass)
 
         # Unsubscribe from any listeners
-        for unsub_listener in hass.data[DOMAIN][config_entry.entry_id].get(
-            UNSUB_LISTENERS, []
+        for unsub_listener in list(
+            hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, [])
         ):
             unsub_listener()
         hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []).clear()
@@ -201,7 +219,7 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
     coordinator = entry_data[COORDINATOR]
 
     # Unsubscribe to any listeners so we can create new ones
-    for unsub_listener in entry_data.get(UNSUB_LISTENERS, []):
+    for unsub_listener in list(entry_data.get(UNSUB_LISTENERS, [])):
         unsub_listener()
     entry_data.get(UNSUB_LISTENERS, []).clear()
 
@@ -210,6 +228,200 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
         async_register_keymaster_listener(hass, config_entry)
     else:
         _LOGGER.debug("Skipping re-adding listeners")
+
+
+def _managed_slot_readability_entity_ids(
+    coordinator: RentalControlCoordinator,
+) -> list[str]:
+    """Return the managed Keymaster entities needed to observe slot state."""
+    if not coordinator.lockname:
+        return []
+
+    entities: list[str] = []
+    for slot in range(
+        coordinator.start_slot, coordinator.start_slot + coordinator.max_events
+    ):
+        entities.extend(
+            (
+                f"{TEXT}.{coordinator.lockname}_code_slot_{slot}_name",
+                f"{TEXT}.{coordinator.lockname}_code_slot_{slot}_pin",
+                f"{SWITCH}.{coordinator.lockname}_code_slot_{slot}_enabled",
+            )
+        )
+    return entities
+
+
+def _is_readable_keymaster_state(state: State | None) -> bool:
+    """Return whether a watched Keymaster entity can be read."""
+    return state is not None and state.state != STATE_UNAVAILABLE
+
+
+def _all_managed_slots_readable(
+    hass: HomeAssistant,
+    entity_ids: list[str],
+) -> bool:
+    """Return whether all watched managed-slot entities are readable."""
+    return all(
+        _is_readable_keymaster_state(hass.states.get(entity_id))
+        for entity_id in entity_ids
+    )
+
+
+def _needs_startup_readability_refresh(
+    hass: HomeAssistant,
+    coordinator: RentalControlCoordinator,
+) -> tuple[bool, list[str]]:
+    """Return whether startup saw unreadable managed Keymaster entities."""
+    entity_ids = _managed_slot_readability_entity_ids(coordinator)
+    if not entity_ids:
+        return False, entity_ids
+    return not _all_managed_slots_readable(hass, entity_ids), entity_ids
+
+
+@callback
+def async_arm_startup_readability_refresh(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: RentalControlCoordinator,
+    *,
+    startup_slots_unreadable: bool = False,
+) -> None:
+    """Arm a one-shot refresh when startup Keymaster slots become readable."""
+    needs_refresh, entity_ids = _needs_startup_readability_refresh(hass, coordinator)
+    if not needs_refresh and not startup_slots_unreadable:
+        return
+
+    done = False
+    unsub_state: CALLBACK_TYPE | None = None
+    unsub_timer: CALLBACK_TYPE | None = None
+    unsub_watchdog: CALLBACK_TYPE | None = None
+    refresh_task = None
+
+    @callback
+    def _remove_listener_reference() -> None:
+        """Remove this watcher from entry listener cleanup."""
+        entry_data = get_entry_data(hass, config_entry.entry_id)
+        if entry_data is None:
+            return
+        listeners = entry_data.get(UNSUB_LISTENERS, [])
+        if _remove_self in listeners:
+            listeners.remove(_remove_self)
+
+    @callback
+    def _cancel_watchers() -> None:
+        """Unsubscribe state tracking, debounce timer, and watchdog."""
+        nonlocal unsub_state, unsub_timer, unsub_watchdog
+
+        if unsub_timer is not None:
+            unsub_timer()
+            unsub_timer = None
+        if unsub_watchdog is not None:
+            unsub_watchdog()
+            unsub_watchdog = None
+        if unsub_state is not None:
+            unsub_state()
+            unsub_state = None
+
+    @callback
+    def _remove_self() -> None:
+        """Unsubscribe the startup readability watcher and pending work."""
+        nonlocal done, refresh_task
+
+        done = True
+        _cancel_watchers()
+        if refresh_task is not None and not refresh_task.done():
+            refresh_task.cancel()
+        refresh_task = None
+        _remove_listener_reference()
+
+    @callback
+    def _refresh_done(_task) -> None:
+        """Drop unload cleanup after the one-shot refresh task finishes."""
+        nonlocal refresh_task
+
+        refresh_task = None
+        _remove_listener_reference()
+
+    async def _async_refresh_once() -> None:
+        """Run the one-shot readability refresh."""
+        if get_entry_data(hass, config_entry.entry_id) is None:
+            return
+        try:
+            await coordinator.async_refresh()
+        except Exception:
+            _LOGGER.exception(
+                "Startup readability refresh failed for %s",
+                config_entry.entry_id,
+            )
+
+    @callback
+    def _refresh_if_readable(_now) -> None:
+        """Refresh once the watched startup entities have settled."""
+        nonlocal done, refresh_task, unsub_timer
+
+        unsub_timer = None
+        if done:
+            return
+        if not _all_managed_slots_readable(hass, entity_ids):
+            return
+
+        done = True
+        _cancel_watchers()
+        refresh_task = config_entry.async_create_task(
+            hass,
+            _async_refresh_once(),
+            name=f"{DOMAIN} startup readability refresh {config_entry.entry_id}",
+        )
+        refresh_task.add_done_callback(_refresh_done)
+
+    @callback
+    def _schedule_refresh(
+        event: Event[EventStateChangedData],
+    ) -> None:
+        """Debounce readable state-change storms into one refresh."""
+        nonlocal unsub_timer
+
+        if done:
+            return
+
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+        if not _is_readable_keymaster_state(new_state):
+            return
+        if old_state is not None and _is_readable_keymaster_state(old_state):
+            return
+
+        if unsub_timer is not None:
+            unsub_timer()
+        unsub_timer = async_call_later(
+            hass,
+            _STARTUP_READABILITY_REFRESH_DELAY,
+            _refresh_if_readable,
+        )
+
+    @callback
+    def _expire(_now) -> None:
+        """Give up if Keymaster entities never become readable."""
+        _LOGGER.debug(
+            "Startup readability watcher expired for %s before slots settled",
+            config_entry.entry_id,
+        )
+        _remove_self()
+
+    unsub_state = async_track_state_change_event(hass, entity_ids, _schedule_refresh)
+    unsub_watchdog = async_call_later(hass, _STARTUP_READABILITY_WATCHDOG, _expire)
+    hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(_remove_self)
+    if _all_managed_slots_readable(hass, entity_ids):
+        unsub_timer = async_call_later(
+            hass,
+            _STARTUP_READABILITY_REFRESH_DELAY,
+            _refresh_if_readable,
+        )
+    _LOGGER.debug(
+        "Armed startup readability refresh for %s watching %d entities",
+        config_entry.entry_id,
+        len(entity_ids),
+    )
 
 
 async def async_start_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> None:

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -19,12 +19,22 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from aioresponses import aioresponses
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
+from custom_components.rental_control.const import CONF_LOCK_ENTRY
+from custom_components.rental_control.const import CONF_MAX_EVENTS
+from custom_components.rental_control.const import CONF_REFRESH_FREQUENCY
+from custom_components.rental_control.const import CONF_START_SLOT
 from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DOMAIN
+from custom_components.rental_control.const import SLOT_STATUS_PENDING_CLEAR
+from custom_components.rental_control.coordinator import RentalControlCoordinator
+from custom_components.rental_control.util import OperationResult
 
 from tests.fixtures import calendar_data
 from tests.integration.helpers import FROZEN_START_OF_DAY
@@ -128,6 +138,154 @@ async def test_scheduled_refresh(
 
     assert coordinator.data is not None
     assert coordinator.last_update_success is True
+
+
+async def test_wedged_recovers_promptly_when_slots_become_available(
+    hass: HomeAssistant,
+) -> None:
+    """Recover a pending-clear startup wedge when Keymaster becomes readable."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Prompt Recovery Rental",
+        version=10,
+        unique_id="prompt-recovery",
+        data={
+            "name": "Prompt Recovery Rental",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "UTC",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            CONF_START_SLOT: 10,
+            CONF_MAX_EVENTS: 1,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "honor_event_times": False,
+            CONF_LOCK_ENTRY: "front_door",
+            CONF_REFRESH_FREQUENCY: 30,
+            "code_buffer_before": 0,
+            "code_buffer_after": 0,
+        },
+        entry_id="prompt_recovery_entry",
+    )
+    entry.add_to_hass(hass)
+
+    for suffix in ("name", "pin"):
+        hass.states.async_set(
+            f"text.front_door_code_slot_10_{suffix}",
+            STATE_UNAVAILABLE,
+        )
+    hass.states.async_set("switch.front_door_code_slot_10_enabled", STATE_UNAVAILABLE)
+
+    store_data: dict[str, Any] = {
+        "schema_version": 1,
+        "entry_id": entry.entry_id,
+        "lockname": "front_door",
+        "start_slot": 10,
+        "max_slots": 1,
+        "updated_at": "2026-06-21T00:00:00+00:00",
+        "mappings": {
+            "stale-pending-clear": {
+                "slot": 10,
+                "status": SLOT_STATUS_PENDING_CLEAR,
+                "operation_id": "pending-clear-token",
+                "operation_kind": "clear",
+                "identity": {
+                    "identity_key": "stale-pending-clear",
+                    "summary": "Old Guest",
+                    "slot_name": "Old Guest",
+                    "uid_aliases": [],
+                    "booking_aliases": [],
+                },
+                "missing_count": 0,
+                "pending_set_since": None,
+                "pending_clear_since": "2026-06-20T00:00:00+00:00",
+                "fingerprint_history": [],
+                "updated_at": "2026-06-20T00:00:00+00:00",
+                "last_observed_actual": {
+                    "slot": 10,
+                    "classification": SLOT_STATUS_PENDING_CLEAR,
+                    "name_state": None,
+                    "has_code": None,
+                    "start_state": None,
+                    "end_state": None,
+                    "use_date_range": None,
+                    "enabled": None,
+                },
+            }
+        },
+        "blocked_slots": {},
+    }
+
+    async def load_store(coordinator: RentalControlCoordinator) -> None:
+        """Load wedged pending-clear state into the coordinator."""
+        coordinator._slot_mappings = store_data
+
+    async def save_store(_coordinator: RentalControlCoordinator) -> None:
+        """Avoid writing the HA Store in the test."""
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(
+            RentalControlCoordinator,
+            "async_load_slot_store",
+            autospec=True,
+            side_effect=load_store,
+        ),
+        patch.object(
+            RentalControlCoordinator,
+            "async_save_slot_store",
+            autospec=True,
+            side_effect=save_store,
+        ),
+        patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            new=AsyncMock(
+                return_value=OperationResult(kind="set", slot=10, confirmed=True)
+            ),
+        ) as set_code,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
+    ):
+        mock_session.get(
+            entry.data["url"],
+            status=200,
+            body=future_ics(),
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected == {}
+        assert coordinator._latest_plan.overflow != {}
+        set_code.assert_not_awaited()
+
+        for suffix in ("name", "pin"):
+            hass.states.async_set(
+                f"text.front_door_code_slot_10_{suffix}",
+                STATE_UNKNOWN,
+            )
+        hass.states.async_set("switch.front_door_code_slot_10_enabled", "off")
+        await hass.async_block_till_done()
+
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+        assert set_code.await_count == 1
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.overflow == {}
+        assert coordinator._latest_plan.selected != {}
+
+        hass.states.async_set("text.front_door_code_slot_10_name", "Later Change")
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=6))
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+        assert set_code.await_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -12,16 +13,25 @@ from unittest.mock import patch
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNKNOWN
+import homeassistant.util.dt as dt_util
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
+from custom_components.rental_control import async_arm_startup_readability_refresh
 from custom_components.rental_control import update_listener
 from custom_components.rental_control.const import CONF_CODE_LENGTH
 from custom_components.rental_control.const import CONF_CREATION_DATETIME
 from custom_components.rental_control.const import CONF_GENERATE
 from custom_components.rental_control.const import CONF_HONOR_EVENT_TIMES
+from custom_components.rental_control.const import CONF_LOCK_ENTRY
+from custom_components.rental_control.const import CONF_MAX_EVENTS
 from custom_components.rental_control.const import CONF_PATH
+from custom_components.rental_control.const import CONF_REFRESH_FREQUENCY
 from custom_components.rental_control.const import CONF_SHOULD_UPDATE_CODE
+from custom_components.rental_control.const import CONF_START_SLOT
 from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DEFAULT_CODE_LENGTH
 from custom_components.rental_control.const import DEFAULT_GENERATE
@@ -30,6 +40,44 @@ from custom_components.rental_control.const import UNSUB_LISTENERS
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+
+
+def _lock_config_entry(entry_id: str) -> MockConfigEntry:
+    """Return a config entry with one managed Keymaster slot."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Listener Rental",
+        version=10,
+        unique_id=f"{entry_id}-unique",
+        data={
+            "name": "Listener Rental",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "UTC",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            CONF_START_SLOT: 10,
+            CONF_MAX_EVENTS: 1,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "honor_event_times": False,
+            CONF_LOCK_ENTRY: "front_door",
+            CONF_REFRESH_FREQUENCY: 30,
+            "code_buffer_before": 0,
+            "code_buffer_after": 0,
+        },
+        entry_id=entry_id,
+    )
+
+
+def _set_slot_readability_states(hass: HomeAssistant, state: str) -> None:
+    """Set the Keymaster entities used by the startup readability watcher."""
+    hass.states.async_set("text.front_door_code_slot_10_name", state)
+    hass.states.async_set("text.front_door_code_slot_10_pin", state)
+    hass.states.async_set(
+        "switch.front_door_code_slot_10_enabled",
+        "off" if state == STATE_UNKNOWN else state,
+    )
 
 
 async def test_async_setup_entry(
@@ -69,6 +117,101 @@ async def test_async_setup_entry(
     assert coordinator is not None
     assert coordinator.hass == hass
     assert coordinator.config_entry == mock_config_entry
+
+
+async def test_healthy_startup_does_not_arm_watcher(
+    hass: HomeAssistant,
+    mock_aiohttp_session,
+) -> None:
+    """Verify readable Keymaster slots only register normal listeners."""
+    entry = _lock_config_entry("healthy_startup_entry")
+    entry.add_to_hass(hass)
+    _set_slot_readability_states(hass, STATE_UNKNOWN)
+    mock_aiohttp_session.get(
+        entry.data["url"],
+        status=200,
+        body="BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n",
+        repeat=True,
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    listeners = hass.data[DOMAIN][entry.entry_id][UNSUB_LISTENERS]
+    assert len(listeners) == 2
+
+
+async def test_startup_readability_watcher_unloads_cleanly(
+    hass: HomeAssistant,
+    mock_aiohttp_session,
+) -> None:
+    """Verify the startup readability watcher is removed on unload."""
+    entry = _lock_config_entry("unreadable_startup_entry")
+    entry.add_to_hass(hass)
+    _set_slot_readability_states(hass, STATE_UNAVAILABLE)
+    mock_aiohttp_session.get(
+        entry.data["url"],
+        status=200,
+        body="BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n",
+        repeat=True,
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    listeners = hass.data[DOMAIN][entry.entry_id][UNSUB_LISTENERS]
+    assert len(listeners) == 3
+    coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+    refresh_mock = AsyncMock()
+    coordinator.async_refresh = refresh_mock
+    hass.states.async_set("text.front_door_code_slot_10_name", STATE_UNKNOWN)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("text.front_door_code_slot_10_pin", STATE_UNKNOWN)
+    hass.states.async_set("switch.front_door_code_slot_10_enabled", "off")
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
+    await hass.async_block_till_done()
+
+    refresh_mock.assert_not_awaited()
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
+
+
+async def test_startup_readability_watcher_handles_missed_transition(
+    hass: HomeAssistant,
+) -> None:
+    """Verify startup-unreadable slots refresh if readable before watcher arm."""
+    entry = _lock_config_entry("missed_transition_entry")
+    entry.add_to_hass(hass)
+    _set_slot_readability_states(hass, STATE_UNKNOWN)
+
+    coordinator = MagicMock()
+    coordinator.lockname = "front_door"
+    coordinator.start_slot = 10
+    coordinator.max_events = 1
+    coordinator.async_refresh = AsyncMock()
+    hass.data[DOMAIN] = {
+        entry.entry_id: {
+            COORDINATOR: coordinator,
+            UNSUB_LISTENERS: [],
+        },
+    }
+
+    async_arm_startup_readability_refresh(
+        hass,
+        entry,
+        coordinator,
+        startup_slots_unreadable=True,
+    )
+
+    assert len(hass.data[DOMAIN][entry.entry_id][UNSUB_LISTENERS]) == 1
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
+    await hass.async_block_till_done()
+
+    coordinator.async_refresh.assert_awaited_once()
+    assert hass.data[DOMAIN][entry.entry_id][UNSUB_LISTENERS] == []
 
 
 async def test_async_unload_entry(


### PR DESCRIPTION
## Summary
- Recover wedged startup promptly when Keymaster managed slot entities become readable after RC first refresh.
- Add a one-shot, debounced startup readability watcher for managed slot name/PIN/enabled entities.
- Leave conservative `unavailable` safety and self-heal/no-wipe reconciliation logic unchanged.

## Production symptom
A system wedged by an earlier 3.5.x release recovered on current `main`, but only after the scheduled refresh interval or a manual Rental Control reload. The first startup reconcile ran while Keymaster slot entities were still `unavailable`, so pending-clear slots could not be safely freed and new reservations overflowed.

## Root cause
Rental Control intentionally treats `unavailable` Keymaster slot text as not confirmed empty. That prevents unsafe slot reuse, but if Keymaster settles to `unknown`/empty immediately after RC startup, the normal slot state listener can skip disabled reset slots and no prompt reconcile is forced. The next reconcile is then delayed until the scheduled refresh.

## Fix
When managed slot entities were missing or unavailable around first refresh, arm a startup one-shot watcher. Once the managed name, PIN, and enabled entities are readable, it debounces the startup state-change storm, schedules one coordinator refresh, and unregisters its state listener, timers, and task cleanup. Healthy startups do not arm the watcher.

## Validation
- Failing-before-fix reproduction: new prompt recovery test did not call `set_code` after slot entities became readable on main.
- `uv run pytest tests/unit/test_init.py tests/unit/test_coordinator.py tests/integration/test_refresh_cycle.py tests/unit/test_util.py -q`
- `uv run pytest tests/ --cov=custom_components.rental_control --cov-report=term-missing -q` (94.62%)
- `uv run ruff check custom_components/ tests/`
- `uv run ruff format --check custom_components/ tests/`
- `uv run pre-commit run --all-files`
- code-review and rubber-duck reviews clean after fixes.