### PR TITLE
Docs(plan): Add implementation plan for spec 013

### DIFF
--- a/specs/013-stateless-reconciliation/data-model.md
+++ b/specs/013-stateless-reconciliation/data-model.md
@@ -19,7 +19,7 @@ physical state with persisted mapping status (`reconciliation.py:252-319`).
 | `managed` | `bool` | True only inside `start_slot .. start_slot + max_events - 1`. |
 | `raw_name` | `str \| None` | Raw Keymaster name text state for this refresh; never from Store. |
 | `raw_pin` | `str \| None` | Raw Keymaster PIN in memory only for this refresh; never logged or persisted. |
-| `has_pin` | `bool \| None` | True when PIN is non-empty, false when confirmed blank/unknown/None, none when unreadable. |
+| `has_pin` | `bool \| None` | True when PIN is non-empty, false when confirmed blank/unknown/None, `None` when unreadable. |
 | `actual_start` | `datetime \| None` | Observed Keymaster date-range start when readable. |
 | `actual_end` | `datetime \| None` | Observed Keymaster date-range end when readable. |
 | `date_range_enabled` | `bool \| None` | Observed Keymaster date-range switch state. |
@@ -38,8 +38,9 @@ physical state with persisted mapping status (`reconciliation.py:252-319`).
 - `unavailable` makes `readable == False` via
   `is_unreadable_keymaster_text_state()` (`util.py:82-84`) and forces
   `classification == unknown`.
-- `raw_pin` is memory-only and must not appear in Store, logs, diagnostics, or
-  sensor attributes.
+- `raw_pin` is memory-only and must not appear in Store, logs, or
+  diagnostics. A desired `slot_code` derived from the raw PIN may continue to
+  appear in existing `event_N` sensor attributes for compatibility.
 - A slot with `classification == occupied` cannot receive a different
   reservation until a reset is confirmed empty.
 

--- a/specs/013-stateless-reconciliation/data-model.md
+++ b/specs/013-stateless-reconciliation/data-model.md
@@ -17,18 +17,18 @@ physical state with persisted mapping status (`reconciliation.py:252-319`).
 |-------|------|---------|
 | `slot` | `int` | Physical Keymaster slot number. |
 | `managed` | `bool` | True only inside `start_slot .. start_slot + max_events - 1`. |
-| `raw_name` | `str | None` | Raw Keymaster name text state for this refresh; never from Store. |
-| `raw_pin` | `str | None` | Raw Keymaster PIN in memory only for this refresh; never logged or persisted. |
-| `has_pin` | `bool | None` | True when PIN is non-empty, false when confirmed blank/unknown/None, none when unreadable. |
-| `actual_start` | `datetime | None` | Observed Keymaster date-range start when readable. |
-| `actual_end` | `datetime | None` | Observed Keymaster date-range end when readable. |
-| `date_range_enabled` | `bool | None` | Observed Keymaster date-range switch state. |
-| `enabled` | `bool | None` | Observed Keymaster slot-enabled switch state. |
+| `raw_name` | `str \| None` | Raw Keymaster name text state for this refresh; never from Store. |
+| `raw_pin` | `str \| None` | Raw Keymaster PIN in memory only for this refresh; never logged or persisted. |
+| `has_pin` | `bool \| None` | True when PIN is non-empty, false when confirmed blank/unknown/None, none when unreadable. |
+| `actual_start` | `datetime \| None` | Observed Keymaster date-range start when readable. |
+| `actual_end` | `datetime \| None` | Observed Keymaster date-range end when readable. |
+| `date_range_enabled` | `bool \| None` | Observed Keymaster date-range switch state. |
+| `enabled` | `bool \| None` | Observed Keymaster slot-enabled switch state. |
 | `readable` | `bool` | False when any safety-critical state is `unavailable` or missing. |
 | `empty_confirmed` | `bool` | True only when both name and PIN are cleared by util helpers. |
 | `classification` | `ObservedSlotStatus` | `empty`, `occupied`, `phantom`, or `unknown`. |
 | `normalized_name_forms` | `set[str]` | Full/prefix-stripped/trim-aware normalized names for matching. |
-| `matched_desired_id` | `str | None` | Desired reservation matched by stable name in this refresh. |
+| `matched_desired_id` | `str \| None` | Desired reservation matched by stable name in this refresh. |
 
 **Validation rules**:
 
@@ -59,18 +59,18 @@ current refresh.
 | `buffered_start` | `datetime` | Keymaster date-range start after `apply_buffer()` (`util.py:442-463`). |
 | `buffered_end` | `datetime` | Keymaster date-range end after `apply_buffer()`. |
 | `slot_code` | `str` | Desired PIN for this refresh; generated or manual override. |
-| `code_source` | `generated | manual_observed | manual_config` | Why `slot_code` was chosen; never persisted raw. |
-| `event_uid` | `str | None` | Optional current iCal UID for cache-only aliases. |
+| `code_source` | `generated \| manual_observed \| manual_config` | Why `slot_code` was chosen; never persisted raw. |
+| `event_uid` | `str \| None` | Optional current iCal UID for cache-only aliases. |
 | `booking_aliases` | `set[str]` | Optional booking IDs for cache-only diagnostics. |
 | `eligible` | `bool` | True when existing calendar parsing/config includes the reservation. |
 | `protected_active` | `bool` | True for current checked-in guest from check-in sensor state. |
 | `checked_out` | `bool` | True when check-in sensor says the stay checked out. |
-| `selected_rank` | `int | None` | Rank in the should-be set after active protection and soonest-N selection. |
-| `matched_slot` | `int | None` | Physical slot matched by stable name this refresh. |
-| `assigned_slot` | `int | None` | Physical slot planned to contain this reservation after actions. |
+| `selected_rank` | `int \| None` | Rank in the should-be set after active protection and soonest-N selection. |
+| `matched_slot` | `int \| None` | Physical slot matched by stable name this refresh. |
+| `assigned_slot` | `int \| None` | Physical slot planned to contain this reservation after actions. |
 | `sensor_lookup_keys` | `set[str]` | Current-event fingerprints, UID aliases, and compatibility keys used by `event_N` sensors to find this desired record. |
-| `physical_time_override` | `tuple[datetime, datetime] | None` | Access window derived from a matched physical slot after reversing buffers when manual time override semantics apply. |
-| `overflow_reason` | `str | None` | Why the reservation is not selected or assignable. |
+| `physical_time_override` | `tuple[datetime, datetime] \| None` | Access window derived from a matched physical slot after reversing buffers when manual time override semantics apply. |
+| `overflow_reason` | `str \| None` | Why the reservation is not selected or assignable. |
 
 **Validation rules**:
 
@@ -94,15 +94,15 @@ A stateless per-slot decision emitted by the planner. This replaces the current
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `kind` | `noop | update_in_place | reset | assign | blocked` | Action category for this slot. |
+| `kind` | `noop \| update_in_place \| reset \| assign \| blocked` | Action category for this slot. |
 | `slot` | `int` | Physical Keymaster slot number. |
-| `desired_id` | `str | None` | Desired reservation involved in the action. |
-| `matched_by` | `name_exact | name_trimmed | name_prefixed | duplicate_order | none` | How identity was established. |
+| `desired_id` | `str \| None` | Desired reservation involved in the action. |
+| `matched_by` | `name_exact \| name_trimmed \| name_prefixed \| duplicate_order \| none` | How identity was established. |
 | `requires_confirmed_empty` | `bool` | True before any replacement PIN can be written. |
-| `reason` | `str | None` | Diagnostic reason such as stale, duplicate, phantom, drift, or unreadable. |
+| `reason` | `str \| None` | Diagnostic reason such as stale, duplicate, phantom, drift, or unreadable. |
 | `sequence` | `list[PhysicalOperation]` | Ordered service operations for apply: clear, update_times, set, or none. |
 | `preflight_read` | `bool` | True when apply must re-read physical name/PIN immediately before the operation. |
-| `blocked_reason` | `str | None` | Why no physical write is safe this cycle. |
+| `blocked_reason` | `str \| None` | Why no physical write is safe this cycle. |
 
 **Action semantics**:
 
@@ -159,7 +159,7 @@ Optional HA Store cache record. The current schema/key may remain
 |-------|------|---------|
 | `schema_version` | `int` | Cache schema version. Existing v1 files are accepted as cache input. |
 | `entry_id` | `str` | Integration config entry scope. |
-| `lockname` | `str | None` | Keymaster lock scope for diagnostics only. |
+| `lockname` | `str \| None` | Keymaster lock scope for diagnostics only. |
 | `updated_at` | `str` | Last successful cache write. |
 | `aliases` | `dict[str, AliasRecord]` | UID/booking aliases keyed by normalized stable name and start order. |
 | `last_plan` | `dict[str, Any]` | Redacted last stateless plan diagnostics. |

