### PR TITLE
Fix(reconcile): Adopt coded slots when readable

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -958,7 +958,6 @@ Please update Keymaster to at least v0.1.0-b0
         are adopted here so deleted or missing stores recover on any
         refresh once Keymaster entities settle.
         """
-        persisted: dict[str, Any] = self._slot_mappings.get("mappings", {})
         self._adopt_observed_coded_slots(managed_slots)
         persisted = self._slot_mappings.get("mappings", {})
         for ms in managed_slots:

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -665,8 +665,15 @@ Please update Keymaster to at least v0.1.0-b0
         now_str = dt.now().isoformat()
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
         mappings: dict[str, Any] = {}
+        existing_slots = {
+            mapping.get("slot")
+            for mapping in self._slot_mappings.get("mappings", {}).values()
+            if isinstance(mapping, dict)
+        }
 
         for i in range(self.start_slot, self.start_slot + self.max_events):
+            if i in existing_slots:
+                continue
             name_state = self.hass.states.get(
                 f"{TEXT}.{self.lockname}_code_slot_{i}_name"
             )
@@ -721,6 +728,8 @@ Please update Keymaster to at least v0.1.0-b0
             status = SLOT_STATUS_OCCUPIED if has_code else SLOT_STATUS_PENDING_CLEAR
             pending_clear_since: str | None = now_str if not has_code else None
             identity_key = f"adopted.{self._entry_id}.slot{i}"
+            if identity_key in self._slot_mappings.get("mappings", {}):
+                continue
 
             mappings[identity_key] = {
                 "slot": i,
@@ -772,6 +781,85 @@ Please update Keymaster to at least v0.1.0-b0
                 self.event_overrides.load_persisted_mappings(
                     self._slot_mappings.get("mappings", {})
                 )
+
+    def _adopt_observed_coded_slots(self, managed_slots: list[_ManagedSlot]) -> None:
+        """Adopt readable coded slots that have no persisted mapping yet."""
+        persisted: dict[str, Any] = self._slot_mappings.setdefault("mappings", {})
+        existing_slots = {
+            mapping.get("slot")
+            for mapping in persisted.values()
+            if isinstance(mapping, dict)
+        }
+        now_str = dt.now().isoformat()
+        prefix = f"{self.event_prefix} " if self.event_prefix else ""
+        adopted = False
+
+        for ms in managed_slots:
+            if (
+                not ms.managed
+                or ms.persisted_identity_key is not None
+                or ms.slot in existing_slots
+                or ms.status is not _SlotStatus.OCCUPIED
+                or ms.actual_code_present is not True
+            ):
+                continue
+
+            slot_name = ms.actual_name or _adopted_slot_placeholder(ms.slot)
+            if prefix and slot_name.startswith(prefix):
+                slot_name = slot_name[len(prefix) :]
+
+            identity_key = f"adopted.{self._entry_id}.slot{ms.slot}"
+            if identity_key in persisted:
+                continue
+
+            persisted[identity_key] = {
+                "slot": ms.slot,
+                "status": SLOT_STATUS_OCCUPIED,
+                "operation_id": None,
+                "operation_kind": None,
+                "identity": {
+                    "identity_key": identity_key,
+                    "summary": slot_name,
+                    "slot_name": slot_name,
+                    "start": _store_datetime(ms.actual_start),
+                    "end": _store_datetime(ms.actual_end),
+                    "uid_aliases": [],
+                    "booking_aliases": [],
+                },
+                "missing_count": 0,
+                "pending_set_since": None,
+                "pending_clear_since": None,
+                "fingerprint_history": [],
+                "updated_at": now_str,
+                "last_observed_actual": {
+                    "slot": ms.slot,
+                    "classification": ms.status.value,
+                    "name_state": ms.actual_name,
+                    "has_code": True,
+                    "start_state": _store_datetime(ms.actual_start),
+                    "end_state": _store_datetime(ms.actual_end),
+                    "use_date_range": ms.date_range_enabled,
+                    "enabled": ms.enabled,
+                },
+            }
+            ms.persisted_identity_key = identity_key
+            existing_slots.add(ms.slot)
+            adopted = True
+
+        if adopted:
+            self._slot_mappings.update(
+                {
+                    "schema_version": STORE_SCHEMA_VERSION,
+                    "entry_id": self._entry_id,
+                    "lockname": self.lockname,
+                    "start_slot": self.start_slot,
+                    "max_slots": self.max_events,
+                    "updated_at": now_str,
+                    "blocked_slots": self._slot_mappings.get("blocked_slots", {}),
+                }
+            )
+            if self.event_overrides is not None:
+                self.event_overrides.load_persisted_mappings(persisted)
 
     def _generate_date_based_code(self, start: datetime, end: datetime) -> str:
         """Generate a date-based door code from reservation start/end times.
