### PR TITLE
Fix(util): Bound slot set confirmation wait

### DIFF
--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -25,7 +25,6 @@ from datetime import time
 from datetime import timedelta
 from datetime import tzinfo
 import hashlib
-import inspect
 import logging
 from pathlib import Path
 import re
@@ -50,6 +49,7 @@ from homeassistant.core import Event
 from homeassistant.core import EventStateChangedData
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotFound
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util import dt
 from homeassistant.util import slugify
 
@@ -63,6 +63,7 @@ from .const import NAME
 _LOGGER = logging.getLogger(__name__)
 _CLEARED_KEYMASTER_TEXT_STATES = frozenset(("", str(STATE_UNKNOWN).casefold()))
 _UNREADABLE_KEYMASTER_TEXT_STATE = str(STATE_UNAVAILABLE).casefold()
+_SET_CODE_CONFIRMATION_TIMEOUT = 5.0
 
 
 def _keymaster_text_state_token(value: Any) -> str | None:
@@ -193,6 +194,53 @@ def add_call(
         )
     )
     return coro
+
+
+def _state_matches_expected_name(
+    hass: HomeAssistant, entity_id: str, name: str
+) -> bool:
+    """Return whether the entity state currently matches the expected name."""
+    state = hass.states.get(entity_id)
+    return state is not None and isinstance(state.state, str) and state.state == name
+
+
+def _state_has_non_string_value(hass: HomeAssistant, entity_id: str) -> bool:
+    """Return whether the entity exists with a non-HA state value."""
+    state = hass.states.get(entity_id)
+    return state is not None and not isinstance(state.state, str)
+
+
+async def _async_wait_for_expected_name(
+    hass: HomeAssistant, entity_id: str, name: str, timeout: float
+) -> bool:
+    """Wait briefly for one name entity to match the expected slot name."""
+    if _state_matches_expected_name(hass, entity_id, name):
+        return True
+    if _state_has_non_string_value(hass, entity_id):
+        return False
+
+    matched = asyncio.Event()
+
+    def _handle_state_change(event: Event[EventStateChangedData]) -> None:
+        """Set the wait flag when the target entity reaches the expected name."""
+        new_state = event.data.get("new_state")
+        if new_state is not None and new_state.state == name:
+            matched.set()
+
+    unsub = async_track_state_change_event(hass, [entity_id], _handle_state_change)
+    try:
+        if _state_matches_expected_name(hass, entity_id, name):
+            return True
+        if _state_has_non_string_value(hass, entity_id):
+            return False
+        try:
+            async with asyncio.timeout(timeout):
+                await matched.wait()
+        except TimeoutError:
+            return False
+        return _state_matches_expected_name(hass, entity_id, name)
+    finally:
+        unsub()
 
 
 def delete_rc_and_base_folder(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
@@ -561,24 +609,22 @@ async def async_fire_set_code(coordinator, event, slot: int) -> OperationResult:
         )
 
     name_entity = f"{TEXT}.{lockname}_code_slot_{slot}_name"
-    block_till_done = getattr(coordinator.hass, "async_block_till_done", None)
-    if block_till_done is not None:
-        done_result = block_till_done()
-        if inspect.isawaitable(done_result):
-            await done_result
-    name_state = coordinator.hass.states.get(name_entity)
-    if name_state is None:
+    if not await _async_wait_for_expected_name(
+        coordinator.hass,
+        name_entity,
+        slot_name,
+        _SET_CODE_CONFIRMATION_TIMEOUT,
+    ):
         return OperationResult(kind="set", slot=slot, unconfirmed=True)
-    if name_state.state == slot_name:
-        was_escalated = coordinator.event_overrides._escalated.get(slot, False)
-        coordinator.event_overrides.record_retry_success(slot)
-        if was_escalated:
-            pn_dismiss(
-                coordinator.hass,
-                notification_id=f"rental_control_slot_{slot}_failure",
-            )
-        return OperationResult(kind="set", slot=slot, confirmed=True)
-    return OperationResult(kind="set", slot=slot, unconfirmed=True)
+
+    was_escalated = coordinator.event_overrides._escalated.get(slot, False)
+    coordinator.event_overrides.record_retry_success(slot)
+    if was_escalated:
+        pn_dismiss(
+            coordinator.hass,
+            notification_id=f"rental_control_slot_{slot}_failure",
+        )
+    return OperationResult(kind="set", slot=slot, confirmed=True)
 
 
 async def async_fire_update_times(coordinator, event, slot: int) -> OperationResult:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -24,6 +24,7 @@ from homeassistant.exceptions import ServiceNotFound
 from homeassistant.util import dt as dt_util
 import pytest
 