--- a/specs/013-stateless-reconciliation/data-model.md
+++ b/specs/013-stateless-reconciliation/data-model.md
@@ -1,0 +1,255 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Data Model: Stateless Slot Reconciliation
+
+## Entities
+
+### ObservedSlot
+
+A physical Keymaster slot in the Rental-Control-managed range, read during the
+current refresh. This replaces the current `ManagedSlot` fields that mix
+physical state with persisted mapping status (`reconciliation.py:252-319`).
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `slot` | `int` | Physical Keymaster slot number. |
+| `managed` | `bool` | True only inside `start_slot .. start_slot + max_events - 1`. |
+| `raw_name` | `str | None` | Raw Keymaster name text state for this refresh; never from Store. |
+| `raw_pin` | `str | None` | Raw Keymaster PIN in memory only for this refresh; never logged or persisted. |
+| `has_pin` | `bool | None` | True when PIN is non-empty, false when confirmed blank/unknown/None, none when unreadable. |
+| `actual_start` | `datetime | None` | Observed Keymaster date-range start when readable. |
+| `actual_end` | `datetime | None` | Observed Keymaster date-range end when readable. |
+| `date_range_enabled` | `bool | None` | Observed Keymaster date-range switch state. |
+| `enabled` | `bool | None` | Observed Keymaster slot-enabled switch state. |
+| `readable` | `bool` | False when any safety-critical state is `unavailable` or missing. |
+| `empty_confirmed` | `bool` | True only when both name and PIN are cleared by util helpers. |
+| `classification` | `ObservedSlotStatus` | `empty`, `occupied`, `phantom`, or `unknown`. |
+| `normalized_name_forms` | `set[str]` | Full/prefix-stripped/trim-aware normalized names for matching. |
+| `matched_desired_id` | `str | None` | Desired reservation matched by stable name in this refresh. |
+
+**Validation rules**:
+
+- Unmanaged slots are emitted for diagnostics at most and are never modified.
+- `empty_confirmed` requires both name and PIN to satisfy
+  `is_cleared_keymaster_text_state()` (`util.py:76-79`).
+- `unavailable` makes `readable == False` via
+  `is_unreadable_keymaster_text_state()` (`util.py:82-84`) and forces
+  `classification == unknown`.
+- `raw_pin` is memory-only and must not appear in Store, logs, diagnostics, or
+  sensor attributes.
+- A slot with `classification == occupied` cannot receive a different
+  reservation until a reset is confirmed empty.
+
+### DesiredReservation
+
+A calendar stay that should be considered for Keymaster programming during the
+current refresh.
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `desired_id` | `str` | Refresh-local stable identifier: normalized stable slot name plus start-order index for duplicate names. |
+| `stable_slot_name` | `str` | Unprefixed, untrimmed slot name from `get_slot_name()` (`util.py:784-847`). |
+| `display_slot_name` | `str` | Prefixed/trimmed Keymaster display name, matching `async_fire_set_code()` (`util.py:478-489`). |
+| `normalized_name_forms` | `set[str]` | Stable full and display forms used to match `ObservedSlot` names. |
+| `start` | `datetime` | Reservation access start before buffer. |
+| `end` | `datetime` | Reservation access end before buffer. |
+| `buffered_start` | `datetime` | Keymaster date-range start after `apply_buffer()` (`util.py:442-463`). |
+| `buffered_end` | `datetime` | Keymaster date-range end after `apply_buffer()`. |
+| `slot_code` | `str` | Desired PIN for this refresh; generated or manual override. |
+| `code_source` | `generated | manual_observed | manual_config` | Why `slot_code` was chosen; never persisted raw. |
+| `event_uid` | `str | None` | Optional current iCal UID for cache-only aliases. |
+| `booking_aliases` | `set[str]` | Optional booking IDs for cache-only diagnostics. |
+| `eligible` | `bool` | True when existing calendar parsing/config includes the reservation. |
+| `protected_active` | `bool` | True for current checked-in guest from check-in sensor state. |
+| `checked_out` | `bool` | True when check-in sensor says the stay checked out. |
+| `selected_rank` | `int | None` | Rank in the should-be set after active protection and soonest-N selection. |
+| `matched_slot` | `int | None` | Physical slot matched by stable name this refresh. |
+| `assigned_slot` | `int | None` | Physical slot planned to contain this reservation after actions. |
+| `sensor_lookup_keys` | `set[str]` | Current-event fingerprints, UID aliases, and compatibility keys used by `event_N` sensors to find this desired record. |
+| `physical_time_override` | `tuple[datetime, datetime] | None` | Access window derived from a matched physical slot after reversing buffers when manual time override semantics apply. |
+| `overflow_reason` | `str | None` | Why the reservation is not selected or assignable. |
+
+**Validation rules**:
+
+- `start < end` after timezone normalization.
+- `display_slot_name` must be exactly the value the set helper will write.
+- Duplicate `stable_slot_name` values are allowed; `desired_id` disambiguates by
+  start-time order under the whole-unit non-overlap assumption. If trimmed-name
+  collisions, group-count mismatches, or reordered duplicate/date-shift groups
+  prevent one deterministic pairing, the affected group is blocked and
+  diagnosed rather than guessed.
+- `protected_active` reservations are selected before non-protected
+  reservations and count against capacity.
+- `slot_code` is never read from Store. If a matched physical slot contains a
+  manual PIN, the PIN may be copied in memory for this refresh only.
+
+### SlotAction
+
+A stateless per-slot decision emitted by the planner. This replaces the current
+`ActionKind` set/update/clear model that relies on persisted slot ownership
+(`reconciliation.py:106-135`, `reconciliation.py:1453-1536`).
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `kind` | `noop | update_in_place | reset | assign | blocked` | Action category for this slot. |
+| `slot` | `int` | Physical Keymaster slot number. |
+| `desired_id` | `str | None` | Desired reservation involved in the action. |
+| `matched_by` | `name_exact | name_trimmed | name_prefixed | duplicate_order | none` | How identity was established. |
+| `requires_confirmed_empty` | `bool` | True before any replacement PIN can be written. |
+| `reason` | `str | None` | Diagnostic reason such as stale, duplicate, phantom, drift, or unreadable. |
+| `sequence` | `list[PhysicalOperation]` | Ordered service operations for apply: clear, update_times, set, or none. |
+| `preflight_read` | `bool` | True when apply must re-read physical name/PIN immediately before the operation. |
+| `blocked_reason` | `str | None` | Why no physical write is safe this cycle. |
+
+**Action semantics**:
+
+- `noop`: physical name, PIN policy, and date window already match the desired
+  reservation; no service call.
+- `update_in_place`: physical name matches the desired reservation. Date-only
+  drift may use `update_times`. PIN or display-name replacement performs
+  `fresh read -> clear -> confirm empty -> fresh read -> set same desired to
+  same slot` in the same apply path. If clear is not confirmed, the set is
+  skipped and the next refresh retries from physical state.
+- `reset`: physical slot contains no selected desired reservation, contains a
+  duplicate non-canonical match, contains phantom state, or drifted to an
+  unrelated name. Apply clears only; reassignment waits until a later or same
+  apply phase sees confirmed empty.
+- `assign`: desired reservation is not physically present by name and this slot
+  is already confirmed empty. Apply re-checks name and PIN immediately before
+  writing, then sets name, PIN, dates, and enabled state.
+- `blocked`: slot is unreadable, still occupied while waiting for reset, outside
+  managed scope, or otherwise unsafe. No assignment is made.
+
+### StatelessPlan
+
+The planner's refresh result.
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `plan_id` | `str` | Refresh-scoped identifier for logs and callback suppression. |
+| `generated_at` | `datetime` | Plan computation timestamp. |
+| `observed_slots` | `dict[int, ObservedSlot]` | Current physical facts by slot. |
+| `desired_reservations` | `dict[str, DesiredReservation]` | Current desired reservations by refresh-local ID. |
+| `selected` | `dict[str, int]` | Desired IDs planned into slots after the action sequence. |
+| `overflow` | `dict[str, str]` | Eligible desired reservations not selected or not assignable. |
+| `actions` | `list[SlotAction]` | Per-slot actions ordered reset/update before assign. |
+| `diagnostics` | `dict[str, Any]` | Redacted explanation of matches, resets, blocks, and overflow. |
+
+**Plan invariants**:
+
+- Every selected desired reservation appears in at most one slot.
+- Every physical managed slot has at most one action.
+- A non-empty slot never receives a different reservation until an empty
+  physical state is confirmed.
+- Existing matched reservations are updated in their physical slot rather than
+  causing a second assignment; ambiguous matches block rather than allocate a
+  duplicate.
+- Store/cache data does not participate in `selected`, `actions`, or overflow
+  computation.
+
+### CacheOnlyStoreRecord
+
+Optional HA Store cache record. The current schema/key may remain
+(`const.py:138-146`) but its semantics change.
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `schema_version` | `int` | Cache schema version. Existing v1 files are accepted as cache input. |
+| `entry_id` | `str` | Integration config entry scope. |
+| `lockname` | `str | None` | Keymaster lock scope for diagnostics only. |
+| `updated_at` | `str` | Last successful cache write. |
+| `aliases` | `dict[str, AliasRecord]` | UID/booking aliases keyed by normalized stable name and start order. |
+| `last_plan` | `dict[str, Any]` | Redacted last stateless plan diagnostics. |
+| `migration_notes` | `list[str]` | Notes about ignored legacy status/fence fields. |
+
+**Cache invariants**:
+
+- Raw PIN values are never stored.
+- Legacy fields `status`, `slot`, `operation_id`, `operation_kind`,
+  `pending_clear_since`, `blocked_slots`, and `missing_count` are ignored by the
+  planner.
+- Loading failure, missing cache, duplicate cache claims, stale cache, or cache
+  deletion cannot change physical actions.
+- Cache writes are best-effort and can be skipped without changing runtime
+  correctness.
+
+## Matching and Identity Rules
+
+1. Build desired reservations from the sorted calendar using existing parsing,
+   Honor Event Times, override fallback, and buffer rules.
+2. Build observed slots by reading physical Keymaster name, PIN, dates, and
+   switches for every managed slot.
+3. Normalize desired and observed names:
+   - strip surrounding whitespace and casefold;
+   - remove configured prefix plus separator from observed names when present;
+   - compare desired full name, desired display name, observed full name, and
+     observed prefix-stripped name;
+   - when trimming is enabled, accept `trim_name(longer, guest_max) == shorter`.
+4. Group desired reservations and observed occupied slots by normalized stable
+   name. For each group, pair by start-time order. If physical start is missing,
+   slot number is the deterministic fallback. If trim-colliding full names or
+   simultaneous duplicate-name date shifts cannot produce a single safe order,
+   block the group and report ambiguity.
+5. Matched pairs get `update_in_place` or `noop`; unmatched occupied physical
+   slots get `reset` or `blocked`; unmatched desired reservations get `assign`
+   only into confirmed-empty slots.
+6. Duplicate physical slots for one desired reservation keep one canonical match
+   selected by active protection, then earliest start-order pair, then lowest
+   slot. Non-canonical duplicates reset through confirmed clear.
+
+## State Transitions
+
+### Physical Slot Lifecycle
+
+```text
+UNKNOWN ──readable empty──────────────► EMPTY
+UNKNOWN ──readable occupied───────────► OCCUPIED
+UNKNOWN ──unavailable/missing─────────► BLOCKED
+
+EMPTY ──assign desired────────────────► OCCUPIED (after set confirmed)
+EMPTY ──no desired────────────────────► EMPTY
+
+OCCUPIED ──same desired correct───────► OCCUPIED (noop)
+OCCUPIED ──same desired date drift────► OCCUPIED (update_times)
+OCCUPIED ──same desired PIN drift─────► CLEARING_SAME_SLOT
+OCCUPIED ──not desired/duplicate──────► CLEARING_EMPTY
+
+CLEARING_SAME_SLOT ──empty confirmed──► OCCUPIED (set same desired same slot)
+CLEARING_SAME_SLOT ──not confirmed────► OCCUPIED/BLOCKED next refresh
+CLEARING_EMPTY ──empty confirmed──────► EMPTY
+CLEARING_EMPTY ──not confirmed────────► OCCUPIED/BLOCKED next refresh
+```
+
+There is no persisted `pending_clear` state in this machine. A slot that did
+not clear remains occupied or unknown when physically observed later.
+
+### Desired Reservation Lifecycle
+
+```text
+calendar eligible ──active checked-in──────► selected protected
+calendar eligible ──within soonest-N───────► selected unprotected
+calendar eligible ──beyond capacity────────► overflow capacity
+selected ──stable name matched physically──► matched existing slot
+selected ──unmatched + empty slot──────────► assign
+selected ──unmatched + no empty slot───────► blocked no_empty_slot
+calendar removed/not eligible──────────────► no desired reservation
+```
+
+Active checked-in reservations are selected before non-protected reservations
+and count against capacity. Removed/non-eligible reservations have no ghost
+reservation synthesized from Store.
+
+### Cache-Only Store Lifecycle
+
+```text
+missing/corrupt/legacy Store ──load────────► empty cache + migration note
+cache aliases available ──load─────────────► optional diagnostics only
+refresh complete ──best-effort save────────► redacted aliases/last_plan
+cache deleted mid-run ──next refresh───────► empty cache, same actions
+```
+
+Store records never transition a physical slot between empty, occupied,
+blocked, reset, or assign states.