@@ -866,9 +954,13 @@ Please update Keymaster to at least v0.1.0-b0
         ``last_observed_actual`` snapshots.  Before rematching current
         calendar reservations, physical Keymaster state must be allowed to
         win over those stale snapshots so populated slots can be reclaimed
-        rather than stale-cleared.
+        rather than stale-cleared.  Readable coded slots with no mapping
+        are adopted here so deleted or missing stores recover on any
+        refresh once Keymaster entities settle.
         """
         persisted: dict[str, Any] = self._slot_mappings.get("mappings", {})
+        self._adopt_observed_coded_slots(managed_slots)
+        persisted = self._slot_mappings.get("mappings", {})
         for ms in managed_slots:
             if ms.persisted_identity_key is None:
                 continue
@@ -1758,8 +1850,14 @@ Please update Keymaster to at least v0.1.0-b0
             date_range_on = (
                 use_date_range_state is not None and use_date_range_state.state == "on"
             )
+            date_range_enabled: bool | None = None
+            if use_date_range_state is not None and use_date_range_state.state in (
+                "on",
+                "off",
+            ):
+                date_range_enabled = date_range_on
             enabled: bool | None = None
-            if enabled_state is not None:
+            if enabled_state is not None and enabled_state.state in ("on", "off"):
                 enabled = enabled_state.state == "on"
 
             actual_start: datetime | None = None
@@ -1829,7 +1927,7 @@ Please update Keymaster to at least v0.1.0-b0
                 actual_code_present=has_code,
                 actual_start=actual_start,
                 actual_end=actual_end,
-                date_range_enabled=date_range_on,
+                date_range_enabled=date_range_enabled,
                 enabled=enabled,
                 persisted_identity_key=persisted_key,
                 blocked_reason=blocked_reason,
@@ -1853,7 +1951,7 @@ Please update Keymaster to at least v0.1.0-b0
                     "has_code": has_code,
                     "start_state": actual_start,
                     "end_state": actual_end,
-                    "use_date_range": date_range_on,
+                    "use_date_range": date_range_enabled,
                     "enabled": enabled,
                 },
             )

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -288,6 +288,234 @@ async def test_wedged_recovers_promptly_when_slots_become_available(
         assert set_code.await_count == 1
 
 
+async def test_missing_store_adopts_coded_slots_when_unavailable_at_setup(
+    hass: HomeAssistant,
+) -> None:
+    """Adopt a coded slot that was unreadable during empty-store setup."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Readable Adoption Rental",
+        version=10,
+        unique_id="readable-adoption",
+        data={
+            "name": "Readable Adoption Rental",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "UTC",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            CONF_START_SLOT: 10,
+            CONF_MAX_EVENTS: 1,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "honor_event_times": False,
+            CONF_LOCK_ENTRY: "front_door",
+            CONF_REFRESH_FREQUENCY: 30,
+            "code_buffer_before": 0,
+            "code_buffer_after": 0,
+        },
+        entry_id="readable_adoption_entry",
+    )
+    entry.add_to_hass(hass)
+
+    for suffix in ("name", "pin"):
+        hass.states.async_set(
+            f"text.front_door_code_slot_10_{suffix}",
+            STATE_UNAVAILABLE,
+        )
+    hass.states.async_set("switch.front_door_code_slot_10_enabled", STATE_UNAVAILABLE)
+
+    async def load_empty_store(coordinator: RentalControlCoordinator) -> None:
+        """Simulate a missing mappings Store file."""
+        coordinator._slot_mappings = {}
+
+    async def save_store(_coordinator: RentalControlCoordinator) -> None:
+        """Avoid writing the HA Store in the test."""
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(
+            RentalControlCoordinator,
+            "async_load_slot_store",
+            autospec=True,
+            side_effect=load_empty_store,
+        ),
+        patch.object(
+            RentalControlCoordinator,
+            "async_save_slot_store",
+            autospec=True,
+            side_effect=save_store,
+        ),
+        patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            new=AsyncMock(
+                return_value=OperationResult(kind="clear", slot=10, confirmed=True)
+            ),
+        ) as clear_code,
+        patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            new=AsyncMock(
+                return_value=OperationResult(kind="set", slot=10, confirmed=True)
+            ),
+        ) as set_code,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
+    ):
+        mock_session.get(
+            entry.data["url"],
+            status=200,
+            body=future_ics(summary="Current Guest"),
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+        assert coordinator.get_persisted_slot_mappings() == {}
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected == {}
+
+        hass.states.async_set("text.front_door_code_slot_10_name", "Current Guest")
+        hass.states.async_set("text.front_door_code_slot_10_pin", "2468")
+        hass.states.async_set("switch.front_door_code_slot_10_enabled", "on")
+        await hass.async_block_till_done()
+
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+        mappings = coordinator.get_persisted_slot_mappings()
+        assert len(mappings) == 1
+        identity_key = next(iter(mappings))
+        assert not identity_key.startswith("adopted.")
+        mapping = next(iter(mappings.values()))
+        assert mapping["slot"] == 10
+        assert mapping["status"] == "occupied"
+        assert mapping["identity"]["slot_name"] == "Current Guest"
+        assert mapping["last_observed_actual"]["has_code"] is True
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected == {identity_key: 10}
+        assert coordinator._latest_plan.overflow == {}
+        assert not any(
+            action.slot == 10 and action.kind.value == "clear"
+            for action in coordinator._latest_plan.actions
+        )
+        assert not any(
+            action.slot == 10 and action.kind.value == "overwrite_manual_change"
+            for action in coordinator._latest_plan.actions
+        )
+        clear_code.assert_not_awaited()
+        set_code.assert_not_awaited()
+
+
+async def test_deleted_store_reenable_recovers_coded_slots(
+    hass: HomeAssistant,
+) -> None:
+    """Recover existing coded slots after disable, Store delete, re-enable."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Deleted Store Rental",
+        version=10,
+        unique_id="deleted-store-adoption",
+        data={
+            "name": "Deleted Store Rental",
+            "url": "https://example.com/calendar.ics",
+            "timezone": "UTC",
+            "checkin": "16:00",
+            "checkout": "11:00",
+            CONF_START_SLOT: 10,
+            CONF_MAX_EVENTS: 1,
+            "days": 90,
+            "verify_ssl": True,
+            "ignore_non_reserved": False,
+            "honor_event_times": False,
+            CONF_LOCK_ENTRY: "front_door",
+            CONF_REFRESH_FREQUENCY: 30,
+            "code_buffer_before": 0,
+            "code_buffer_after": 0,
+        },
+        entry_id="deleted_store_adoption_entry",
+    )
+    entry.add_to_hass(hass)
+
+    async def load_deleted_store(coordinator: RentalControlCoordinator) -> None:
+        """Simulate the maintainer-deleted mappings Store file."""
+        coordinator._slot_mappings = {}
+
+    async def save_store(_coordinator: RentalControlCoordinator) -> None:
+        """Avoid writing the HA Store in the test."""
+
+    with (
+        aioresponses() as mock_session,
+        patch.object(
+            RentalControlCoordinator,
+            "async_load_slot_store",
+            autospec=True,
+            side_effect=load_deleted_store,
+        ),
+        patch.object(
+            RentalControlCoordinator,
+            "async_save_slot_store",
+            autospec=True,
+            side_effect=save_store,
+        ),
+        patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            new=AsyncMock(
+                return_value=OperationResult(kind="clear", slot=10, confirmed=True)
+            ),
+        ) as clear_code,
+        patch(
+            "custom_components.rental_control.event_overrides.async_fire_set_code",
+            new=AsyncMock(
+                return_value=OperationResult(kind="set", slot=10, confirmed=True)
+            ),
+        ) as set_code,
+        patch.object(dt_util, "now", return_value=FROZEN_TIME),
+        patch.object(dt_util, "start_of_local_day", return_value=FROZEN_START_OF_DAY),
+    ):
+        mock_session.get(
+            entry.data["url"],
+            status=200,
+            body=future_ics(summary="Reenabled Guest"),
+            repeat=True,
+        )
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+        assert coordinator.get_persisted_slot_mappings() == {}
+
+        hass.states.async_set("text.front_door_code_slot_10_name", "Reenabled Guest")
+        hass.states.async_set("text.front_door_code_slot_10_pin", "8642")
+        hass.states.async_set("switch.front_door_code_slot_10_enabled", "on")
+        await hass.async_block_till_done()
+
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+        mappings = coordinator.get_persisted_slot_mappings()
+        assert len(mappings) == 1
+        identity_key = next(iter(mappings))
+        assert not identity_key.startswith("adopted.")
+        mapping = next(iter(mappings.values()))
+        assert mapping["slot"] == 10
+        assert mapping["status"] == "occupied"
+        assert mapping["identity"]["slot_name"] == "Reenabled Guest"
+        assert coordinator._latest_plan is not None
+        assert coordinator._latest_plan.selected == {identity_key: 10}
+        assert coordinator._latest_plan.overflow == {}
+        assert not any(
+            action.slot == 10 and action.kind.value == "overwrite_manual_change"
+            for action in coordinator._latest_plan.actions
+        )
+        clear_code.assert_not_awaited()
+        set_code.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # T114 – sensor state updates on refresh
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -6754,6 +6754,106 @@ class TestCoordinatorPersistenceUpdate:
         assert adopted_a not in mappings
         assert adopted_b not in mappings
 
+    def test_empty_slot_not_adopted_as_occupied(self, hass: "HomeAssistant") -> None:
+        """Physically empty unmapped slots stay free, not adopted occupied."""
+        from custom_components.rental_control.reconciliation import SlotStatus
+
+        entry = self._make_persist_entry(max_events=1)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {"mappings": {}, "blocked_slots": {}}
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings({})
+        hass.states.async_set("text.test_lock_code_slot_10_name", "unknown")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "")
+
+        observed = coordinator._observe_managed_slots()
+        coordinator._merge_observed_slots_into_mappings(observed)
+
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        assert slot10.status is SlotStatus.FREE
+        assert coordinator.get_persisted_slot_mappings() == {}
+
+    def test_readopt_is_idempotent(self, hass: "HomeAssistant") -> None:
+        """Repeated observation adoption keeps one stable rematched mapping."""
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        entry = self._make_persist_entry(max_events=1)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {"mappings": {}, "blocked_slots": {}}
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings({})
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Idempotent Guest")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "1357")
+
+        start = datetime(2026, 9, 1, 16, 0, tzinfo=dt_util.UTC)
+        event = MagicMock()
+        event.summary = "Idempotent Guest"
+        event.description = ""
+        event.start = start
+        event.end = start + timedelta(days=4)
+        event.uid = "idempotent-guest"
+
+        for _ in range(2):
+            observed = coordinator._observe_managed_slots()
+            coordinator._merge_observed_slots_into_mappings(observed)
+            reservations = coordinator._build_reservations([event], observed)
+            coordinator.event_overrides.load_persisted_mappings(
+                coordinator.get_persisted_slot_mappings()
+            )
+            observed = coordinator._observe_managed_slots()
+
+        mappings = coordinator.get_persisted_slot_mappings()
+        assert len(mappings) == 1
+        mapping = next(iter(mappings.values()))
+        assert mapping["slot"] == 10
+        assert mapping["identity"]["slot_name"] == "Idempotent Guest"
+
+        plan = compute_desired_plan(
+            reservations,
+            observed,
+            max_events=1,
+            plan_id="idempotent-readopt",
+            generated_at=start,
+        )
+        assert plan.selected == {next(iter(mappings)): 10}
+        assert plan.overflow == {}
+
+    def test_unavailable_slot_not_adopted_until_readable(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Unreadable unmapped slots wait, then adopt after readable code."""
+        from custom_components.rental_control.reconciliation import SlotStatus
+
+        entry = self._make_persist_entry(max_events=1)
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        coordinator._slot_mappings = {"mappings": {}, "blocked_slots": {}}
+        assert coordinator.event_overrides is not None
+        coordinator.event_overrides.load_persisted_mappings({})
+        hass.states.async_set("text.test_lock_code_slot_10_name", "unavailable")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "unavailable")
+
+        observed = coordinator._observe_managed_slots()
+        coordinator._merge_observed_slots_into_mappings(observed)
+
+        slot10 = next(slot for slot in observed if slot.slot == 10)
+        assert slot10.status is SlotStatus.UNKNOWN
+        assert coordinator.get_persisted_slot_mappings() == {}
+
+        hass.states.async_set("text.test_lock_code_slot_10_name", "Readable Guest")
+        hass.states.async_set("text.test_lock_code_slot_10_pin", "9753")
+        observed = coordinator._observe_managed_slots()
+        coordinator._merge_observed_slots_into_mappings(observed)
+
+        mappings = coordinator.get_persisted_slot_mappings()
+        assert len(mappings) == 1
+        mapping = next(iter(mappings.values()))
+        assert mapping["slot"] == 10
+        assert mapping["status"] == "occupied"
+        assert mapping["identity"]["slot_name"] == "Readable Guest"
+
     def test_display_name_trims_full_name_when_prefix_consumes_limit(self) -> None:
         """Display-name formatting avoids negative guest-name trim lengths."""
         from custom_components.rental_control.coordinator import (


### PR DESCRIPTION
## Summary
- Recover the maintainer flow: disable an RC entry, delete its slot mappings Store file, then re-enable while Keymaster entities are still loading.
- Adopt readable physically-coded managed slots during observation so missing/deleted stores behave like a fresh upgrade once entities settle.
- Preserve no-wipe/self-heal behavior: coded slots are not cleared or overwritten, empty/unknown slots remain free, and unavailable slots wait until readable.

## Root cause
Startup adoption only ran once when the Store was empty. If Keymaster slot name/PIN entities were missing or unavailable during setup, adoption skipped the physical codes. The startup readability watcher later called refresh only, so reconciliation saw coded-but-unmapped slots as stale occupants instead of current reservations.

## Fix
The observation path now creates an idempotent adopted mapping for readable coded managed slots with no existing mapping. The next reservation build rematches that adopted identity to the current reservation before planning. Existing mappings are not overwritten, and ancillary switch states stay unknown unless explicitly on/off to avoid set-code churn.

## Validation
- Reproduction tests failed before the fix and now pass.
- uv run pytest tests/unit/test_coordinator.py tests/unit/test_init.py tests/integration/test_refresh_cycle.py tests/unit/test_event_overrides.py -q
- uv run pytest tests/ -q --cov=custom_components.rental_control --cov-report=term --cov-fail-under=85 (94.61%)
- uv run ruff check custom_components/ tests/
- uv run pre-commit run --all-files