+from custom_components.rental_control import util as util_module
 from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DEFAULT_PATH
 from custom_components.rental_control.const import DOMAIN
@@ -1662,8 +1663,8 @@ class TestAsyncFireSetCode:
         assert result.error is not None
         coordinator.event_overrides.record_retry_failure.assert_called_once_with(10)
 
-    async def test_set_code_flushes_before_verification(self) -> None:
-        """Verify set_code flushes HA jobs before reading state."""
+    async def test_set_code_confirms_without_blocking_whole_loop(self) -> None:
+        """Verify set_code confirms without flushing every pending HA job."""
         coordinator = MagicMock()
         coordinator.lockname = "front_door"
         coordinator.event_prefix = ""
@@ -1674,13 +1675,133 @@ class TestAsyncFireSetCode:
         coordinator.event_overrides._escalated = {}
         coordinator.event_overrides.record_retry_success.return_value = None
         coordinator.hass.services.async_call = AsyncMock()
-        coordinator.hass.async_block_till_done = AsyncMock()
+        coordinator.hass.async_block_till_done = AsyncMock(
+            side_effect=AssertionError("whole-loop flush must not be used")
+        )
         coordinator.hass.states.get.return_value = MagicMock(state="Guest")
 
         result = await async_fire_set_code(coordinator, self._make_event(), 10)
 
-        coordinator.hass.async_block_till_done.assert_awaited_once()
+        coordinator.hass.async_block_till_done.assert_not_called()
         assert result.confirmed is True