--- a/specs/013-stateless-reconciliation/plan.md
+++ b/specs/013-stateless-reconciliation/plan.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 `013-stateless-reconciliation-plan` | **Date**: 2026-06-23 | **Spec**:
 [spec.md](spec.md)
 **Input**: Feature specification from
-`/specs/013-stateless-reconciliation/spec.md` and GitHub issue #607
+`specs/013-stateless-reconciliation/spec.md` and GitHub issue #607
 
 ## Summary
 

--- a/specs/013-stateless-reconciliation/plan.md
+++ b/specs/013-stateless-reconciliation/plan.md
@@ -32,7 +32,7 @@ protection, deterministic code generation, check-in sensors, and read-only
 
 ## Technical Context
 
-**Language/Version**: Python >=3.14.2
+**Language/Version**: Python ≥3.14.2
 **Primary Dependencies**: Home Assistant core, Keymaster integration,
 `pytest-homeassistant-custom-component`, existing `homeassistant.helpers.storage.Store`
 **Storage**: Home Assistant `Store` remains available but is cache-only for

--- a/specs/013-stateless-reconciliation/plan.md
+++ b/specs/013-stateless-reconciliation/plan.md
@@ -1,0 +1,185 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Implementation Plan: Stateless Slot Reconciliation
+
+**Feature**: `013-stateless-reconciliation` | **Planning Branch**:
+`013-stateless-reconciliation-plan` | **Date**: 2026-06-23 | **Spec**:
+[spec.md](spec.md)
+**Input**: Feature specification from
+`/specs/013-stateless-reconciliation/spec.md` and GitHub issue #607
+
+## Summary
+
+Redesign the managed-slot reconciliation loop so each refresh derives the
+correct Keymaster state from only two authoritative inputs: the physical
+Keymaster managed-slot entities and the current calendar-derived reservations.
+Persisted slot mappings are demoted to cache-only diagnostics/alias metadata and
+must never decide selection, duplicate prevention, reset safety, or assignment.
+
+The implementation will rework the existing coordinator-owned reconciliation
+path (`coordinator.py:2053-2173`) into a stateless planner that observes managed
+slots (`coordinator.py:1735-1958`), builds desired reservations with existing
+calendar semantics (`coordinator.py:1118-1430`), matches desired reservations to
+physical slots by stable trim-aware slot-name identity, and emits per-slot
+actions: no-op, update in place, reset, assign, or blocked. This replaces the
+persisted-authoritative Store/mapping/fence path introduced by spec 012 while
+preserving buffers, Honor Event Times, manual overrides, active guest
+protection, deterministic code generation, check-in sensors, and read-only
+`event_N` sensors.
+
+## Technical Context
+
+**Language/Version**: Python >=3.14.2
+**Primary Dependencies**: Home Assistant core, Keymaster integration,
+`pytest-homeassistant-custom-component`, existing `homeassistant.helpers.storage.Store`
+**Storage**: Home Assistant `Store` remains available but is cache-only for
+alias history and redacted diagnostics; Keymaster physical entities plus the
+calendar are the correctness source
+**Testing**: pytest via `uv run pytest tests/`; ruff via
+`uv run ruff check custom_components/ tests/`; pre-commit hooks for reuse,
+ruff, mypy, interrogate, yamllint, actionlint, and gitlint
+**Target Platform**: Home Assistant custom integration on Linux, HA OS, Docker,
+and HACS-managed installs using the HA asyncio event loop
+**Project Type**: Single Home Assistant custom integration
+**Performance Goals**: One O(max_events + max_slots) observation/matching pass
+per refresh; bounded per-slot Keymaster service confirmation waits; no blocking
+I/O on the event loop beyond existing executor-wrapped calendar parsing
+**Constraints**: Lock-code programming is safety-critical; managed slots are
+never reused until physical name and PIN are confirmed empty; `unavailable`
+Keymaster text state is conservative; unmanaged slots are never modified;
+callbacks must not re-enter reconciliation
+**Scale/Scope**: Typical default five managed Keymaster slots and calendar
+horizon from configuration; redesign touches coordinator refresh, the pure
+planner, EventOverrides/slot-operation state, Keymaster callback handling,
+sensors, Store migration/cache handling, diagnostics, and tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I: Code Quality & Testing | PASS | The plan requires pure unit coverage for the stateless planner plus integration tests for duplicate prevention, confirmed reset, Store deletion, callbacks, manual overrides, and active protection. |
+| II: Atomic Commit Discipline | PASS | This PR contains only PLAN-stage docs. Future implementation can split planner, coordinator wiring, Store migration, sensor updates, and tests into atomic commits. |
+| III: Licensing & Attribution | PASS | All new or modified markdown artifacts include SPDX headers. Future Python modules must keep project SPDX headers. |
+| IV: Pre-Commit Integrity | PASS | No hook bypass is planned. Quickstart defines targeted validation before implementation merge. |
+| V: Agent Co-Authorship & DCO | PASS | The PLAN commit uses `git commit -s` and the requested `Co-authored-by` trailer. |
+| VI: User Experience Consistency | PASS | Existing entity names, `event_N` attributes, manual code/time semantics, buffers, trimming, Honor Event Times, and check-in tracking are preserved. |
+| VII: Performance Requirements | PASS | Stateless planning is linear in configured slots/events and removes Store recovery/adoption loops from correctness decisions. |
+
+**Gate result: PASS** — no violations. Proceeding to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-stateless-reconciliation/
+├── plan.md                    # This file
+├── research.md                # Phase 0 design decisions and alternatives
+├── data-model.md              # Phase 1 entities and state transitions
+├── quickstart.md              # Phase 1 validation guide
+├── checklists/
+│   └── requirements.md        # Existing SPEC-stage checklist
+└── tasks.md                   # Phase 2 output only; not created in PLAN stage
+```
+
+`contracts/` is intentionally omitted. This redesign introduces no external
+HTTP, WebSocket, Home Assistant service, entity-service, or public API contract.
+The internal planner interface is specified in [data-model.md](data-model.md)
+instead.
+
+### Source Code (repository root)
+
+```text
+custom_components/rental_control/
+├── __init__.py                # Keep setup order; simplify startup readability
+│                              # watcher once stateless retry makes timing safe
+├── coordinator.py             # Observe physical slots, build desired
+│                              # reservations, invoke stateless planner, apply
+│                              # actions, and write cache-only Store metadata
+├── event_overrides.py         # Retain the single async lock, Keymaster
+│                              # service helpers, retry diagnostics, and
+│                              # callback suppression; delete greedy/persisted-
+│                              # authoritative allocation state
+├── reconciliation.py          # Rework into a stateless pure planner (or split
+│                              # to slot_planner.py if implementation prefers)
+│                              # with ObservedSlot, DesiredReservation, and
+│                              # SlotAction types
+├── util.py                    # Reuse blank/unreadable helpers, bounded
+│                              # confirmation waits, trimming, buffers, and
+│                              # callback feedback handling
+├── const.py                   # Keep code generation, refresh, and Store key
+│                              # constants; Store schema becomes cache-only
+├── sensor.py                  # No entity-name changes
+└── sensors/
+    ├── calsensor.py           # Keep `event_N` sensors read-only from the
+    │                          # latest reconciled plan, with compatibility
+    │                          # lookup from current events to desired IDs
+    └── checkinsensor.py       # Continue exposing active guest state and read
+                               # latest-plan slot ownership for unlock checks
+
+tests/
+├── unit/
+│   ├── test_slot_reconciliation.py      # Pure stateless planner invariants
+│   ├── test_event_overrides.py          # Apply actions and lock/clear safety
+│   ├── test_util.py                     # Confirmed empty and service waits
+│   ├── test_sensors.py                  # `event_N` read-only reflection
+│   └── test_checkin_sensor.py           # Active guest protection surface
+└── integration/
+    ├── test_refresh_cycle.py            # End-to-end convergence scenarios
+    └── test_slot_concurrency.py         # Callback/reconciliation atomicity
+```
+
+**Structure Decision**: Keep the existing single-integration layout. Rework the
+current `reconciliation.py` pure planning module rather than introduce a new
+runtime dependency. A `slot_planner.py` split is acceptable only if it remains an
+internal module with the same pure inputs/outputs and no Store dependency.
+
+## Phase 0 Research
+
+Research is complete in [research.md](research.md). It resolves the required
+stateless engine, stable-name identity, confirmed-reset, cache-only Store,
+soonest-N/active/manual semantics, `event_N` sensors, concurrency, and deletion
+of persisted-authoritative machinery. Every decision cites live code paths that
+will be changed or retired.
+
+## Phase 1 Design Artifacts
+
+- [research.md](research.md): required and complete.
+- [data-model.md](data-model.md): required and complete.
+- [quickstart.md](quickstart.md): required and complete.
+- `contracts/`: omitted because no external API is introduced.
+- `update-agent-context.sh`: intentionally not run. The redesign adds no new
+  technology, dependency, runtime, or agent-relevant tool; HA Store already
+  exists in the codebase (`coordinator.py:50`, `coordinator.py:559-621`).
+
+## Post-Design Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I: Code Quality & Testing | PASS | Quickstart enumerates must-pass acceptance tests for every safety and compatibility invariant in FR-001 through FR-021, including deleted Store cold start and duplicate/date-shift cases. |
+| II: Atomic Commit Discipline | PASS | PLAN artifacts are one docs-only change; implementation can proceed as separate behavior/test commits. |
+| III: Licensing & Attribution | PASS | `plan.md`, `research.md`, `data-model.md`, and `quickstart.md` include SPDX headers. |
+| IV: Pre-Commit Integrity | PASS | The PR must pass repository hooks and CI without bypasses. |
+| V: Agent Co-Authorship & DCO | PASS | The planned commit uses sign-off and co-authorship trailers. |
+| VI: User Experience Consistency | PASS | The design preserves existing entity names, configuration options, lock-code generation semantics, check-in tracking, and diagnostics boundaries. |
+| VII: Performance Requirements | PASS | Stateless matching is bounded by configured slots/events and avoids Store-adoption timing loops as a correctness dependency. |
+
+**Gate result: PASS** — no complexity violations.
+
+## Complexity Tracking
+
+> No violations to justify — all constitution gates pass.
+
+## Phase Notes
+
+- PLAN stage stops here. Do not create `tasks.md` or modify runtime source in
+  this PR.
+- Implementation must keep all physical operations scoped to the configured
+  Rental-Control-managed Keymaster slot range.
+- The first implementation task should build the pure stateless planner tests
+  before coordinator/apply-path rewiring.

--- a/specs/013-stateless-reconciliation/quickstart.md
+++ b/specs/013-stateless-reconciliation/quickstart.md
@@ -1,0 +1,248 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart: Stateless Slot Reconciliation Validation
+
+## Scope
+
+This guide validates the implementation stage for spec
+`013-stateless-reconciliation`. It is not a task list and does not implement the
+feature. Validation must prove that every refresh reconciles from physical
+Keymaster state plus current calendar data, stable slot-name matching prevents
+duplicates across reservation changes, confirmed-reset-before-reapply holds
+without persisted fences, and the Store is cache-only.
+
+## Developer Setup
+
+```bash
+cd /home/tykeal/repos/personal/homeassistant/rental-control
+uv sync
+```
+
+Run targeted tests first, then escalate only if failures indicate broader
+breakage.
+
+```bash
+uv run pytest tests/unit/test_slot_reconciliation.py \
+  tests/unit/test_event_overrides.py \
+  tests/unit/test_util.py -q
+uv run pytest tests/integration/test_refresh_cycle.py \
+  tests/integration/test_slot_concurrency.py -q
+uv run ruff check custom_components/ tests/
+```
+
+## Pure Planner Unit Tests
+
+Create or migrate `tests/unit/test_slot_reconciliation.py` around the stateless
+planner inputs and outputs.
+
+1. **Already correct no-op**: physical slot name, PIN, and buffered dates match
+   one desired reservation; action is `noop` and no service call is planned.
+2. **Length increase**: physical slot name matches a desired reservation whose
+   end time moved later; planner emits `update_in_place` for the same slot and
+   no second slot is selected for that reservation.
+3. **Length decrease**: same as above with earlier end time; same slot is used.
+4. **Full date shift with date-based code change**: physical name matches, old
+   generated code differs from the new generated code, planner emits
+   `update_in_place(replace_code)` for the same slot, and the desired
+   reservation appears in exactly one slot.
+5. **Same-guest back-to-back**: adjacent reservations with the same stable name
+   are paired by start-time order and do not collapse into one slot.
+6. **Duplicate guest names**: two concurrent upcoming reservations with the same
+   display/stable name are matched by start-time order; each selected
+   reservation appears in exactly one managed slot.
+7. **Duplicate names plus date shift**: both duplicate-name reservations change
+   dates in one refresh; physical slots pair to desired reservations by ordered
+   stable-name group, update in place, and no extra slot is allocated. Add an
+   ambiguous reorder/trim-collision variant and assert the affected writes are
+   blocked with diagnostics rather than guessed.
+8. **Soonest-N overflow**: with more eligible reservations than managed slots,
+   selected non-active reservations are the earliest starts after protected
+   active guests are counted.
+9. **Farther reservation dropout**: when a nearer reservation enters capacity,
+   the farthest unprotected physical occupant resets, and the nearer
+   reservation is assigned only after an empty slot is confirmed.
+10. **Duplicate physical occupant**: same desired reservation appears in two
+    physical slots by name; one canonical slot remains matched and the
+    non-canonical duplicate resets through confirmed clear.
+11. **Unknown/unavailable conservative**: `unknown`, blank, and `None` count as
+    cleared text states; `unavailable` blocks assignment.
+12. **Unmanaged slot ignored**: a populated slot outside the configured managed
+    range never receives an action.
+
+## Confirmed Reset and Apply Tests
+
+Use `tests/unit/test_event_overrides.py` and `tests/unit/test_util.py` to pin
+service-operation safety.
+
+1. `async_fire_clear_code()` returns confirmed only when both physical name and
+   PIN are cleared; lingering name/PIN leaves the action unconfirmed.
+2. `async_fire_clear_code()` treats `unavailable` name or PIN as unconfirmed,
+   not empty.
+3. `update_in_place(replace_code)` re-reads the physical slot, calls clear
+   first, re-reads/sets the same reservation into the same slot only after the
+   clear result is confirmed, and never writes a replacement PIN after an
+   unconfirmed clear.
+4. A clear that remains physically occupied is not fenced by Store; the next
+   planner run sees the slot still occupied and retries or blocks from physical
+   state.
+5. A physically empty slot previously mentioned in a legacy pending-clear cache
+   is assignable because Store is non-authoritative.
+6. Set confirmation reuses `_async_wait_for_expected_name()` and returns
+   unconfirmed when the bounded wait expires.
+7. Callback suppression ignores coordinator-originated name/PIN/date feedback
+   and does not launch reconciliation.
+
+## Store Non-Authoritative Tests
+
+Create tests that run the same physical/calendar scenario with cache present,
+cache missing, cache stale, cache contradictory, and cache corrupt. The planned
+actions must be identical.
+
+1. **Deleted Store cold start**: existing coded Keymaster slots are recognized by
+   physical stable name and reconciled in place without adoption.
+2. **First upgrade with legacy 3.5.x Store**: legacy `status`, `slot`,
+   `pending_clear_since`, `operation_id`, `missing_count`, and `blocked_slots`
+   fields are ignored for correctness; no working slot is wiped merely because
+   Store disagrees.
+3. **Contradictory Store**: cache says slot 10 belongs to Alice while physical
+   slot 10 is Bob and calendar wants Bob; Bob wins by physical name.
+4. **Stale pending clear**: cache says slot is pending clear but physical name
+   and PIN are empty; planner may assign an unassigned desired reservation.
+5. **Cache deletion mid-run**: after a successful refresh, delete the Store file
+   or make `async_load()` return `None`; the next refresh with unchanged
+   physical slots and calendar emits the same no-op/update/reset/assign actions.
+6. **Cache write failure**: simulate Store save failure; physical reconciliation
+   still completes and later refresh behavior is unchanged.
+
+## Preserved Semantics Tests
+
+1. **Manual door-code override**: a matched physical slot whose PIN does not
+   equal the generated code for its observed dates is treated as manual and
+   preserved in the desired reservation; raw PIN is not persisted or logged.
+2. **Generated date-based code replacement**: when the observed PIN equals the
+   previously generated date-based code and dates shift with
+   `should_update_code` enabled, the old generated code is replaced in place.
+3. **Manual time overrides**: when Honor Event Times is off, existing/manual
+   time-of-day overrides still determine the programmed window.
+4. **Honor Event Times**: timed calendar events use PMS event times; all-day
+   events use description times or configured/default fallback as today.
+5. **Buffers**: before/after lock-code buffers produce the same Keymaster
+   date-range values as the existing `apply_buffer()` helper.
+6. **Trimming and prefixing**: matching accepts full, prefixed, trimmed, and
+   prefixed-trimmed physical names, and writes the configured display name.
+7. **Check-in tracking**: checked-in guests are protected and checked-out guests
+   can leave the should-be set; sensor attributes remain unchanged.
+8. **`event_N` sensors**: sensors expose the same calendar attributes and read
+   `slot_number`/`slot_code` from the latest stateless plan without invoking
+   `async_reserve_or_get_slot()`, set, clear, or update services. Include a
+   date-shift case proving the sensor's existing event fingerprint lookup is
+   bridged to the refresh-local desired ID.
+9. **Manual time override from physical state**: a matched physical slot with
+   manually adjusted Keymaster dates feeds the desired access window after
+   reversing buffers when Honor Event Times does not override it.
+10. **Check-in unlock validation**: unlock validation reads latest plan/observed
+    slot ownership, not deleted override maps, and still rejects unlocks from a
+    different guest's slot.
+
+## Integration Scenarios
+
+Use `tests/integration/test_refresh_cycle.py` and
+`tests/integration/test_slot_concurrency.py` for end-to-end refresh behavior.
+
+### Scenario A: reservation length increase/decrease
+
+- Seed a managed physical slot with a reservation by name, generated PIN, and
+  dates.
+- Change only the checkout date later, run refresh, confirm the same slot is
+  updated and no duplicate exists.
+- Change checkout earlier, run refresh, confirm the same slot is still the only
+  physical assignment.
+
+### Scenario B: full date shift and code change
+
+- Use `date_based` code generation.
+- Seed a physical slot with old dates/code for a reservation.
+- Move both start and end so the generated code changes.
+- Run refresh with clear and set confirmations.
+- Assert the old physical slot is cleared, confirmed empty, and set with the new
+  code/name/dates; no other slot receives that reservation.
+
+### Scenario C: duplicate names and rebooking
+
+- Seed two same-name reservations in two physical slots.
+- Shift one reservation's dates and add a back-to-back same-guest stay.
+- Run refresh and assert start-time ordered matching leaves each selected stay
+  in exactly one slot with no duplicate assignment.
+
+### Scenario D: soonest-N overflow and active protection
+
+- Fill all managed slots with farther-future reservations.
+- Mark one current guest checked in through the check-in sensor.
+- Add a nearer upcoming reservation.
+- Run refresh. Assert the active guest remains, the nearer reservation enters
+  after a confirmed reset, and the farthest unprotected reservation overflows.
+
+### Scenario E: confirmed-reset-before-reapply
+
+- Require a reset before assigning a new reservation.
+- Force reset confirmation to lag by leaving name or PIN populated.
+- Run refresh and assert no replacement PIN is written.
+- Change physical state to empty and run refresh again; assignment may proceed.
+
+### Scenario F: physical-empty self-heal
+
+- Seed a managed slot with blank/`unknown`/`None` name and PIN while legacy cache
+  claims it is occupied or pending clear.
+- Run refresh and assert the slot is treated as free and can receive an
+  unassigned selected reservation.
+
+### Scenario G: manual drift correction
+
+- Manually edit a managed slot name, PIN, or dates away from its desired
+  reservation.
+- Run refresh and assert the planner either restores the matched desired state
+  in place or resets an unrelated/stale occupant, with diagnostics identifying
+  the drifted fields and no raw PIN values.
+
+### Scenario H: callback re-entrancy
+
+- Start an apply operation and emit Keymaster name/PIN/date state changes while
+  it is in progress.
+- Assert callbacks update in-memory feedback or are suppressed when
+  coordinator-originated, call any compatibility update path with
+  `request_refresh=False`, and do not start nested reconciliation.
+- Complete the operation and verify the next normal refresh observes physical
+  truth.
+
+## Manual Verification
+
+In a Home Assistant development instance with a test Keymaster lock:
+
+1. Configure Rental Control with two managed slots.
+2. Program two upcoming reservations and confirm both slots match their names.
+3. Extend one stay, wait for refresh, and confirm the same slot updates without
+   a duplicate.
+4. Shift the stay dates so the date-based code changes; confirm the old slot is
+   cleared then reprogrammed in place only after empty confirmation.
+5. Delete the Rental Control slot-mapping Store file or disable Store loading,
+   restart/reload, and confirm existing physical slots reconcile by name.
+6. Mark a guest checked in, add nearer reservations, and confirm active guest
+   protection.
+7. Manually edit a slot and confirm drift diagnostics plus self-healing.
+
+## Expected Final Validation
+
+Before merging the implementation PR, run:
+
+```bash
+uv run pytest tests/ -x -q
+uv run ruff check custom_components/ tests/
+pre-commit run --all-files
+```
+
+All tests and hooks must pass without `--no-verify`, `--no-gpg-sign`, or other
+bypasses. The final implementation must prove deleting the Store mid-run causes
+no behavior change.

--- a/specs/013-stateless-reconciliation/quickstart.md
+++ b/specs/013-stateless-reconciliation/quickstart.md
@@ -17,7 +17,7 @@ without persisted fences, and the Store is cache-only.
 ## Developer Setup
 
 ```bash