+
+    async def test_set_code_unconfirmed_on_confirmation_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify confirmation timeout leaves a set unconfirmed, not failed."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides.record_retry_failure.return_value = False
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = MagicMock(state="Old Guest")
+        monkeypatch.setattr(util_module, "_SET_CODE_CONFIRMATION_TIMEOUT", 0.01)
+        unsub = MagicMock()
+        monkeypatch.setattr(
+            util_module,
+            "async_track_state_change_event",
+            MagicMock(return_value=unsub),
+        )
+
+        result = await async_fire_set_code(coordinator, self._make_event(), 10)
+
+        assert result == OperationResult(kind="set", slot=10, unconfirmed=True)
+        coordinator.event_overrides.record_retry_failure.assert_not_called()
+        unsub.assert_called_once_with()
+
+    async def test_set_code_confirmed_when_name_updates_after_short_delay(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify a matching name update confirms through a targeted wait."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides._escalated = {}
+        coordinator.event_overrides.record_retry_success.return_value = None
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = MagicMock(state="Old Guest")
+        monkeypatch.setattr(util_module, "_SET_CODE_CONFIRMATION_TIMEOUT", 0.5)
+        callbacks = []
+        unsub = MagicMock()
+
+        def track_state_change(hass, entity_ids, action):
+            """Capture the targeted listener registered by the wait helper."""
+            callbacks.append((entity_ids, action))
+            return unsub
+
+        monkeypatch.setattr(
+            util_module,
+            "async_track_state_change_event",
+            track_state_change,
+        )
+
+        async def update_name() -> None:
+            """Fire the captured listener after the wait helper is armed."""
+            await asyncio.sleep(0.01)
+            _entity_ids, action = callbacks[0]
+            coordinator.hass.states.get.return_value = MagicMock(state="Guest")
+            event = MagicMock()
+            event.data = {"new_state": MagicMock(state="Guest")}
+            action(event)
+
+        update_task = asyncio.create_task(update_name())
+        result = await async_fire_set_code(coordinator, self._make_event(), 10)
+        await update_task
+
+        assert result == OperationResult(kind="set", slot=10, confirmed=True)
+        assert callbacks[0][0] == ["text.front_door_code_slot_10_name"]
+        unsub.assert_called_once_with()
+
+    async def test_set_code_unconfirmed_when_matching_event_is_stale(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify confirmation re-checks state after a matching event."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = ""
+        coordinator.trim_names = False
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.event_overrides.verify_slot_ownership.return_value = True
+        coordinator.event_overrides.record_retry_failure.return_value = False
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.hass.states.get.return_value = MagicMock(state="Old Guest")
+        monkeypatch.setattr(util_module, "_SET_CODE_CONFIRMATION_TIMEOUT", 0.5)
+        callbacks = []
+
+        def track_state_change(hass, entity_ids, action):
+            """Capture the targeted listener registered by the wait helper."""
+            callbacks.append(action)
+            return MagicMock()
+
+        monkeypatch.setattr(
+            util_module,
+            "async_track_state_change_event",
+            track_state_change,
+        )
+
+        async def update_name() -> None:
+            """Fire a stale matching event while current state is mismatched."""
+            await asyncio.sleep(0.01)
+            coordinator.hass.states.get.return_value = MagicMock(state="Other")
+            event = MagicMock()
+            event.data = {"new_state": MagicMock(state="Guest")}
+            callbacks[0](event)
+
+        update_task = asyncio.create_task(update_name())
+        result = await async_fire_set_code(coordinator, self._make_event(), 10)
+        await update_task
+
+        assert result == OperationResult(kind="set", slot=10, unconfirmed=True)
+        coordinator.event_overrides.record_retry_failure.assert_not_called()
 
     async def test_set_code_cancelled_error_propagates(self) -> None:
         """Verify set_code does not swallow task cancellation."""
@@ -2894,10 +3015,13 @@ class TestAsyncFireSetCodeOperationResult:
 
         assert result == OperationResult(kind="set", slot=10, confirmed=True)
 
-    async def test_unconfirmed_when_name_state_none(self) -> None:
+    async def test_unconfirmed_when_name_state_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Set is unconfirmed when the name entity is unreadable."""
         coordinator = self._make_coordinator()
         coordinator.hass.states.get.return_value = None
+        monkeypatch.setattr(util_module, "_SET_CODE_CONFIRMATION_TIMEOUT", 0.01)
 
         result = await async_fire_set_code(coordinator, self._make_event(), 10)
 


### PR DESCRIPTION
## Symptom

Reloading Rental Control integrations can hang during setup on large installs
(confirmed on 10 RC config entries, 4 managed slots each = 40 slots, and 13
Keymaster locks). Home Assistant eventually cancels the config entry with a
`CancelledError` while setup is inside `async_config_entry_first_refresh()`:

```text
Setup of config entry 'Symple Suite 5' for rental_control integration cancelled
  custom_components/rental_control/__init__.py:110 async_setup_entry
  coordinator.py:2053 _async_update_data
  event_overrides.py:920 async_apply_plan
  event_overrides.py:1071 _apply_set
  util.py:568 async_fire_set_code
  hass.async_block_till_done() -> asyncio.wait -> CancelledError
```

## Root cause

`async_fire_set_code()` issued the Keymaster set calls with `blocking=True`, then
called `hass.async_block_till_done()` only to let the name entity state settle
before confirmation. During config-entry first refresh/reload, that flush waits
on the whole Home Assistant pending-task graph. At scale the loop may not settle
within HA setup timeout, so setup is cancelled.

## Fix

Replace the whole-loop flush with a bounded, per-slot wait for only the slot name
entity (`text.<lock>_code_slot_<slot>_name`) to reach the expected display name.
The wait uses a state-change listener plus a 5-second `asyncio.timeout`, with the
listener unsubscribed in all paths.

Confirmation semantics are preserved:

- confirmed only when the current name entity matches the expected slot name
- timeout/missing/mismatch returns `OperationResult(..., unconfirmed=True)`
- service-call failures still use the existing failed/escalation path
- confirmed sets still record retry success and dismiss prior escalation

Reconciliation re-confirms unconfirmed sets on the next cycle.

## Validation

- Reproduction test fails on the old whole-loop block behavior, then passes
- `uv run pytest tests/unit/test_util.py tests/unit/test_event_overrides.py tests/integration/test_refresh_cycle.py tests/unit/test_coordinator.py -q`
- `uv run pytest tests/ -q --cov=custom_components.rental_control --cov-report=term-missing` (94.64%)
- `uv run ruff check custom_components/ tests/`
- `uv run pre-commit run --all-files`
- code-review and rubber-duck sub-agent reviews clean