-cd /home/tykeal/repos/personal/homeassistant/rental-control
+cd path/to/homeassistant-rental-control
 uv sync
 ```
 
@@ -240,7 +240,7 @@ Before merging the implementation PR, run:
 ```bash
 uv run pytest tests/ -x -q
 uv run ruff check custom_components/ tests/
-pre-commit run --all-files
+uv run pre-commit run --all-files
 ```
 
 All tests and hooks must pass without `--no-verify`, `--no-gpg-sign`, or other

--- a/specs/013-stateless-reconciliation/research.md
+++ b/specs/013-stateless-reconciliation/research.md
@@ -1,0 +1,495 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Research: Stateless Slot Reconciliation
+
+## R-001: Stateless Reconciliation Engine
+
+**Decision**: Rework the existing pure planner in
+`custom_components/rental_control/reconciliation.py` into a stateless engine
+that accepts only:
+
+1. `ObservedSlot` records read from physical Keymaster entities for the current
+   refresh;
+2. `DesiredReservation` records derived from the current calendar and current
+   check-in tracking state; and
+3. immutable runtime configuration such as managed slot range, prefix, trimming,
+   buffers, and code-generation options.
+
+The engine returns a per-slot action plan containing `noop`,
+`update_in_place`, `reset`, `assign`, and `blocked` actions. The coordinator
+continues to call the planner from `_async_update_data()` after calendar fetch
+and before publishing coordinator data, because that method already owns the
+refresh cycle and currently wires observation, reservation building,
+`compute_desired_plan()`, apply, Store sync, and save at
+`coordinator.py:2053-2173`.
+
+**Rationale**:
+
+- The live refresh cycle already has the correct orchestration point: it fetches
+  current calendar data (`coordinator.py:2062-2077`), applies calendar miss
+  tolerance (`coordinator.py:2078-2103`), observes managed slots
+  (`coordinator.py:2122`, `coordinator.py:2128`), builds reservations
+  (`coordinator.py:2124`), invokes `compute_desired_plan()`
+  (`coordinator.py:2131-2141`), applies actions (`coordinator.py:2150-2152`),
+  and saves Store data (`coordinator.py:2173`).
+- Physical observation is already isolated in `_observe_managed_slots()`, which
+  reads Keymaster name/PIN text entities and date/switch state for each managed
+  slot (`coordinator.py:1735-1958`). The stateless engine keeps that physical
+  read as an input but removes persisted status from classification.
+- The current planner module is already pure enough to test in isolation: it
+  defines `Reservation`, `ManagedSlot`, `SlotAction`, `DesiredPlan`, and
+  `compute_desired_plan()` (`reconciliation.py:136-427`,
+  `reconciliation.py:1638-1831`). Reworking it avoids introducing new
+  dependencies.
+- The current Store/mapping path is not stateless: `_build_reservations()`
+  consults `_slot_mappings` for fingerprint history and missing counts
+  (`coordinator.py:1118-1152`), rematches current reservations to persisted
+  mappings (`coordinator.py:1290-1342`), synthesizes ghost reservations from
+  Store records (`coordinator.py:1422-1430`), and then syncs Store as an
+  authoritative mapping after apply (`coordinator.py:1596-1733`). That path is
+  the core plan-vs-reality drift to remove.
+
+**Replaces / deletes**:
+
+- Delete persisted status as an input to slot classification. `_observe_managed_slots()`
+  currently imports pending-clear fences from `event_overrides.pending_clear_slots`
+  and persisted status at `coordinator.py:1753-1769` and changes classification
+  based on Store state at `coordinator.py:1870-1918`; the stateless design uses
+  only observed physical state for free/occupied/unknown/phantom.
+- Delete Store-driven rematch and ghost logic from `_build_reservations()`:
+  `_remap_observed_mappings_to_physical_reservations()`
+  (`coordinator.py:1046-1117`), `find_reservation_rematch()` use
+  (`coordinator.py:1290-1296`), mapping re-keying (`coordinator.py:1297-1376`),
+  miss-count reset (`coordinator.py:1378-1387`), and ghost reservations
+  (`coordinator.py:1422-1595`).
+- Delete the persisted-authoritative fields from `EventOverrides.__init__()`:
+  `_next_slot`, `_slot_miss_counts`, `_slot_uids`, `_persisted_mappings`,
+  `_pending_clear_slots`, and `_pending_fences` (`event_overrides.py:162-177`).
+  Keep the async lock (`event_overrides.py:160`), actual-state/diagnostics cache,
+  retry tracking, and callback suppression.
+- Delete `async_reserve_or_get_slot()` and `_find_overlapping_slot()` as
+  production paths (`event_overrides.py:551-785`). The new planner owns global
+  matching/allocation instead of per-event greedy reservation.
+- Delete adoption as correctness machinery: `async_adopt_keymaster_slots()`
+  (`coordinator.py:647-783`) and `_adopt_observed_coded_slots()`
+  (`coordinator.py:785-863`) become unnecessary for correctness because a
+  deleted Store cold start reads physical slot names directly.
+
+**Alternatives considered**:
+
+- **Patch the existing persisted planner**: Rejected because FR-001 and FR-002
+  require physical Keymaster state plus calendar to be the only correctness
+  inputs. Persisted pending clears, ghost reservations, and stale mappings would
+  remain load-bearing.
+- **Keep `EventOverrides` as the assignment owner**: Rejected because its legacy
+  `_next_slot` path is greedy (`event_overrides.py:481-532`) and cannot prove
+  soonest-N ordering or duplicate collapse across all slots.
+- **Run reconciliation from Keymaster callbacks**: Rejected because callbacks are
+  noisy and current code intentionally avoids re-entering reconciliation after a
+  callback update (`util.py:1047-1055`).
+
+---
+
+## R-002: Stable Slot-Name Identity Matching
+
+**Decision**: Match desired reservations to physical managed slots by stable
+slot-name identity before considering code or date equality. A desired
+reservation's stable name is the guest/reservation slot name returned by
+`get_slot_name(summary, description, event_prefix)` (`util.py:784-847`) before
+Keymaster display trimming. Its Keymaster display form is then generated by
+applying the configured prefix and `trim_name()` (`util.py:399-439`), matching
+how `async_fire_set_code()` writes names at `util.py:478-489`.
+
+A physical slot's name is read from the Keymaster name text entity in
+`_observe_managed_slots()` (`coordinator.py:1772-1833`). Matching normalizes
+case and surrounding whitespace, strips the configured prefix when present, and
+accepts exact full-name, exact display-name, and trim-aware prefix-aware forms.
+When duplicate desired names or ambiguous physical names exist, the planner
+pairs the name group by start-time order: desired reservations sort by
+`(start, original_index)` and observed occupied slots sort by observed
+Keymaster start time, then slot number when the physical start is missing. Each
+desired reservation and each physical slot may be matched at most once. If a
+trimmed display name collides across different full stable names, group counts
+do not line up, or a duplicate-name/date-shift group cannot produce one
+deterministic total order, the safe result is `blocked` with diagnostics rather
+than guessing or allocating an extra slot.
+
+**Rationale**:
+
+- Issue #607 identifies the failure mode: matching by dates or generated code
+  treats a changed reservation as absent. The default/date-based generator
+  explicitly changes the code when start/end dates shift. The sensor documents
+  that side effect at `sensors/calsensor.py:299-304`, and the coordinator
+  generator builds the code from start/end day/month/year at
+  `coordinator.py:864-889` and falls back to it from `_generate_slot_code()` at
+  `coordinator.py:921-946`.
+- Slot name survives length increases, length decreases, and full date shifts.
+  The existing event-name extraction already normalizes multiple booking-source
+  formats while preserving the guest/reservation identifier (`util.py:784-847`).
+- Keymaster stores the display name, which may be prefixed and trimmed.
+  `async_fire_set_code()` writes `event_prefix + slot_name` or the trimmed
+  version when configured (`util.py:478-489`), so the matcher must accept both
+  full and Keymaster-display forms.
+- The live 012 rematch logic still starts from Store mappings and fingerprints
+  that include start/end (`reconciliation.py:608-647`) and then tries UID/name
+  and continuity rematches (`reconciliation.py:1056-1296`). A date-shifted
+  reservation can therefore still depend on stale persisted history. The 013
+  matcher instead treats the physical slot name as the durable identity that is
+  re-read every cycle.
+
+**In-place update path**:
+
+- If a physical slot name matches a desired reservation and code/dates/name
+  display are already correct, emit `noop` to avoid lock churn (FR-013).
+- If the same matched reservation has only date-window drift and the PIN is
+  unchanged, emit `update_in_place(update_times)` for the same physical slot,
+  reusing the existing `async_fire_update_times()` service helper
+  (`util.py:630-687`).
+- If the same matched reservation needs a replacement PIN or display name, emit
+  `update_in_place(replace_code)` bound to that same slot. The apply path clears
+  that slot, verifies it is physically empty, and then sets the same reservation
+  back into the same slot during the same apply operation. If clear is not
+  confirmed, the set is skipped; the next refresh will still observe the old
+  physical name and retry the same in-place update rather than allocate a second
+  slot.
+- Desired reservations that do not match any physical slot by name are assigned
+  only to physical slots already confirmed empty. Assignment uses a fresh
+  immediate physical read just before writing, not only the snapshot from plan
+  time, so a slot that changed after observation becomes `blocked` instead of
+  receiving a PIN.
+
+**Alternatives considered**:
+
+- **Code/date matching**: Rejected because date-based code changes when dates
+  shift (`sensors/calsensor.py:299-304`; `coordinator.py:864-889`), recreating
+  duplicate slot assignments.
+- **Persisted fingerprint primary matching**: Rejected for correctness because
+  the v1 fingerprint includes start/end (`reconciliation.py:608-647`), so a
+  full date shift requires Store rematch history.
+- **UID-primary matching**: Rejected because issue #607 explicitly demotes
+  Store/UID aliasing to cache-only, and current UID matching lives in the
+  retiring `_slot_uids` structure (`event_overrides.py:166-167`).
+
+---
+
+## R-003: Confirmed Reset Before Reapply
+
+**Decision**: A slot is reusable only when the current physical Keymaster read
+confirms both name and PIN are empty, blank, `unknown`, or `None` using the
+existing case-insensitive helpers. `unavailable` is unreadable and therefore
+conservative: the planner emits `blocked` and tries again on a later refresh.
+No persisted pending-clear fence participates in this decision.
+
+**Rationale**:
+
+- `is_cleared_keymaster_text_state()` treats `None`, blank strings, and
+  casefolded `unknown` as cleared (`util.py:64-79`), while
+  `is_unreadable_keymaster_text_state()` treats casefolded `unavailable` as
+  unreadable (`util.py:82-84`). The physical observation path already uses those
+  helpers to compute `physically_empty` and `unreadable` at
+  `coordinator.py:1798-1805`.
+- `async_fire_clear_code()` already performs bounded physical confirmation. It
+  presses Keymaster reset (`util.py:299-306`), waits briefly for propagation
+  (`util.py:326-327`), force-clears lingering name when needed
+  (`util.py:335-369`), checks the PIN text state (`util.py:370-376`), and
+  returns an `OperationResult` that distinguishes confirmed, unconfirmed,
+  failed, lingering name, and lingering PIN (`util.py:378-396`).
+- `async_fire_set_code()` already uses a bounded name confirmation wait after a
+  set (`util.py:611-627`), implemented by `_async_wait_for_expected_name()` at
+  `util.py:213-243`. The redesign reuses bounded waits around individual
+  service calls and does not block the whole refresh loop waiting for unrelated
+  slots. Before any destructive clear or assign, the apply path also performs
+  an immediate physical re-read of the target slot. A clear proceeds only when
+  the current physical name still matches the expected reservation or reset
+  reason; a set proceeds only when the current physical name and PIN are still
+  confirmed empty.
+- The current persisted fence path can wedge correctness: `_apply_clear()` marks
+  `_pending_clear_slots` before the reset (`event_overrides.py:954-972`), and
+  `_observe_managed_slots()` then imports those fences into future slot status
+  (`coordinator.py:1753-1755`, `coordinator.py:1887-1904`). In the stateless
+  model, a slot pending physical clear is simply observed as still occupied if
+  the name/PIN remain present, or as free when both are physically empty.
+
+**Alternatives considered**:
+
+- **Persist pending-clear fences across cycles**: Rejected because FR-002 says
+  stale pending-clear data must not affect assignment safety once the slot is
+  physically empty.
+- **Assume reset service success means free**: Rejected because Keymaster can
+  report lingering name or PIN after reset (`util.py:340-376`), and FR-010
+  requires physical confirmation.
+- **Treat `unavailable` as empty**: Rejected because `unavailable` is explicitly
+  unreadable (`util.py:82-84`) and FR-012 requires conservative handling.
+
+---
+
+## R-004: Cache-Only Store and Migration
+
+**Decision**: Keep the HA Store key and schema only as cache/diagnostics. The
+Store may retain UID aliases, booking aliases, stable-name alias history,
+redacted last plan diagnostics, and migration breadcrumbs. It must not contain
+or drive occupied/pending/blocked status used by selection, matching, reset,
+assignment, or duplicate prevention. Missing, stale, corrupt, delayed, or
+deleted Store data must produce the same physical actions as an empty cache.
+
+**Rationale**:
+
+- The current Store is loaded during setup (`__init__.py:84-99`) and by
+  `async_load_slot_store()` (`coordinator.py:559-585`), then injected into
+  `EventOverrides.load_persisted_mappings()` (`event_overrides.py:409-445`).
+  That makes persisted mappings and pending clears influence runtime behavior.
+- Current Store saves authoritative statuses and pending operation fields at
+  `coordinator.py:591-621` and `_sync_slot_store_from_plan()`
+  (`coordinator.py:1596-1733`). These fields directly recreate the wedging
+  risks called out in issue #607.
+- Physical state already contains enough durable identity for correctness: the
+  Keymaster slot name is read every cycle (`coordinator.py:1772-1833`) and the
+  desired stable name comes from the current calendar (`util.py:784-847`).
+- Raw PINs are already excluded from persisted snapshots (`coordinator.py:579-584`,
+  `coordinator.py:600-610`, `reconciliation.py:462-491`), and that boundary is
+  kept.
+
+**Migration**:
+
+- Existing 3.5.x Store files are not wiped. On upgrade, load may parse them for
+  non-authoritative alias/diagnostic cache entries, but `status`, `slot`,
+  `pending_clear`, `operation_id`, `missing_count`, and `blocked_slots` are
+  ignored for correctness.
+- No working Keymaster slot is cleared merely because Store is missing, stale,
+  corrupt, or contradictory. Existing coded slots are recognized by the
+  physical name matcher on the first readable refresh.
+- If the Store is deleted mid-run, the next refresh still computes from
+  physical slots plus calendar. The only lost information is optional alias or
+  diagnostic history.
+- Cache writes should occur after a refresh for diagnostics/aliases only and
+  must be safe to skip if Store saving fails.
+
+**Alternatives considered**:
+
+- **Persist authoritative slot mappings with better recovery**: Rejected by
+  FR-002 and issue #607; recovery bugs are caused by making Store load-bearing.
+- **Delete Store entirely**: Rejected because non-sensitive alias and diagnostic
+  history can still help support and migration, provided tests prove deleting it
+  does not change behavior.
+- **Wipe Store and all slots on upgrade**: Rejected because issue #607 requires
+  no wipe of working slots on upgrade, and FR-001 makes physical slots the truth.
+
+---
+
+## R-005: Soonest-N, Active Protection, Buffers, and Overrides
+
+**Decision**: Desired reservations are derived from the same parsed calendar
+semantics as today, then selected as the soonest eligible whole-unit,
+non-overlapping reservations up to managed-slot capacity, with active checked-in
+guests selected first and counted against capacity. The stateless planner
+preserves lock-code buffers, Honor Event Times, manual time-of-day overrides,
+manual door-code overrides, name trimming, deterministic code generation,
+`should_update_code`, and check-in tracking.
+
+**Rationale**:
+
+- The coordinator already stores the relevant options: check-in/out time,
+  managed range, max events, code generator, `should_update_code`, Honor Event
+  Times, trimming, max name length, and before/after buffers at
+  `coordinator.py:170-210`.
+- Calendar parsing already preserves Honor Event Times and manual override
+  fallback: explicit event times win when enabled (`coordinator.py:2418-2427`),
+  description times and existing override times are fallback sources
+  (`coordinator.py:2427-2457`), and disabled Honor Event Times falls back to
+  stored/manual override or configured defaults (`coordinator.py:2458-2479`).
+- Buffers are applied by the shared `apply_buffer()` helper
+  (`util.py:442-463`) and are already used by reservation construction
+  (`coordinator.py:1250-1260`) and physical set/update helpers
+  (`util.py:530-537`, `util.py:648-655`).
+- Active-guest state is exposed by the check-in tracking sensor attributes
+  (`sensors/checkinsensor.py:276-300`) and is currently applied to reservation
+  objects at `coordinator.py:1960-1999`. The stateless planner keeps that input
+  but does not use Store missing counts for protection.
+- The current pure planner already demonstrates the desired selection shape:
+  protected reservations are selected first and remaining capacity is filled by
+  non-protected reservations sorted by `(start, identity_key)` at
+  `reconciliation.py:1399-1450`. The 013 implementation must replace the
+  identity-key tie breaker with duplicate-name start-order pairing where names
+  collide, but keep the soonest-N invariant.
+- Manual door-code overrides are preserved by treating observed Keymaster PINs
+  as in-memory physical facts for matched-name slots. The raw PIN is never
+  persisted or logged. If the observed PIN matches the deterministic/generated
+  code for the old observed reservation dates, a date shift with
+  `should_update_code` regenerates the expected date-based code; otherwise the
+  observed PIN is treated as a manual override and carried into the desired
+  reservation. This preserves FR-015 while still satisfying date-shift code
+  replacement for generated codes.
+- Manual time-of-day overrides are preserved without Store authority by reading
+  the matched physical slot date range and reversing configured buffers back to
+  the reservation access window when Honor Event Times is not taking explicit
+  PMS event times. This replaces the existing dependency on
+  `event_overrides.get_slot_with_name()` in the parser fallback path
+  (`coordinator.py:2414-2468`) with physical-state-derived override input.
+- `handle_state_change()` continues to update in-memory slot feedback from
+  Keymaster state changes (`util.py:850-1053`), including preserving untrimmed
+  names when a trimmed Keymaster value matches the expected display form
+  (`util.py:1021-1046`). It must remain non-authoritative and must not launch
+  reconciliation (`util.py:1054-1055`). Because
+  `update_event_overrides()` currently requests a refresh by default
+  (`coordinator.py:2334-2358`), the implementation must replace this callback
+  update with a non-refreshing observation-cache update or call it with
+  `request_refresh=False`.
+
+**Alternatives considered**:
+
+- **Strict soonest-N without active protection**: Rejected because FR-016
+  requires active guests not be evicted mid-stay.
+- **Ignore observed PINs and always regenerate**: Rejected because FR-015
+  requires manual code overrides to be preserved.
+- **Keep Store miss-count ghost reservations**: Rejected because ghost
+  reservations are Store-authoritative (`coordinator.py:1422-1595`) and conflict
+  with FR-001/FR-002. Calendar fetch miss tolerance (`coordinator.py:2078-2103`)
+  can remain because it governs the calendar input itself, not slot mappings.
+
+---
+
+## R-006: `event_N` Sensors
+
+**Decision**: `event_N` sensors remain read-only reflections of the latest
+calendar event and reconciled plan. They expose the same event summary, start,
+end, parsed attributes, `slot_name`, `slot_number`, and `slot_code` attributes,
+but do not reserve slots or call Keymaster services.
+
+**Rationale**:
+
+- The live `RentalControlCalSensor` already reads slot assignment and code from
+  coordinator reconciliation state at `sensors/calsensor.py:416-437`, but it
+  currently looks up date-bearing fingerprints (`sensors/calsensor.py:424-431`).
+  The stateless plan must expose a compatibility lookup from the current event
+  fingerprint/UID to the refresh-local `DesiredReservation.desired_id` so sensor
+  attributes survive date shifts and the internal identity change remains
+  invisible to users.
+- The historical side-effect method `_async_handle_slot_assignment()` is now a
+  no-op shim that documents the retired per-event mutation path
+  (`sensors/calsensor.py:505-537`). The stateless redesign keeps that
+  direction and removes any remaining dependency on `async_reserve_or_get_slot()`.
+- Preserving `event_N` as read-only satisfies FR-017 while letting the
+  coordinator enforce global invariants across all slots.
+
+**Alternatives considered**:
+
+- **Reintroduce per-sensor assignment for empty slots**: Rejected because it
+  splits global soonest-N and duplicate prevention across multiple entities.
+- **Remove slot attributes from sensors**: Rejected because existing users rely
+  on the display behavior, and FR-017 requires preservation.
+
+---
+
+## R-007: Concurrency and Refresh Behavior
+
+**Decision**: Keep one async lock around reconciliation apply operations and
+Keymaster callback feedback. The coordinator computes and applies one atomic
+plan per refresh; Keymaster state-change callbacks update in-memory observation
+feedback and suppress coordinator-originated echoes, but never trigger a nested
+reconciliation. Entity-readiness timing is no longer correctness-critical:
+`unavailable` slots are blocked for one cycle and re-evaluated on the next
+refresh.
+
+**Rationale**:
+
+- `EventOverrides` already has the lock used to serialize mutable slot state
+  (`event_overrides.py:160`), and `async_apply_plan()` marks reconciliation
+  active while applying actions (`event_overrides.py:866-952`). The design keeps
+  the single-lock pattern while deleting persisted authoritative fields.
+- Set/overwrite paths already suppress coordinator-originated callback echoes
+  (`event_overrides.py:1049-1063`, `event_overrides.py:1229-1243`), and
+  callbacks check `should_suppress_state_change()` before updating local state
+  (`util.py:896-904`). Keep that feedback loop to avoid re-entrancy storms.
+- `handle_state_change()` explicitly does not launch reconciliation after
+  callback updates (`util.py:1047-1055`). Stateless correctness depends on the
+  next scheduled/manual refresh rather than immediate callback-driven planning.
+- The current startup-readability watcher exists because early unreadable
+  Keymaster entities used to interact with Store/adoption timing. It watches
+  name, PIN, and enabled entities (`__init__.py:233-278`), arms a delayed
+  refresh when they become readable (`__init__.py:281-424`), and registers the
+  normal Keymaster listener at `__init__.py:427-454`. In the stateless design it
+  may be simplified or removed because unreadable slots are retried naturally;
+  keeping a one-shot refresh is acceptable as an optimization, not correctness.
+
+**Alternatives considered**:
+
+- **Per-slot independent apply tasks**: Rejected because action ordering matters
+  for confirmed reset before assignment and for duplicate collapse diagnostics.
+- **Nested reconcile from callbacks**: Rejected because Keymaster service calls
+  generate state-change storms and current code already suppresses callbacks.
+- **Startup blocking until all slots readable**: Rejected because unavailable
+  slots are conservative and stateless re-evaluation makes readiness timing
+  non-load-bearing.
+
+---
+
+## R-008: Obsolete Machinery to Retire
+
+**Decision**: Remove persisted-authoritative machinery that no longer
+contributes to correctness, while retaining service helpers, callback feedback,
+retry diagnostics, and the single lock.
+
+**Retire / delete**:
+
+- `_next_slot`, `next_slot`, `__assign_next_slot()`, and greedy slot selection
+  (`event_overrides.py:162`, `event_overrides.py:192-204`,
+  `event_overrides.py:481-532`). Stateless assignment is global and per-refresh.
+- `_slot_uids` as authoritative matching state (`event_overrides.py:166-167`)
+  and the UID phases in `_find_overlapping_slot()` (`event_overrides.py:551-716`).
+  UID aliases may remain cache-only in Store.
+- `_slot_miss_counts` and Store ghost reservations
+  (`event_overrides.py:166`, `coordinator.py:1422-1595`). Calendar fetch miss
+  tolerance may remain, but slot-mapping miss tolerance is no longer
+  correctness input.
+- `_pending_clear_slots`, `_pending_fences`, persisted operation IDs, and
+  persisted blocked slots as assignment fences (`event_overrides.py:173-177`,
+  `event_overrides.py:436-445`, `coordinator.py:1870-1904`). Physical empty
+  state is the only reusable proof.
+- `load_persisted_mappings()` validation and pending-clear import as runtime
+  authority (`event_overrides.py:409-445`). A replacement cache loader must not
+  raise because two stale cache records claim the same slot.
+- `async_reserve_or_get_slot()` and `async_check_overrides()` production paths
+  (`event_overrides.py:718-785`, `event_overrides.py:1509-1659`). The planner
+  emits resets/assignments for stale, duplicate, and overflow cases.
+- `async_adopt_keymaster_slots()` and `_adopt_observed_coded_slots()` as first
+  upgrade/deleted Store correctness machinery (`coordinator.py:647-863`).
+  Physical slots are recognized directly by name on every refresh.
+- Store re-keying/rematch helpers that make Store authoritative
+  (`coordinator.py:996-1117`, `reconciliation.py:1056-1296`).
+
+**Keep / preserve**:
+
+- `async_fire_clear_code()`, `async_fire_set_code()`, and
+  `async_fire_update_times()` with bounded confirmation and retry diagnostics
+  (`util.py:275-396`, `util.py:466-687`).
+- `is_cleared_keymaster_text_state()` and
+  `is_unreadable_keymaster_text_state()` for physical empty/readability
+  classification (`util.py:76-84`).
+- Slot-name extraction/trimming helpers (`util.py:399-439`, `util.py:784-847`).
+- A latest-plan slot lookup for check-in unlock validation, replacing direct
+  reads from `event_overrides.get_slot_name()` used today at
+  `sensors/checkinsensor.py:1621-1641`. The replacement must compare the
+  incoming Keymaster slot to the tracked reservation's latest planned/observed
+  stable name without depending on deleted override maps.
+- The coordinator refresh lock/apply pattern and callback suppression, with
+  re-entrancy prohibited (`event_overrides.py:866-952`, `util.py:896-904`,
+  `util.py:1047-1055`).
+- `event_N` read-only sensor reflection (`sensors/calsensor.py:416-437`) and
+  check-in tracking state (`sensors/checkinsensor.py:276-300`).
+
+**Rationale**: Removing the obsolete machinery does not break preserved
+features because those features are either derived from physical Keymaster
+state each refresh, from the current calendar/config, or from explicit sensor
+state. The implementation is large and safety-sensitive; tasks must migrate
+unit and integration tests before deleting shims.
+
+**Alternatives considered**:
+
+- **Keep obsolete fields as compatibility shims indefinitely**: Rejected because
+  hidden references could accidentally make Store authoritative again.
+- **Delete `EventOverrides` wholesale**: Rejected for this stage because its
+  lock, retry/error tracking, service-helper adapters, and callback suppression
+  remain useful; implementation may rename/split it after tests pin behavior.


### PR DESCRIPTION
## Summary

- Adds PLAN-stage artifacts for the stateless slot-reconciliation redesign (#607 stage 2)
- Defines stateless physical-state plus calendar reconciliation, stable slot-name identity matching, confirmed-reset-before-reapply, and cache-only Store migration
- Documents validation scenarios for duplicate avoidance, Store deletion, manual overrides, active protection, and callback safety

## Validation

- uv run pre-commit run --files specs/013-stateless-reconciliation/plan.md specs/013-stateless-reconciliation/research.md specs/013-stateless-reconciliation/data-model.md specs/013-stateless-reconciliation/quickstart.md