### PR TITLE
Feat(reconcile): Stateless slot reconciliation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ pythonenv*
 .coverage
 venv
 .venv
+dist/
+*.egg-info/
 htmlcov/
 .pytest_cache/
 *.pyc
@@ -16,3 +18,8 @@ htmlcov/
 .aislop/install_id
 .tox/
 *.log
+.DS_Store
+Thumbs.db
+*.tmp
+*.swp
+.idea/

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -84,19 +84,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # Load Store before Keymaster bootstrap (ordering fix for #597)
     await coordinator.async_load_slot_store()
 
-    # Inject persisted mappings or adopt slots on first upgrade
+    # Inject cache-only mappings. Physical Keymaster state is re-read during
+    # every coordinator refresh, so missing cache never triggers adoption.
     persisted = coordinator.get_persisted_slot_mappings()
-    if persisted:
-        if coordinator.event_overrides is not None:
-            try:
-                coordinator.event_overrides.load_persisted_mappings(persisted)
-            except ValueError:
-                _LOGGER.exception(
-                    "Failed to load persisted slot mappings for %s",
-                    config_entry.entry_id,
-                )
-    elif coordinator.lockname:
-        await coordinator.async_adopt_keymaster_slots()
+    if persisted and coordinator.event_overrides is not None:
+        coordinator.event_overrides.load_persisted_mappings(persisted)
 
     # Bootstrap Keymaster slot overrides from current HA state before
     # first refresh so overrides are checked against the initial data

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -100,6 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         COORDINATOR: coordinator,
         UNSUB_LISTENERS: [],
     }
+    coordinator._checkin_restore_pending = True
 
     # Perform first data refresh before platform setup to guarantee
     # coordinator.data is populated when entities are created
@@ -120,6 +121,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     await async_start_listener(hass, config_entry)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+    coordinator._checkin_restore_pending = False
 
     # Register keymaster event bus listener after platform setup
     # so the checkin sensor reference is available (T024/T026)

--- a/custom_components/rental_control/__init__.py
+++ b/custom_components/rental_control/__init__.py
@@ -96,17 +96,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     startup_slots_unreadable, _ = _needs_startup_readability_refresh(hass, coordinator)
 
+    hass.data[DOMAIN][config_entry.entry_id] = {
+        COORDINATOR: coordinator,
+        UNSUB_LISTENERS: [],
+    }
+
     # Perform first data refresh before platform setup to guarantee
     # coordinator.data is populated when entities are created
     try:
         await coordinator.async_config_entry_first_refresh()
     except ConfigEntryNotReady:
+        hass.data[DOMAIN].pop(config_entry.entry_id, None)
         raise
-
-    hass.data[DOMAIN][config_entry.entry_id] = {
-        COORDINATOR: coordinator,
-        UNSUB_LISTENERS: [],
-    }
 
     async_arm_startup_readability_refresh(
         hass,

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -19,6 +19,7 @@ import asyncio
 from collections import deque
 from collections.abc import Coroutine
 from collections.abc import Mapping
+from datetime import date
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
@@ -1442,8 +1443,8 @@ Please update Keymaster to at least v0.1.0-b0
             if slot_name:
                 key = normalize_slot_name_for_fingerprint(slot_name)
                 slot_name_counts[key] = slot_name_counts.get(key, 0) + 1
-                event_start: datetime = event.start  # type: ignore[assignment]
-                event_end: datetime = event.end  # type: ignore[assignment]
+                event_start = self._coerce_event_datetime(event.start)
+                event_end = self._coerce_event_datetime(event.end)
                 buffered_start_raw, buffered_end_raw = apply_buffer(
                     event_start,
                     event_end,
@@ -1480,8 +1481,8 @@ Please update Keymaster to at least v0.1.0-b0
             if not slot_name:
                 continue
 
-            start: datetime = event.start  # type: ignore[assignment]
-            end: datetime = event.end  # type: ignore[assignment]
+            start = self._coerce_event_datetime(event.start)
+            end = self._coerce_event_datetime(event.end)
 
             buffered_start_raw, buffered_end_raw = apply_buffer(
                 start, end, self.code_buffer_before, self.code_buffer_after, self
@@ -1514,25 +1515,29 @@ Please update Keymaster to at least v0.1.0-b0
             code_source = "generated"
             active_windows = self._active_checkin_windows_for_name(slot_name)
             matched_physical = self._find_observed_slot_by_name(
-                observed_slots,
-                slot_name,
-                display_slot_name,
-                consumed_observed_slots,
-                buffered_start,
-                buffered_end,
-                slot_name_counts.get(normalize_slot_name_for_fingerprint(slot_name), 0)
+                managed_slots=observed_slots,
+                slot_name=slot_name,
+                display_slot_name=display_slot_name,
+                consumed_slots=consumed_observed_slots,
+                desired_start=buffered_start,
+                desired_end=buffered_end,
+                require_date_match=slot_name_counts.get(
+                    normalize_slot_name_for_fingerprint(slot_name), 0
+                )
                 > 1,
-                slot_name_date_windows.get(
+                reserved_date_windows=slot_name_date_windows.get(
                     normalize_slot_name_for_fingerprint(slot_name)
                 ),
-                slot_name_ordered_windows.get(
+                ordered_date_windows=slot_name_ordered_windows.get(
                     normalize_slot_name_for_fingerprint(slot_name)
                 ),
-                bool(
+                block_unknown_date_fallback=bool(
                     active_windows
                     and (buffered_start, buffered_end) not in active_windows
                 ),
-                slot_name_counts.get(normalize_slot_name_for_fingerprint(slot_name), 1),
+                expected_name_count=slot_name_counts.get(
+                    normalize_slot_name_for_fingerprint(slot_name), 1
+                ),
             )
             if matched_physical is not None and matched_physical.actual_code:
                 observed_code = matched_physical.actual_code
@@ -2167,6 +2172,12 @@ Please update Keymaster to at least v0.1.0-b0
             parsed = dt.parse_datetime(value)
             return parsed if isinstance(parsed, datetime) else None
         return None
+
+    def _coerce_event_datetime(self, value: date | datetime) -> datetime:
+        """Return a timezone-aware datetime for calendar date/datetime values."""
+        if isinstance(value, datetime):
+            return value
+        return datetime.combine(value, time.min, self.timezone)
 
     def _must_defer_for_checkin_restore(
         self, reservations: list[_Reservation], managed_slots: list[_ManagedSlot]

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -2693,6 +2693,13 @@ Please update Keymaster to at least v0.1.0-b0
                 f"Buffer time update slot {slot} ({self.lockname})",
                 _LOGGER,
             )
+            if not any(isinstance(result, Exception) for result in results):
+                override["start_time"] = (
+                    buffered_start if isinstance(buffered_start, datetime) else start
+                )
+                override["end_time"] = (
+                    buffered_end if isinstance(buffered_end, datetime) else end
+                )
 
     async def update_event_overrides(
         self,

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -568,41 +568,41 @@ Please update Keymaster to at least v0.1.0-b0
                 self._entry_id,
                 err,
             )
-            self._slot_mappings = {
-                "schema_version": STORE_SCHEMA_VERSION,
-                "entry_id": self._entry_id,
-                "lockname": self.lockname,
-                "mappings": {},
-                "aliases": {},
-                "migration_notes": ["cache_load_failed"],
-            }
+            self._slot_mappings = self._empty_slot_cache("cache_load_failed")
             return
         if raw is None:
-            self._slot_mappings = {
-                "schema_version": STORE_SCHEMA_VERSION,
-                "entry_id": self._entry_id,
-                "lockname": self.lockname,
-                "mappings": {},
-                "aliases": {},
-                "migration_notes": ["cache_missing"],
-            }
+            self._slot_mappings = self._empty_slot_cache("cache_missing")
             return
         if not isinstance(raw, dict):
-            self._slot_mappings = {
-                "schema_version": STORE_SCHEMA_VERSION,
-                "entry_id": self._entry_id,
-                "lockname": self.lockname,
-                "mappings": {},
-                "aliases": {},
-                "migration_notes": ["cache_corrupt"],
-            }
+            self._slot_mappings = self._empty_slot_cache("cache_corrupt")
             return
         schema_version = raw.get("schema_version", 0)
+        if not isinstance(schema_version, int):
+            self._slot_mappings = self._empty_slot_cache("cache_corrupt")
+            return
         if schema_version < 1:
             raw = await self._migrate_slot_store_v1(raw)
-        for mapping in raw.get("mappings", {}).values():
+        mappings = raw.get("mappings", {})
+        if not isinstance(mappings, dict):
+            self._slot_mappings = self._empty_slot_cache("cache_corrupt")
+            return
+        aliases = raw.get("aliases", {})
+        if aliases is not None and not isinstance(aliases, dict):
+            self._slot_mappings = self._empty_slot_cache("cache_corrupt")
+            return
+        migration_notes = raw.get("migration_notes", [])
+        if migration_notes is not None and not isinstance(migration_notes, list):
+            self._slot_mappings = self._empty_slot_cache("cache_corrupt")
+            return
+        for mapping in mappings.values():
+            if not isinstance(mapping, dict):
+                self._slot_mappings = self._empty_slot_cache("cache_corrupt")
+                return
             last_obs = mapping.get("last_observed_actual")
             if last_obs is not None:
+                if not isinstance(last_obs, dict):
+                    self._slot_mappings = self._empty_slot_cache("cache_corrupt")
+                    return
                 last_obs.pop("pin", None)
                 last_obs.pop("code", None)
                 last_obs.pop("slot_code", None)
@@ -610,6 +610,17 @@ Please update Keymaster to at least v0.1.0-b0
         raw.setdefault("aliases", {})
         raw.setdefault("migration_notes", [])
         self._slot_mappings = raw
+
+    def _empty_slot_cache(self, note: str) -> dict[str, Any]:
+        """Return an empty cache-only Store payload with a migration note."""
+        return {
+            "schema_version": STORE_SCHEMA_VERSION,
+            "entry_id": self._entry_id,
+            "lockname": self.lockname,
+            "mappings": {},
+            "aliases": {},
+            "migration_notes": [note],
+        }
 
     def get_persisted_slot_mappings(self) -> dict[str, Any]:
         """Return entry-scoped persisted reservation-slot mappings."""
@@ -1086,6 +1097,7 @@ Please update Keymaster to at least v0.1.0-b0
         desired_start: datetime | None = None,
         desired_end: datetime | None = None,
         require_date_match: bool = False,
+        reserved_date_windows: set[tuple[datetime, datetime]] | None = None,
     ) -> _ManagedSlot | None:
         """Return the current physical slot matching a stable/display name."""
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
@@ -1122,11 +1134,18 @@ Please update Keymaster to at least v0.1.0-b0
                 ):
                     consumed.add(slot.slot)
                     return slot
-        if require_date_match:
-            return None
-        if candidates:
-            consumed.add(candidates[0].slot)
-            return candidates[0]
+        fallback_candidates = candidates
+        if require_date_match and reserved_date_windows:
+            fallback_candidates = [
+                slot
+                for slot in candidates
+                if slot.actual_start is None
+                or slot.actual_end is None
+                or (slot.actual_start, slot.actual_end) not in reserved_date_windows
+            ]
+        if fallback_candidates:
+            consumed.add(fallback_candidates[0].slot)
+            return fallback_candidates[0]
         return None
 
     @staticmethod
@@ -1237,6 +1256,7 @@ Please update Keymaster to at least v0.1.0-b0
         observed_slots = managed_slots or []
         consumed_observed_slots: set[int] = set()
         slot_name_counts: dict[str, int] = {}
+        slot_name_date_windows: dict[str, set[tuple[datetime, datetime]]] = {}
         for event in calendar:
             slot_name = get_slot_name(
                 event.summary,
@@ -1246,6 +1266,28 @@ Please update Keymaster to at least v0.1.0-b0
             if slot_name:
                 key = normalize_slot_name_for_fingerprint(slot_name)
                 slot_name_counts[key] = slot_name_counts.get(key, 0) + 1
+                event_start: datetime = event.start  # type: ignore[assignment]
+                event_end: datetime = event.end  # type: ignore[assignment]
+                buffered_start_raw, buffered_end_raw = apply_buffer(
+                    event_start,
+                    event_end,
+                    self.code_buffer_before,
+                    self.code_buffer_after,
+                    self,
+                )
+                buffered_start_dt = (
+                    buffered_start_raw
+                    if isinstance(buffered_start_raw, datetime)
+                    else event_start
+                )
+                buffered_end_dt = (
+                    buffered_end_raw
+                    if isinstance(buffered_end_raw, datetime)
+                    else event_end
+                )
+                slot_name_date_windows.setdefault(key, set()).add(
+                    (buffered_start_dt, buffered_end_dt)
+                )
 
         for event in calendar:
             slot_name = get_slot_name(
@@ -1297,6 +1339,9 @@ Please update Keymaster to at least v0.1.0-b0
                 buffered_end,
                 slot_name_counts.get(normalize_slot_name_for_fingerprint(slot_name), 0)
                 > 1,
+                slot_name_date_windows.get(
+                    normalize_slot_name_for_fingerprint(slot_name)
+                ),
             )
             if matched_physical is not None and matched_physical.actual_code:
                 observed_code = matched_physical.actual_code
@@ -1776,7 +1821,11 @@ Please update Keymaster to at least v0.1.0-b0
 
         return slots
 
-    def _apply_checkin_protection(self, reservations: list[_Reservation]) -> None:
+    def _apply_checkin_protection(
+        self,
+        reservations: list[_Reservation],
+        managed_slots: list[_ManagedSlot] | None = None,
+    ) -> None:
         """Mark active checked-in reservation as protected, if present.
 
         Reads :class:`~.sensors.checkinsensor.CheckinTrackingSensor` state
@@ -1808,14 +1857,97 @@ Please update Keymaster to at least v0.1.0-b0
         guest_name: str | None = attrs.get("guest_name")
         if not guest_name:
             return
+        tracked_start = self._coerce_checkin_datetime(attrs.get("start"))
+        tracked_end = self._coerce_checkin_datetime(attrs.get("end"))
 
-        for res in reservations:
-            if res.slot_name == guest_name:
-                if sensor_state == CHECKIN_STATE_CHECKED_IN:
-                    res.protected_active = True
-                elif sensor_state == CHECKIN_STATE_CHECKED_OUT:
-                    res.checked_out = True
-                break
+        name_matches = [res for res in reservations if res.slot_name == guest_name]
+        exact_matches = [
+            res
+            for res in name_matches
+            if tracked_start is not None
+            and tracked_end is not None
+            and res.start == tracked_start
+            and res.end == tracked_end
+        ]
+        matches = exact_matches or (name_matches if len(name_matches) == 1 else [])
+        for res in matches[:1]:
+            if sensor_state == CHECKIN_STATE_CHECKED_IN:
+                res.protected_active = True
+            elif sensor_state == CHECKIN_STATE_CHECKED_OUT:
+                res.checked_out = True
+            return
+
+        if (
+            sensor_state == CHECKIN_STATE_CHECKED_IN
+            and tracked_start is not None
+            and tracked_end is not None
+            and managed_slots
+        ):
+            prefix = f"{self.event_prefix} " if self.event_prefix else ""
+            display_slot_name = _format_display_slot_name(
+                guest_name, prefix, self.trim_names, self.max_name_length
+            )
+            buffered_start_raw, buffered_end_raw = apply_buffer(
+                tracked_start,
+                tracked_end,
+                self.code_buffer_before,
+                self.code_buffer_after,
+                self,
+            )
+            buffered_start = (
+                buffered_start_raw
+                if isinstance(buffered_start_raw, datetime)
+                else tracked_start
+            )
+            buffered_end = (
+                buffered_end_raw
+                if isinstance(buffered_end_raw, datetime)
+                else tracked_end
+            )
+            matched_physical = self._find_observed_slot_by_name(
+                managed_slots,
+                guest_name,
+                display_slot_name,
+                desired_start=buffered_start,
+                desired_end=buffered_end,
+            )
+            if matched_physical is None:
+                return
+            identity_key = make_reservation_fingerprint(
+                self._entry_id, guest_name, tracked_start, tracked_end
+            )
+            slot_code = matched_physical.actual_code or self._generate_slot_code(
+                tracked_start, tracked_end, None, None
+            )
+            protected = _Reservation(
+                identity_key=identity_key,
+                start=tracked_start,
+                end=tracked_end,
+                buffered_start=buffered_start,
+                buffered_end=buffered_end,
+                summary=str(attrs.get("summary") or guest_name),
+                slot_name=guest_name,
+                display_slot_name=display_slot_name,
+                slot_code=slot_code,
+                protected_active=True,
+                code_source=(
+                    "manual_observed"
+                    if matched_physical.actual_code is not None
+                    else "generated"
+                ),
+            )
+            protected.sensor_lookup_keys.add(identity_key)
+            reservations.append(protected)
+
+    @staticmethod
+    def _coerce_checkin_datetime(value: Any) -> datetime | None:
+        """Return a datetime from check-in sensor attributes."""
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            parsed = dt.parse_datetime(value)
+            return parsed if isinstance(parsed, datetime) else None
+        return None
 
     async def _async_fetch_calendar(self) -> list[CalendarEvent]:
         """Fetch iCalendar data from URL and parse into events."""
@@ -1937,7 +2069,7 @@ Please update Keymaster to at least v0.1.0-b0
             try:
                 observed_slots = self._observe_managed_slots()
                 reservations = self._build_reservations(new_calendar, observed_slots)
-                self._apply_checkin_protection(reservations)
+                self._apply_checkin_protection(reservations, observed_slots)
 
                 plan_id = str(uuid.uuid4())
                 plan = compute_desired_plan(

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1105,6 +1105,7 @@ Please update Keymaster to at least v0.1.0-b0
         desired_end: datetime | None = None,
         require_date_match: bool = False,
         reserved_date_windows: set[tuple[datetime, datetime]] | None = None,
+        block_unknown_date_fallback: bool = False,
     ) -> _ManagedSlot | None:
         """Return the current physical slot matching a stable/display name."""
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
@@ -1146,9 +1147,15 @@ Please update Keymaster to at least v0.1.0-b0
             fallback_candidates = [
                 slot
                 for slot in candidates
-                if slot.actual_start is None
-                or slot.actual_end is None
-                or (slot.actual_start, slot.actual_end) not in reserved_date_windows
+                if (
+                    not block_unknown_date_fallback
+                    or (slot.actual_start is not None and slot.actual_end is not None)
+                )
+                and (
+                    slot.actual_start is None
+                    or slot.actual_end is None
+                    or (slot.actual_start, slot.actual_end) not in reserved_date_windows
+                )
             ]
         if fallback_candidates:
             consumed.add(fallback_candidates[0].slot)
@@ -1340,6 +1347,7 @@ Please update Keymaster to at least v0.1.0-b0
 
             slot_code = self._generate_slot_code(start, end, event.description, uid)
             code_source = "generated"
+            active_windows = self._active_checkin_windows_for_name(slot_name)
             matched_physical = self._find_observed_slot_by_name(
                 observed_slots,
                 slot_name,
@@ -1351,6 +1359,10 @@ Please update Keymaster to at least v0.1.0-b0
                 > 1,
                 slot_name_date_windows.get(
                     normalize_slot_name_for_fingerprint(slot_name)
+                ),
+                bool(
+                    active_windows
+                    and (buffered_start, buffered_end) not in active_windows
                 ),
             )
             if matched_physical is not None and matched_physical.actual_code:
@@ -1927,10 +1939,13 @@ Please update Keymaster to at least v0.1.0-b0
                 desired_start=buffered_start,
                 desired_end=buffered_end,
             )
-            if (
-                matched_physical is None
-                or matched_physical.actual_start != buffered_start
-                or matched_physical.actual_end != buffered_end
+            if matched_physical is None or (
+                matched_physical.actual_start is not None
+                and matched_physical.actual_end is not None
+                and (
+                    matched_physical.actual_start != buffered_start
+                    or matched_physical.actual_end != buffered_end
+                )
             ):
                 return
             identity_key = make_reservation_fingerprint(

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1083,6 +1083,9 @@ Please update Keymaster to at least v0.1.0-b0
         slot_name: str,
         display_slot_name: str,
         consumed_slots: set[int] | None = None,
+        desired_start: datetime | None = None,
+        desired_end: datetime | None = None,
+        require_date_match: bool = False,
     ) -> _ManagedSlot | None:
         """Return the current physical slot matching a stable/display name."""
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
@@ -1091,6 +1094,7 @@ Please update Keymaster to at least v0.1.0-b0
             normalize_slot_name_for_fingerprint(display_slot_name),
         }
         consumed = consumed_slots if consumed_slots is not None else set()
+        candidates: list[_ManagedSlot] = []
         for slot in sorted(
             managed_slots,
             key=lambda observed: (
@@ -1109,8 +1113,20 @@ Please update Keymaster to at least v0.1.0-b0
                     normalize_slot_name_for_fingerprint(actual[len(prefix) :])
                 )
             if actual_forms & desired_forms:
-                consumed.add(slot.slot)
-                return slot
+                candidates.append(slot)
+        if desired_start is not None and desired_end is not None:
+            for slot in candidates:
+                if (
+                    slot.actual_start == desired_start
+                    and slot.actual_end == desired_end
+                ):
+                    consumed.add(slot.slot)
+                    return slot
+        if require_date_match:
+            return None
+        if candidates:
+            consumed.add(candidates[0].slot)
+            return candidates[0]
         return None
 
     @staticmethod
@@ -1220,6 +1236,16 @@ Please update Keymaster to at least v0.1.0-b0
         reservations: list[_Reservation] = []
         observed_slots = managed_slots or []
         consumed_observed_slots: set[int] = set()
+        slot_name_counts: dict[str, int] = {}
+        for event in calendar:
+            slot_name = get_slot_name(
+                event.summary,
+                event.description or "",
+                self.event_prefix or "",
+            )
+            if slot_name:
+                key = normalize_slot_name_for_fingerprint(slot_name)
+                slot_name_counts[key] = slot_name_counts.get(key, 0) + 1
 
         for event in calendar:
             slot_name = get_slot_name(
@@ -1267,6 +1293,10 @@ Please update Keymaster to at least v0.1.0-b0
                 slot_name,
                 display_slot_name,
                 consumed_observed_slots,
+                buffered_start,
+                buffered_end,
+                slot_name_counts.get(normalize_slot_name_for_fingerprint(slot_name), 0)
+                > 1,
             )
             if matched_physical is not None and matched_physical.actual_code:
                 observed_code = matched_physical.actual_code

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1964,13 +1964,25 @@ Please update Keymaster to at least v0.1.0-b0
                 desired_start=buffered_start,
                 desired_end=buffered_end,
             )
-            if matched_physical is None or (
+            same_name_slots = [
+                slot
+                for slot in managed_slots
+                if slot.managed
+                and slot.status is _SlotStatus.OCCUPIED
+                and self._physical_slot_name_matches_name(
+                    slot.actual_name, guest_name, display_slot_name
+                )
+            ]
+            if matched_physical is None:
+                return
+            if (
                 matched_physical.actual_start is not None
                 and matched_physical.actual_end is not None
                 and (
                     matched_physical.actual_start != buffered_start
                     or matched_physical.actual_end != buffered_end
                 )
+                and len(same_name_slots) != 1
             ):
                 return
             identity_key = make_reservation_fingerprint(
@@ -2014,26 +2026,36 @@ Please update Keymaster to at least v0.1.0-b0
     ) -> bool:
         """Return whether apply should wait for check-in sensor restore."""
         domain_data: dict[str, Any] | None = self.hass.data.get(DOMAIN)
-        entry_data: dict[str, Any] = (
-            domain_data.get(self._entry_id, {}) if domain_data is not None else {}
-        )
+        if domain_data is None or self._entry_id not in domain_data:
+            return False
+        entry_data: dict[str, Any] = domain_data.get(self._entry_id, {})
         if entry_data.get(CHECKIN_SENSOR) is not None:
             return False
         return any(
             slot.managed
             and slot.status is _SlotStatus.OCCUPIED
-            and (slot.actual_start is None or slot.actual_end is None)
-            and any(
-                self._physical_slot_name_matches_reservation(slot.actual_name, res)
-                for res in reservations
+            and (
+                not any(
+                    self._physical_slot_name_matches_reservation(slot.actual_name, res)
+                    for res in reservations
+                )
+                or (
+                    (slot.actual_start is None or slot.actual_end is None)
+                    and any(
+                        self._physical_slot_name_matches_reservation(
+                            slot.actual_name, res
+                        )
+                        for res in reservations
+                    )
+                )
             )
             for slot in managed_slots
         )
 
-    def _physical_slot_name_matches_reservation(
-        self, actual_name: str | None, reservation: _Reservation
+    def _physical_slot_name_matches_name(
+        self, actual_name: str | None, slot_name: str, display_slot_name: str
     ) -> bool:
-        """Return whether a physical display name matches a reservation name."""
+        """Return whether a physical display name matches a logical name."""
         if not actual_name:
             return False
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
@@ -2043,10 +2065,18 @@ Please update Keymaster to at least v0.1.0-b0
                 normalize_slot_name_for_fingerprint(actual_name[len(prefix) :])
             )
         desired_forms = {
-            normalize_slot_name_for_fingerprint(reservation.slot_name),
-            normalize_slot_name_for_fingerprint(reservation.display_slot_name),
+            normalize_slot_name_for_fingerprint(slot_name),
+            normalize_slot_name_for_fingerprint(display_slot_name),
         }
         return bool(actual_forms & desired_forms)
+
+    def _physical_slot_name_matches_reservation(
+        self, actual_name: str | None, reservation: _Reservation
+    ) -> bool:
+        """Return whether a physical display name matches a reservation name."""
+        return self._physical_slot_name_matches_name(
+            actual_name, reservation.slot_name, reservation.display_slot_name
+        )
 
     def _active_checkin_windows_for_name(
         self, slot_name: str

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1082,6 +1082,7 @@ Please update Keymaster to at least v0.1.0-b0
         managed_slots: list[_ManagedSlot],
         slot_name: str,
         display_slot_name: str,
+        consumed_slots: set[int] | None = None,
     ) -> _ManagedSlot | None:
         """Return the current physical slot matching a stable/display name."""
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
@@ -1089,7 +1090,16 @@ Please update Keymaster to at least v0.1.0-b0
             normalize_slot_name_for_fingerprint(slot_name),
             normalize_slot_name_for_fingerprint(display_slot_name),
         }
-        for slot in managed_slots:
+        consumed = consumed_slots if consumed_slots is not None else set()
+        for slot in sorted(
+            managed_slots,
+            key=lambda observed: (
+                observed.actual_start or datetime.max.replace(tzinfo=timezone.utc),
+                observed.slot,
+            ),
+        ):
+            if slot.slot in consumed:
+                continue
             if not slot.managed or not slot.actual_name:
                 continue
             actual = slot.actual_name
@@ -1099,12 +1109,7 @@ Please update Keymaster to at least v0.1.0-b0
                     normalize_slot_name_for_fingerprint(actual[len(prefix) :])
                 )
             if actual_forms & desired_forms:
-                return slot
-            if any(
-                desired.startswith(actual_form) or actual_form.startswith(desired)
-                for desired in desired_forms
-                for actual_form in actual_forms
-            ):
+                consumed.add(slot.slot)
                 return slot
         return None
 
@@ -1214,6 +1219,7 @@ Please update Keymaster to at least v0.1.0-b0
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
         reservations: list[_Reservation] = []
         observed_slots = managed_slots or []
+        consumed_observed_slots: set[int] = set()
 
         for event in calendar:
             slot_name = get_slot_name(
@@ -1257,7 +1263,10 @@ Please update Keymaster to at least v0.1.0-b0
             slot_code = self._generate_slot_code(start, end, event.description, uid)
             code_source = "generated"
             matched_physical = self._find_observed_slot_by_name(
-                observed_slots, slot_name, display_slot_name
+                observed_slots,
+                slot_name,
+                display_slot_name,
+                consumed_observed_slots,
             )
             if matched_physical is not None and matched_physical.actual_code:
                 observed_code = matched_physical.actual_code

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1143,7 +1143,9 @@ Please update Keymaster to at least v0.1.0-b0
                     consumed.add(slot.slot)
                     return slot
         fallback_candidates = candidates
-        if reserved_date_windows:
+        if reserved_date_windows and (
+            require_date_match or block_unknown_date_fallback
+        ):
             fallback_candidates = [
                 slot
                 for slot in candidates
@@ -1992,14 +1994,34 @@ Please update Keymaster to at least v0.1.0-b0
         )
         if entry_data.get(CHECKIN_SENSOR) is not None:
             return False
-        reservation_names = {res.slot_name for res in reservations}
         return any(
             slot.managed
             and slot.status is _SlotStatus.OCCUPIED
-            and slot.actual_name in reservation_names
             and (slot.actual_start is None or slot.actual_end is None)
+            and any(
+                self._physical_slot_name_matches_reservation(slot.actual_name, res)
+                for res in reservations
+            )
             for slot in managed_slots
         )
+
+    def _physical_slot_name_matches_reservation(
+        self, actual_name: str | None, reservation: _Reservation
+    ) -> bool:
+        """Return whether a physical display name matches a reservation name."""
+        if not actual_name:
+            return False
+        prefix = f"{self.event_prefix} " if self.event_prefix else ""
+        actual_forms = {normalize_slot_name_for_fingerprint(actual_name)}
+        if prefix and actual_name.startswith(prefix):
+            actual_forms.add(
+                normalize_slot_name_for_fingerprint(actual_name[len(prefix) :])
+            )
+        desired_forms = {
+            normalize_slot_name_for_fingerprint(reservation.slot_name),
+            normalize_slot_name_for_fingerprint(reservation.display_slot_name),
+        }
+        return bool(actual_forms & desired_forms)
 
     def _active_checkin_windows_for_name(
         self, slot_name: str

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -2670,13 +2670,32 @@ Please update Keymaster to at least v0.1.0-b0
                 self.code_buffer_after,
                 self,
             )
+            start_entity = (
+                f"{DATETIME}.{self.lockname}_code_slot_{slot}_date_range_start"
+            )
+            end_entity = f"{DATETIME}.{self.lockname}_code_slot_{slot}_date_range_end"
+            self.event_overrides.suppress_state_changes(
+                slot,
+                {
+                    start_entity: (
+                        buffered_start.isoformat()
+                        if isinstance(buffered_start, datetime)
+                        else buffered_start
+                    ),
+                    end_entity: (
+                        buffered_end.isoformat()
+                        if isinstance(buffered_end, datetime)
+                        else buffered_end
+                    ),
+                },
+            )
             coro: list[Coroutine] = []
             coro = add_call(
                 self.hass,
                 coro,
                 DATETIME,
                 "set_value",
-                f"{DATETIME}.{self.lockname}_code_slot_{slot}_date_range_end",
+                end_entity,
                 {"datetime": buffered_end},
             )
             coro = add_call(
@@ -2684,7 +2703,7 @@ Please update Keymaster to at least v0.1.0-b0
                 coro,
                 DATETIME,
                 "set_value",
-                f"{DATETIME}.{self.lockname}_code_slot_{slot}_date_range_start",
+                start_entity,
                 {"datetime": buffered_start},
             )
             results = await asyncio.gather(*coro, return_exceptions=True)

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1157,6 +1157,20 @@ Please update Keymaster to at least v0.1.0-b0
                         ):
                             consumed.add(slot.slot)
                             return slot
+                shifted_candidates = [
+                    slot
+                    for slot in candidates
+                    if slot.actual_start is not None
+                    and slot.actual_end is not None
+                    and (
+                        not reserved_date_windows
+                        or (slot.actual_start, slot.actual_end)
+                        not in reserved_date_windows
+                    )
+                ]
+                if len(shifted_candidates) == 1:
+                    consumed.add(shifted_candidates[0].slot)
+                    return shifted_candidates[0]
                 return None
             if any(
                 slot.actual_start is None or slot.actual_end is None

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1429,8 +1429,8 @@ Please update Keymaster to at least v0.1.0-b0
         ordered_calendar = sorted(
             calendar,
             key=lambda event: (
-                event.start.isoformat(),
-                event.end.isoformat(),
+                self._coerce_event_datetime(event.start),
+                self._coerce_event_datetime(event.end),
                 event.summary or "",
             ),
         )

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from datetime import time
 from datetime import timedelta
 from datetime import timezone
+from functools import lru_cache
 import logging
 import random
 import re
@@ -1110,6 +1111,7 @@ Please update Keymaster to at least v0.1.0-b0
         desired_end: datetime | None = None,
         require_date_match: bool = False,
         reserved_date_windows: set[tuple[datetime, datetime]] | None = None,
+        ordered_date_windows: list[tuple[datetime, datetime]] | None = None,
         block_unknown_date_fallback: bool = False,
         expected_name_count: int = 1,
     ) -> _ManagedSlot | None:
@@ -1120,6 +1122,7 @@ Please update Keymaster to at least v0.1.0-b0
             normalize_slot_name_for_fingerprint(display_slot_name),
         }
         consumed = consumed_slots if consumed_slots is not None else set()
+        all_candidates: list[_ManagedSlot] = []
         candidates: list[_ManagedSlot] = []
         matching_candidate_count = 0
         for slot in sorted(
@@ -1140,6 +1143,7 @@ Please update Keymaster to at least v0.1.0-b0
                 )
             if actual_forms & desired_forms:
                 matching_candidate_count += 1
+                all_candidates.append(slot)
                 if slot.slot in consumed:
                     continue
                 candidates.append(slot)
@@ -1156,8 +1160,24 @@ Please update Keymaster to at least v0.1.0-b0
                 return None
             if any(
                 slot.actual_start is None or slot.actual_end is None
-                for slot in candidates
+                for slot in all_candidates
             ):
+                return None
+            if ordered_date_windows and matching_candidate_count > expected_name_count:
+                canonical = self._select_ordered_physical_subset(
+                    all_candidates, ordered_date_windows
+                )
+                desired_window = (
+                    (desired_start, desired_end)
+                    if desired_start is not None and desired_end is not None
+                    else None
+                )
+                for slot, window in zip(canonical, ordered_date_windows, strict=False):
+                    if slot.slot not in consumed and (
+                        desired_window is None or window == desired_window
+                    ):
+                        consumed.add(slot.slot)
+                        return slot
                 return None
             if candidates:
                 consumed.add(candidates[0].slot)
@@ -1184,6 +1204,40 @@ Please update Keymaster to at least v0.1.0-b0
             consumed.add(fallback_candidates[0].slot)
             return fallback_candidates[0]
         return None
+
+    @staticmethod
+    def _select_ordered_physical_subset(
+        slots: list[_ManagedSlot], desired_windows: list[tuple[datetime, datetime]]
+    ) -> list[_ManagedSlot]:
+        """Return minimum-distance ordered physical subset for desired windows."""
+
+        def _distance(slot: _ManagedSlot, window: tuple[datetime, datetime]) -> float:
+            """Return absolute date distance for one physical/desired pair."""
+            assert slot.actual_start is not None
+            assert slot.actual_end is not None
+            return abs((slot.actual_start - window[0]).total_seconds()) + abs(
+                (slot.actual_end - window[1]).total_seconds()
+            )
+
+        @lru_cache
+        def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
+            """Return best ordered subset cost and indices from this position."""
+            if desired_index == len(desired_windows):
+                return 0.0, ()
+            if slot_index == len(slots):
+                return float("inf"), ()
+            skip_cost, skip_indices = _best(slot_index + 1, desired_index)
+            take_rest_cost, take_indices = _best(slot_index + 1, desired_index + 1)
+            take_cost = (
+                _distance(slots[slot_index], desired_windows[desired_index])
+                + take_rest_cost
+            )
+            if take_cost < skip_cost:
+                return take_cost, (slot_index, *take_indices)
+            return skip_cost, skip_indices
+
+        _, indices = _best(0, 0)
+        return [slots[index] for index in indices]
 
     @staticmethod
     def _remap_observed_mappings_to_physical_reservations(
@@ -1294,6 +1348,7 @@ Please update Keymaster to at least v0.1.0-b0
         consumed_observed_slots: set[int] = set()
         slot_name_counts: dict[str, int] = {}
         slot_name_date_windows: dict[str, set[tuple[datetime, datetime]]] = {}
+        slot_name_ordered_windows: dict[str, list[tuple[datetime, datetime]]] = {}
         ordered_calendar = sorted(
             calendar,
             key=lambda event: (
@@ -1331,6 +1386,9 @@ Please update Keymaster to at least v0.1.0-b0
                     else event_end
                 )
                 slot_name_date_windows.setdefault(key, set()).add(
+                    (buffered_start_dt, buffered_end_dt)
+                )
+                slot_name_ordered_windows.setdefault(key, []).append(
                     (buffered_start_dt, buffered_end_dt)
                 )
                 active_windows = self._active_checkin_windows_for_name(slot_name)
@@ -1389,6 +1447,9 @@ Please update Keymaster to at least v0.1.0-b0
                 slot_name_counts.get(normalize_slot_name_for_fingerprint(slot_name), 0)
                 > 1,
                 slot_name_date_windows.get(
+                    normalize_slot_name_for_fingerprint(slot_name)
+                ),
+                slot_name_ordered_windows.get(
                     normalize_slot_name_for_fingerprint(slot_name)
                 ),
                 bool(

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1402,11 +1402,9 @@ Please update Keymaster to at least v0.1.0-b0
         to populate :attr:`~.reconciliation.Reservation.fingerprint_history`
         and :attr:`~.reconciliation.Reservation.missing_count`.
 
-        After building reservations from calendar events, ghost Reservation
-        objects are synthesised for occupied persisted mappings that are
-        absent from the current feed (T089).  Their ``missing_count`` is
-        incremented in ``_slot_mappings`` so the planner can apply the
-        two-cycle miss tolerance before generating a CLEAR action.
+        Physical Keymaster observations are used only as current-cycle facts
+        for stable-name matching and manual PIN preservation; missing feed
+        entries are handled by the stateless planner from physical state.
 
         Args:
             calendar: Parsed and sorted calendar events from the current

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -2177,6 +2177,82 @@ Please update Keymaster to at least v0.1.0-b0
             return value
         return datetime.combine(value, time.min, self.timezone)
 
+    def _combine_event_time(
+        self, value: date | datetime, selected_time: time
+    ) -> datetime:
+        """Return an event-date datetime using the selected local time."""
+        event_date = value.date() if isinstance(value, datetime) else value
+        return cast(
+            "datetime",
+            dt.as_utc(datetime.combine(event_date, selected_time, self.timezone)),
+        )
+
+    @staticmethod
+    def _datetimes_match(left: datetime, right: datetime) -> bool:
+        """Return whether two datetimes represent the same instant."""
+        left_utc = cast("datetime", dt.as_utc(left))
+        right_utc = cast("datetime", dt.as_utc(right))
+        return left_utc == right_utc
+
+    def _physical_override_time(self, value: datetime, *, start: bool) -> time:
+        """Return the unbuffered local time represented by a physical slot time."""
+        local_value = (
+            value.replace(tzinfo=self.timezone)
+            if value.tzinfo is None
+            else value.astimezone(self.timezone)
+        )
+        if start and self.code_buffer_before:
+            local_value += timedelta(minutes=self.code_buffer_before)
+        if not start and self.code_buffer_after:
+            local_value -= timedelta(minutes=self.code_buffer_after)
+        return local_value.time()
+
+    def _buffer_aware_override_times(
+        self,
+        event_start: date | datetime,
+        event_end: date | datetime,
+        expected_checkin: time,
+        expected_checkout: time,
+        override: Mapping[str, Any],
+    ) -> tuple[time, time]:
+        """Return manual override times only when physical times truly differ.
+
+        Keymaster stores already-buffered datetimes.  A physical time that
+        matches the expected calendar/default window after applying buffers is
+        system-managed and must not freeze future Honor Event Times changes.
+        """
+        expected_start = self._combine_event_time(event_start, expected_checkin)
+        expected_end = self._combine_event_time(event_end, expected_checkout)
+        buffered_start_raw, buffered_end_raw = apply_buffer(
+            expected_start,
+            expected_end,
+            self.code_buffer_before,
+            self.code_buffer_after,
+            self,
+        )
+        buffered_start = (
+            buffered_start_raw
+            if isinstance(buffered_start_raw, datetime)
+            else expected_start
+        )
+        buffered_end = (
+            buffered_end_raw if isinstance(buffered_end_raw, datetime) else expected_end
+        )
+
+        checkin = expected_checkin
+        checkout = expected_checkout
+        override_start = override.get("start_time")
+        override_end = override.get("end_time")
+        if isinstance(override_start, datetime) and not self._datetimes_match(
+            override_start, buffered_start
+        ):
+            checkin = self._physical_override_time(override_start, start=True)
+        if isinstance(override_end, datetime) and not self._datetimes_match(
+            override_end, buffered_end
+        ):
+            checkout = self._physical_override_time(override_end, start=False)
+        return checkin, checkout
+
     def _must_defer_for_checkin_restore(
         self, reservations: list[_Reservation], managed_slots: list[_ManagedSlot]
     ) -> bool:
@@ -2717,42 +2793,47 @@ Please update Keymaster to at least v0.1.0-b0
                     description = str(raw_desc) if raw_desc else ""
                     desc_checkin = extract_checkin_time(description)
                     desc_checkout = extract_checkout_time(description)
+                    expected_checkin = (
+                        desc_checkin if desc_checkin is not None else self.checkin
+                    )
+                    expected_checkout = (
+                        desc_checkout if desc_checkout is not None else self.checkout
+                    )
 
                     if override:
-                        # Priority 3 fallback for missing description times
-                        start_tz = override["start_time"].astimezone(self.timezone)
-                        end_tz = override["end_time"].astimezone(self.timezone)
-                        checkin = (
-                            desc_checkin
-                            if desc_checkin is not None
-                            else start_tz.time()
+                        # Priority 3 fallback for genuine manual overrides.
+                        # Override timestamps are physical Keymaster dates,
+                        # which already include lock-code buffers.
+                        event_end_dt = (
+                            event["DTEND"].dt
+                            if "DTEND" in event
+                            else event["DTSTART"].dt
                         )
-                        checkout = (
-                            desc_checkout
-                            if desc_checkout is not None
-                            else end_tz.time()
+                        checkin, checkout = self._buffer_aware_override_times(
+                            event["DTSTART"].dt,
+                            event_end_dt,
+                            expected_checkin,
+                            expected_checkout,
+                            override,
                         )
+                        if desc_checkin is not None:
+                            checkin = desc_checkin
+                        if desc_checkout is not None:
+                            checkout = desc_checkout
                     else:
                         # Priority 4 fallback for missing description times
-                        checkin = (
-                            desc_checkin if desc_checkin is not None else self.checkin
-                        )
-                        checkout = (
-                            desc_checkout
-                            if desc_checkout is not None
-                            else self.checkout
-                        )
+                        checkin = expected_checkin
+                        checkout = expected_checkout
                 elif override:
                     # FR-005 (disabled) or FR-004 (all-day with override)
-                    # Get start & end overrides in the correct timezone
-                    # Overrides are stored in UTC since Keymaster's time
-                    # start and end configuration values are in UTC
-                    start_time: datetime = override["start_time"].astimezone(
-                        self.timezone
+                    # Override timestamps are sourced from Keymaster's
+                    # physical, already-buffered date range.
+                    checkin = self._physical_override_time(
+                        override["start_time"], start=True
                     )
-                    end_time: datetime = override["end_time"].astimezone(self.timezone)
-                    checkin = start_time.time()
-                    checkout = end_time.time()
+                    checkout = self._physical_override_time(
+                        override["end_time"], start=False
+                    )
                 else:
                     try:
                         # If the event has a time, use that, otherwise use the

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -89,9 +89,7 @@ from .const import DOMAIN
 from .const import EVENT_AGE_THRESHOLD_DAYS
 from .const import LOCK_MANAGER
 from .const import OPERATION_KIND_CLEAR
-from .const import OPERATION_KIND_SET
 from .const import REQUEST_TIMEOUT
-from .const import SLOT_STATUS_BLOCKED
 from .const import SLOT_STATUS_OCCUPIED
 from .const import SLOT_STATUS_PENDING_CLEAR
 from .const import SLOT_STATUS_PENDING_SET
@@ -107,7 +105,6 @@ from .reconciliation import Reservation as _Reservation
 from .reconciliation import SlotStatus as _SlotStatus
 from .reconciliation import compute_desired_plan
 from .reconciliation import extract_booking_aliases
-from .reconciliation import find_reservation_rematch
 from .reconciliation import make_reservation_fingerprint
 from .reconciliation import normalize_slot_name_for_fingerprint
 from .util import OperationResult
@@ -557,21 +554,48 @@ Please update Keymaster to at least v0.1.0-b0
             )
 
     async def async_load_slot_store(self) -> None:
-        """Load persisted slot mappings from the HA Store.
-
-        Creates the Store on first call using the entry-scoped key
-        ``STORE_SLOT_MAPPINGS_KEY.{entry_id}``.  Applies schema v1
-        migration when the stored schema version is absent or below 1.
-        Raw PINs are stripped after loading as a safety measure.
-        """
+        """Load cache-only slot metadata from the HA Store."""
         self._store = Store(
             self.hass,
             STORE_SCHEMA_VERSION,
             f"{STORE_SLOT_MAPPINGS_KEY}.{self._entry_id}",
         )
-        raw: dict[str, Any] | None = await self._store.async_load()
+        try:
+            raw: dict[str, Any] | None = await self._store.async_load()
+        except Exception as err:
+            _LOGGER.warning(
+                "Ignoring unreadable Rental Control slot cache for %s: %s",
+                self._entry_id,
+                err,
+            )
+            self._slot_mappings = {
+                "schema_version": STORE_SCHEMA_VERSION,
+                "entry_id": self._entry_id,
+                "lockname": self.lockname,
+                "mappings": {},
+                "aliases": {},
+                "migration_notes": ["cache_load_failed"],
+            }
+            return
         if raw is None:
-            self._slot_mappings = {}
+            self._slot_mappings = {
+                "schema_version": STORE_SCHEMA_VERSION,
+                "entry_id": self._entry_id,
+                "lockname": self.lockname,
+                "mappings": {},
+                "aliases": {},
+                "migration_notes": ["cache_missing"],
+            }
+            return
+        if not isinstance(raw, dict):
+            self._slot_mappings = {
+                "schema_version": STORE_SCHEMA_VERSION,
+                "entry_id": self._entry_id,
+                "lockname": self.lockname,
+                "mappings": {},
+                "aliases": {},
+                "migration_notes": ["cache_corrupt"],
+            }
             return
         schema_version = raw.get("schema_version", 0)
         if schema_version < 1:
@@ -582,6 +606,9 @@ Please update Keymaster to at least v0.1.0-b0
                 last_obs.pop("pin", None)
                 last_obs.pop("code", None)
                 last_obs.pop("slot_code", None)
+        raw.setdefault("mappings", {})
+        raw.setdefault("aliases", {})
+        raw.setdefault("migration_notes", [])
         self._slot_mappings = raw
 
     def get_persisted_slot_mappings(self) -> dict[str, Any]:
@@ -589,12 +616,7 @@ Please update Keymaster to at least v0.1.0-b0
         return cast("dict[str, Any]", self._slot_mappings.get("mappings", {}))
 
     async def async_save_slot_store(self) -> None:
-        """Save current slot mappings to the HA Store.
-
-        A no-op when ``_store`` is ``None`` (store not yet
-        initialised).  Raw PINs are stripped from
-        ``last_observed_actual`` before persisting as a safety measure.
-        """
+        """Best-effort save of cache-only slot metadata to the HA Store."""
         if self._store is None:
             return
         mappings: dict[str, Any] = {}
@@ -616,9 +638,18 @@ Please update Keymaster to at least v0.1.0-b0
             "max_slots": self.max_events,
             "updated_at": dt.now().isoformat(),
             "mappings": mappings,
-            "blocked_slots": self._slot_mappings.get("blocked_slots", {}),
+            "aliases": self._slot_mappings.get("aliases", {}),
+            "last_plan": self._slot_mappings.get("last_plan", {}),
+            "migration_notes": self._slot_mappings.get("migration_notes", []),
         }
-        await self._store.async_save(data)
+        try:
+            await self._store.async_save(data)
+        except Exception as err:
+            _LOGGER.warning(
+                "Failed to save Rental Control slot cache for %s: %s",
+                self._entry_id,
+                err,
+            )
 
     async def _migrate_slot_store_v1(self, raw: dict[str, Any]) -> dict[str, Any]:
         """Migrate store data to schema version 1.
@@ -641,7 +672,11 @@ Please update Keymaster to at least v0.1.0-b0
             "max_slots": raw.get("max_slots", self.max_events),
             "updated_at": raw.get("updated_at", dt.now().isoformat()),
             "mappings": raw.get("mappings", {}),
-            "blocked_slots": raw.get("blocked_slots", {}),
+            "aliases": raw.get("aliases", {}),
+            "migration_notes": [
+                *raw.get("migration_notes", []),
+                "legacy_authoritative_fields_ignored",
+            ],
         }
 
     async def async_adopt_keymaster_slots(self) -> None:
@@ -1042,6 +1077,37 @@ Please update Keymaster to at least v0.1.0-b0
             return False
         return True
 
+    def _find_observed_slot_by_name(
+        self,
+        managed_slots: list[_ManagedSlot],
+        slot_name: str,
+        display_slot_name: str,
+    ) -> _ManagedSlot | None:
+        """Return the current physical slot matching a stable/display name."""
+        prefix = f"{self.event_prefix} " if self.event_prefix else ""
+        desired_forms = {
+            normalize_slot_name_for_fingerprint(slot_name),
+            normalize_slot_name_for_fingerprint(display_slot_name),
+        }
+        for slot in managed_slots:
+            if not slot.managed or not slot.actual_name:
+                continue
+            actual = slot.actual_name
+            actual_forms = {normalize_slot_name_for_fingerprint(actual)}
+            if prefix and actual.startswith(prefix):
+                actual_forms.add(
+                    normalize_slot_name_for_fingerprint(actual[len(prefix) :])
+                )
+            if actual_forms & desired_forms:
+                return slot
+            if any(
+                desired.startswith(actual_form) or actual_form.startswith(desired)
+                for desired in desired_forms
+                for actual_form in actual_forms
+            ):
+                return slot
+        return None
+
     @staticmethod
     def _remap_observed_mappings_to_physical_reservations(
         persisted: dict[str, Any],
@@ -1145,95 +1211,9 @@ Please update Keymaster to at least v0.1.0-b0
             List of :class:`~.reconciliation.Reservation` objects ready
             for the planner; includes ghost reservations for absent slots.
         """
-        # Use _slot_mappings["mappings"] as the live source of truth so that
-        # missing_count updates made by ghost logic in previous cycles are
-        # visible here.  At startup this is identical to what was loaded from
-        # the HA Store; ghost cycles then keep it up to date.
-        persisted: dict[str, Any] = self._slot_mappings.get("mappings", {})
-
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
         reservations: list[_Reservation] = []
-        actual_slot_names: dict[int, str] = {}
-        observed_mapping_keys: set[str] = set()
-        if managed_slots is not None:
-            for ms in managed_slots:
-                if ms.actual_name is not None:
-                    actual_slot_names[ms.slot] = ms.actual_name
-                physical_present = (
-                    bool(ms.actual_name) or ms.actual_code_present is True
-                )
-                if ms.persisted_identity_key is not None and physical_present:
-                    observed_mapping_keys.add(ms.persisted_identity_key)
-        else:
-            for persisted_mapping in persisted.values():
-                slot_num = persisted_mapping.get("slot")
-                actual = persisted_mapping.get("last_observed_actual")
-                actual_name = (
-                    actual.get("name_state") if isinstance(actual, dict) else None
-                )
-                if isinstance(slot_num, int) and isinstance(actual_name, str):
-                    actual_slot_names[slot_num] = actual_name
-        current_reservations_for_rematch: list[_Reservation] = []
-        for event in calendar:
-            slot_name = get_slot_name(
-                event.summary,
-                event.description or "",
-                self.event_prefix or "",
-            )
-            if not slot_name:
-                continue
-            rematch_start: datetime = event.start  # type: ignore[assignment]
-            rematch_end: datetime = event.end  # type: ignore[assignment]
-            rematch_buffered_start_raw, rematch_buffered_end_raw = apply_buffer(
-                rematch_start,
-                rematch_end,
-                self.code_buffer_before,
-                self.code_buffer_after,
-                self,
-            )
-            rematch_buffered_start: datetime = (
-                rematch_buffered_start_raw
-                if isinstance(rematch_buffered_start_raw, datetime)
-                else rematch_start
-            )
-            rematch_buffered_end: datetime = (
-                rematch_buffered_end_raw
-                if isinstance(rematch_buffered_end_raw, datetime)
-                else rematch_end
-            )
-            uid = normalize_uid(getattr(event, "uid", None))
-            display_slot_name = _format_display_slot_name(
-                slot_name, prefix, self.trim_names, self.max_name_length
-            )
-            try:
-                current_reservations_for_rematch.append(
-                    _Reservation(
-                        identity_key=make_reservation_fingerprint(
-                            self._entry_id, slot_name, rematch_start, rematch_end
-                        ),
-                        start=rematch_start,
-                        end=rematch_end,
-                        buffered_start=rematch_buffered_start,
-                        buffered_end=rematch_buffered_end,
-                        summary=event.summary,
-                        slot_name=slot_name,
-                        display_slot_name=display_slot_name,
-                        slot_code="",
-                        uid_aliases={uid} if uid else set(),
-                        booking_aliases=extract_booking_aliases(
-                            event.summary, event.description or ""
-                        ),
-                    )
-                )
-            except ValueError:
-                continue
-
-        observed_mapping_keys = self._remap_observed_mappings_to_physical_reservations(
-            persisted,
-            current_reservations_for_rematch,
-            actual_slot_names,
-            observed_mapping_keys,
-        )
+        observed_slots = managed_slots or []
 
         for event in calendar:
             slot_name = get_slot_name(
@@ -1274,125 +1254,39 @@ Please update Keymaster to at least v0.1.0-b0
                 slot_name, prefix, self.trim_names, self.max_name_length
             )
 
-            provisional = _Reservation(
-                identity_key=identity_key,
-                start=start,
-                end=end,
-                buffered_start=buffered_start,
-                buffered_end=buffered_end,
-                summary=event.summary,
-                slot_name=slot_name,
-                display_slot_name=display_slot_name,
-                slot_code="",
-                uid_aliases=uid_aliases,
-                booking_aliases=booking_aliases,
+            slot_code = self._generate_slot_code(start, end, event.description, uid)
+            code_source = "generated"
+            matched_physical = self._find_observed_slot_by_name(
+                observed_slots, slot_name, display_slot_name
             )
-            rematch = find_reservation_rematch(
-                provisional,
-                persisted,
-                current_reservations=current_reservations_for_rematch,
-                actual_slot_names=actual_slot_names,
-                observed_mapping_keys=observed_mapping_keys,
-            )
-            matched_key = rematch.matched_identity_key
-            if matched_key is not None and matched_key != identity_key:
-                if identity_key in persisted and identity_key in observed_mapping_keys:
-                    target_mapping = persisted.pop(identity_key)
-                    target_slot = target_mapping.get("slot")
-                    preserved_key = f"observed.{self._entry_id}.slot{target_slot}"
-                    if preserved_key in persisted and preserved_key != matched_key:
-                        persisted[identity_key] = target_mapping
-                        mapping = persisted.get(identity_key, {})
-                        _LOGGER.warning(
-                            "Reservation %s rematch to %s blocked because "
-                            "fresh observed target %s could not be preserved",
-                            identity_key,
-                            matched_key,
-                            preserved_key,
-                        )
-                        matched_key = None
-                    else:
-                        target_identity = target_mapping.setdefault("identity", {})
-                        if isinstance(target_identity, dict):
-                            target_identity["identity_key"] = preserved_key
-                            actual = target_mapping.get("last_observed_actual", {})
-                            actual_name = (
-                                actual.get("name_state")
-                                if isinstance(actual, dict)
-                                else None
-                            )
-                            if isinstance(actual_name, str) and actual_name:
-                                target_identity["summary"] = actual_name
-                                target_identity["slot_name"] = actual_name
-                        persisted[preserved_key] = target_mapping
-                        observed_mapping_keys.remove(identity_key)
-                        observed_mapping_keys.add(preserved_key)
-
-            if matched_key is not None and matched_key != identity_key:
-                mapping = persisted.pop(matched_key)
-                if matched_key in observed_mapping_keys:
-                    observed_mapping_keys.remove(matched_key)
-                    observed_mapping_keys.add(identity_key)
-                history = set(mapping.get("fingerprint_history", []))
-                history.add(matched_key)
-                mapping["fingerprint_history"] = sorted(history)
-                identity = mapping.setdefault("identity", {})
-                if isinstance(identity, dict):
-                    identity["identity_key"] = identity_key
-                persisted[identity_key] = mapping
-            else:
-                mapping = persisted.get(identity_key, {})
-                if (
-                    mapping
-                    and identity_key in observed_mapping_keys
-                    and not self._physical_mapping_name_matches_reservation(
-                        mapping, provisional, actual_slot_names
+            if matched_physical is not None and matched_physical.actual_code:
+                observed_code = matched_physical.actual_code
+                observed_start = matched_physical.actual_start
+                observed_end = matched_physical.actual_end
+                if observed_start is not None and self.code_buffer_before:
+                    observed_start = observed_start + timedelta(
+                        minutes=self.code_buffer_before
                     )
-                ):
-                    target_mapping = persisted.pop(identity_key)
-                    target_slot = target_mapping.get("slot")
-                    preserved_key = f"observed.{self._entry_id}.slot{target_slot}"
-                    target_identity = target_mapping.setdefault("identity", {})
-                    if isinstance(target_identity, dict):
-                        target_identity["identity_key"] = preserved_key
-                        actual = target_mapping.get("last_observed_actual", {})
-                        actual_name = (
-                            actual.get("name_state")
-                            if isinstance(actual, dict)
-                            else None
-                        )
-                        if isinstance(actual_name, str) and actual_name:
-                            target_identity["summary"] = actual_name
-                            target_identity["slot_name"] = actual_name
-                    persisted[preserved_key] = target_mapping
-                    observed_mapping_keys.remove(identity_key)
-                    observed_mapping_keys.add(preserved_key)
-                    mapping = {}
-                if rematch.kind.value == "ambiguous":
-                    _LOGGER.warning(
-                        "Reservation %s has ambiguous persisted rematch candidates: %s",
-                        identity_key,
-                        rematch.ambiguous_keys,
+                if observed_end is not None and self.code_buffer_after:
+                    observed_end = observed_end - timedelta(
+                        minutes=self.code_buffer_after
                     )
-
-            fingerprint_history: set[str] = set(mapping.get("fingerprint_history", []))
-            missing_count: int = mapping.get("missing_count", 0)
-
-            # Reservation is present in feed – reset any accumulated miss count.
-            if mapping and missing_count != 0:
-                mapping["missing_count"] = 0
-                missing_count = 0
-                _LOGGER.debug(
-                    "Reservation %s reappeared; missing_count reset to 0", identity_key
+                old_generated = (
+                    self._generate_slot_code(
+                        observed_start,
+                        observed_end,
+                        event.description,
+                        uid,
+                    )
+                    if observed_start is not None and observed_end is not None
+                    else None
                 )
-
-            slot_code = ""
-            if self.event_overrides is not None:
-                existing = self.event_overrides.get_slot_with_name(slot_name)
-                if existing and existing.get("slot_code"):
-                    slot_code = str(existing["slot_code"])
-            if not slot_code:
-                slot_code = self._generate_slot_code(start, end, event.description, uid)
+                if old_generated is not None and observed_code != old_generated:
+                    slot_code = observed_code
+                    code_source = "manual_observed"
+                elif not self.should_update_code:
+                    slot_code = observed_code
+                    code_source = "manual_observed"
 
             try:
                 res = _Reservation(
@@ -1407,8 +1301,15 @@ Please update Keymaster to at least v0.1.0-b0
                     slot_code=slot_code,
                     uid_aliases=uid_aliases,
                     booking_aliases=booking_aliases,
-                    fingerprint_history=fingerprint_history,
-                    missing_count=missing_count,
+                    fingerprint_history=set(),
+                    missing_count=0,
+                    code_source=code_source,
+                )
+                res.sensor_lookup_keys.update(
+                    {
+                        identity_key,
+                        *(uid_aliases or set()),
+                    }
                 )
                 reservations.append(res)
             except ValueError:
@@ -1418,14 +1319,6 @@ Please update Keymaster to at least v0.1.0-b0
                     start,
                     end,
                 )
-
-        # Build ghost reservations for occupied slots absent from this feed cycle.
-        if self.event_overrides is not None:
-            current_keys: set[str] = {r.identity_key for r in reservations}
-            ghost_list = self._build_ghost_reservations(
-                current_keys, persisted, prefix, observed_mapping_keys
-            )
-            reservations.extend(ghost_list)
 
         return reservations
 
@@ -1599,67 +1492,31 @@ Please update Keymaster to at least v0.1.0-b0
         res_by_key: dict[str, _Reservation],
         operation_results: list[OperationResult],
     ) -> None:
-        """Synchronize persisted mappings with confirmed reconciliation state.
-
-        The HA Store must be updated after each apply-plan pass so the next
-        refresh and future restarts retain the authoritative reservation-to-slot
-        mapping.  Raw PIN values are never written; only ``has_code`` and
-        reservation identity metadata are persisted.
-        """
+        """Synchronize cache-only alias and diagnostic metadata from a plan."""
         mappings: dict[str, Any] = self._slot_mappings.setdefault("mappings", {})
         now_str = dt.now().isoformat()
-
-        failed_set_slots = {
-            result.slot
-            for result in operation_results
-            if result.kind == "set" and result.failed
-        }
         confirmed_clear_slots = {
             result.slot
             for result in operation_results
             if result.kind == "clear" and result.confirmed
         }
-        unconfirmed_clear_slots = {
+        failed_set_slots = {
             result.slot
             for result in operation_results
-            if result.kind == "clear" and not result.confirmed
+            if result.kind == "set" and result.failed
         }
-
         for identity_key, mapping in list(mappings.items()):
-            slot = mapping.get("slot")
-            if slot in confirmed_clear_slots:
+            if mapping.get("slot") in confirmed_clear_slots:
                 mappings.pop(identity_key, None)
-            elif slot in unconfirmed_clear_slots:
-                mapping["status"] = SLOT_STATUS_PENDING_CLEAR
-                mapping["pending_clear_since"] = mapping.get(
-                    "pending_clear_since", now_str
-                )
-                if self.event_overrides is not None:
-                    operation_id = self.event_overrides.pending_clear_slots.get(slot)
-                    mapping["operation_id"] = operation_id
-                    mapping["operation_kind"] = OPERATION_KIND_CLEAR
 
         for identity_key, slot in plan.selected.items():
-            if slot in failed_set_slots:
-                continue
             if slot in confirmed_clear_slots:
+                continue
+            if slot in failed_set_slots:
                 continue
             res = res_by_key.get(identity_key)
             if res is None:
                 continue
-            if (
-                self.event_overrides is not None
-                and slot in self.event_overrides.pending_clear_slots
-            ):
-                continue
-
-            is_unconfirmed_set = any(
-                result.kind == OPERATION_KIND_SET
-                and result.slot == slot
-                and result.unconfirmed
-                for result in operation_results
-            )
-            existing_mapping = mappings.get(identity_key, {})
             actual = (
                 self.event_overrides.get_actual_state(slot)
                 if self.event_overrides is not None
@@ -1668,21 +1525,14 @@ Please update Keymaster to at least v0.1.0-b0
             for stale_key in [
                 key
                 for key, mapping in mappings.items()
-                if key != identity_key
-                and mapping.get("slot") == slot
-                and mapping.get("status")
-                in (SLOT_STATUS_OCCUPIED, SLOT_STATUS_PENDING_SET)
+                if key != identity_key and mapping.get("slot") == slot
             ]:
                 mappings.pop(stale_key, None)
             mappings[identity_key] = {
                 "slot": slot,
-                "status": (
-                    SLOT_STATUS_PENDING_SET
-                    if is_unconfirmed_set
-                    else SLOT_STATUS_OCCUPIED
-                ),
-                "operation_id": plan.plan_id if is_unconfirmed_set else None,
-                "operation_kind": OPERATION_KIND_SET if is_unconfirmed_set else None,
+                "status": "cache",
+                "operation_id": None,
+                "operation_kind": None,
                 "identity": {
                     "identity_key": identity_key,
                     "summary": res.summary,
@@ -1692,12 +1542,8 @@ Please update Keymaster to at least v0.1.0-b0
                     "uid_aliases": sorted(res.uid_aliases),
                     "booking_aliases": sorted(res.booking_aliases),
                 },
-                "missing_count": res.missing_count,
-                "pending_set_since": (
-                    existing_mapping.get("pending_set_since", now_str)
-                    if is_unconfirmed_set
-                    else None
-                ),
+                "missing_count": 0,
+                "pending_set_since": None,
                 "pending_clear_since": None,
                 "fingerprint_history": sorted(res.fingerprint_history),
                 "updated_at": now_str,
@@ -1725,7 +1571,9 @@ Please update Keymaster to at least v0.1.0-b0
                 "start_slot": self.start_slot,
                 "max_slots": self.max_events,
                 "updated_at": now_str,
-                "blocked_slots": self._slot_mappings.get("blocked_slots", {}),
+                "aliases": self._slot_mappings.get("aliases", {}),
+                "last_plan": plan.diagnostics,
+                "migration_notes": self._slot_mappings.get("migration_notes", []),
             }
         )
 
@@ -1736,9 +1584,8 @@ Please update Keymaster to at least v0.1.0-b0
         """Read Keymaster entity states and build ManagedSlot observations.
 
         Reads Keymaster text, switch, and datetime entities for every slot
-        in the managed range to determine the current physical state.
-        Persisted fence tokens from :attr:`event_overrides` override the
-        entity-derived classification for ``PENDING_CLEAR`` slots.  The
+        in the managed range to determine the current physical state. Store
+        cache contents are deliberately ignored for classification. The
         observed state is also written back to the
         :meth:`~.event_overrides.EventOverrides.update_actual_state`
         cache for diagnostics.
@@ -1749,23 +1596,6 @@ Please update Keymaster to at least v0.1.0-b0
         """
         if not self.lockname or not self.event_overrides:
             return []
-
-        persisted = self._slot_mappings.get("mappings", {})
-        pending_clear = self.event_overrides.pending_clear_slots
-
-        slot_to_persisted_key: dict[int, str] = {}
-        for key, mapping in persisted.items():
-            slot_num = mapping.get("slot")
-            if slot_num is None:
-                continue
-            current = slot_to_persisted_key.get(slot_num)
-            if current is None:
-                slot_to_persisted_key[slot_num] = key
-            elif mapping.get("status") in (
-                SLOT_STATUS_OCCUPIED,
-                SLOT_STATUS_PENDING_SET,
-            ):
-                slot_to_persisted_key[slot_num] = key
 
         slots: list[_ManagedSlot] = []
 
@@ -1797,21 +1627,17 @@ Please update Keymaster to at least v0.1.0-b0
 
             name_empty = _is_blank_keymaster_text(name_state.state)
             code_empty = _is_blank_keymaster_text(code_state.state)
-            physically_empty = name_empty and code_empty
             unreadable = is_unreadable_keymaster_text_state(
                 name_state.state
             ) or is_unreadable_keymaster_text_state(code_state.state)
 
-            if not physically_empty and unreadable:
+            if unreadable:
                 status = _SlotStatus.UNKNOWN
-                blocked_reason = (
-                    "pending_clear_unreadable" if i in pending_clear else None
-                )
                 ms = _ManagedSlot(
                     slot=i,
                     managed=True,
                     status=status,
-                    blocked_reason=blocked_reason,
+                    blocked_reason="unreadable",
                 )
                 slots.append(ms)
                 self.event_overrides.update_actual_state(
@@ -1867,50 +1693,9 @@ Please update Keymaster to at least v0.1.0-b0
                 if end_dt_state is not None:
                     actual_end = dt.parse_datetime(end_dt_state.state)
 
-            persisted_key = slot_to_persisted_key.get(i)
-            persisted_mapping = (
-                persisted.get(persisted_key) if persisted_key is not None else None
-            )
-            persisted_status = (
-                persisted_mapping.get("status")
-                if persisted_mapping is not None
-                else None
-            )
-            persisted_missing_raw = (
-                persisted_mapping.get("missing_count", 0)
-                if persisted_mapping is not None
-                else 0
-            )
-            persisted_missing_count = (
-                persisted_missing_raw if isinstance(persisted_missing_raw, int) else 0
-            )
-            if physically_empty and i in pending_clear:
-                self.event_overrides.release_pending_clear_slot(i)
-                for key in [
-                    key
-                    for key, mapping in persisted.items()
-                    if mapping.get("slot") == i
-                    and mapping.get("status") == SLOT_STATUS_PENDING_CLEAR
-                ]:
-                    persisted.pop(key, None)
-                pending_clear = self.event_overrides.pending_clear_slots
-                persisted_key = None
-                persisted_mapping = None
-                persisted_status = None
-                persisted_missing_count = 0
-
-            if i in pending_clear:
-                status = _SlotStatus.PENDING_CLEAR
-                blocked_reason = "pending_clear"
-            elif persisted_status == SLOT_STATUS_BLOCKED:
-                status = _SlotStatus.BLOCKED
-                blocked_reason = SLOT_STATUS_BLOCKED
-            elif has_code:
+            if has_code:
                 status = _SlotStatus.OCCUPIED
                 blocked_reason = None
-            elif persisted_status == SLOT_STATUS_PENDING_SET:
-                status = _SlotStatus.BLOCKED
-                blocked_reason = SLOT_STATUS_PENDING_SET
             elif name_value:
                 status = _SlotStatus.PHANTOM
                 blocked_reason = None
@@ -1923,20 +1708,15 @@ Please update Keymaster to at least v0.1.0-b0
                 managed=True,
                 status=status,
                 actual_name=name_value or None,
+                actual_code=code_value or None,
                 actual_code_present=has_code,
                 actual_start=actual_start,
                 actual_end=actual_end,
                 date_range_enabled=date_range_enabled,
                 enabled=enabled,
-                persisted_identity_key=persisted_key,
+                persisted_identity_key=None,
                 blocked_reason=blocked_reason,
-                preserve_unmatched=(
-                    status is _SlotStatus.OCCUPIED
-                    and persisted_status
-                    in (SLOT_STATUS_OCCUPIED, SLOT_STATUS_PENDING_SET)
-                    and (bool(name_value) or has_code)
-                    and persisted_missing_count < 3
-                ),
+                preserve_unmatched=False,
                 last_error=self.event_overrides.get_last_slot_error(i),
             )
             slots.append(ms)
@@ -2116,22 +1896,14 @@ Please update Keymaster to at least v0.1.0-b0
 
         if self.event_overrides:
             try:
-                self.event_overrides.load_persisted_mappings(
-                    self._slot_mappings.get("mappings", {})
-                )
                 observed_slots = self._observe_managed_slots()
-                self._merge_observed_slots_into_mappings(observed_slots)
                 reservations = self._build_reservations(new_calendar, observed_slots)
-                self.event_overrides.load_persisted_mappings(
-                    self._slot_mappings.get("mappings", {})
-                )
-                managed_slots = self._observe_managed_slots()
                 self._apply_checkin_protection(reservations)
 
                 plan_id = str(uuid.uuid4())
                 plan = compute_desired_plan(
                     reservations=reservations,
-                    managed_slots=managed_slots,
+                    managed_slots=observed_slots,
                     max_events=self.max_events,
                     plan_id=plan_id,
                     generated_at=dt.now(),

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1294,7 +1294,15 @@ Please update Keymaster to at least v0.1.0-b0
         consumed_observed_slots: set[int] = set()
         slot_name_counts: dict[str, int] = {}
         slot_name_date_windows: dict[str, set[tuple[datetime, datetime]]] = {}
-        for event in calendar:
+        ordered_calendar = sorted(
+            calendar,
+            key=lambda event: (
+                event.start.isoformat(),
+                event.end.isoformat(),
+                event.summary or "",
+            ),
+        )
+        for event in ordered_calendar:
             slot_name = get_slot_name(
                 event.summary,
                 event.description or "",
@@ -1329,7 +1337,7 @@ Please update Keymaster to at least v0.1.0-b0
                 if active_windows:
                     slot_name_date_windows.setdefault(key, set()).update(active_windows)
 
-        for event in calendar:
+        for event in ordered_calendar:
             slot_name = get_slot_name(
                 event.summary,
                 event.description or "",

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1126,6 +1126,7 @@ Please update Keymaster to at least v0.1.0-b0
             managed_slots,
             key=lambda observed: (
                 observed.actual_start or datetime.max.replace(tzinfo=timezone.utc),
+                observed.actual_end or datetime.max.replace(tzinfo=timezone.utc),
                 observed.slot,
             ),
         ):

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -2187,11 +2187,14 @@ Please update Keymaster to at least v0.1.0-b0
             dt.as_utc(datetime.combine(event_date, selected_time, self.timezone)),
         )
 
-    @staticmethod
-    def _datetimes_match(left: datetime, right: datetime) -> bool:
+    def _datetimes_match(self, left: datetime, right: datetime) -> bool:
         """Return whether two datetimes represent the same instant."""
-        left_utc = cast("datetime", dt.as_utc(left))
-        right_utc = cast("datetime", dt.as_utc(right))
+        left_local = left.replace(tzinfo=self.timezone) if left.tzinfo is None else left
+        right_local = (
+            right.replace(tzinfo=self.timezone) if right.tzinfo is None else right
+        )
+        left_utc = cast("datetime", dt.as_utc(left_local))
+        right_utc = cast("datetime", dt.as_utc(right_local))
         return left_utc == right_utc
 
     def _physical_override_time(self, value: datetime, *, start: bool) -> time:
@@ -2712,13 +2715,12 @@ Please update Keymaster to at least v0.1.0-b0
                 f"Buffer time update slot {slot} ({self.lockname})",
                 _LOGGER,
             )
-            if not any(isinstance(result, Exception) for result in results):
-                override["start_time"] = (
-                    buffered_start if isinstance(buffered_start, datetime) else start
-                )
-                override["end_time"] = (
-                    buffered_end if isinstance(buffered_end, datetime) else end
-                )
+            override["start_time"] = (
+                buffered_start if isinstance(buffered_start, datetime) else start
+            )
+            override["end_time"] = (
+                buffered_end if isinstance(buffered_end, datetime) else end
+            )
 
     async def update_event_overrides(
         self,

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1141,6 +1141,26 @@ Please update Keymaster to at least v0.1.0-b0
                 if slot.slot in consumed:
                     continue
                 candidates.append(slot)
+        if require_date_match:
+            if matching_candidate_count < expected_name_count:
+                if desired_start is not None and desired_end is not None:
+                    for slot in candidates:
+                        if (
+                            slot.actual_start == desired_start
+                            and slot.actual_end == desired_end
+                        ):
+                            consumed.add(slot.slot)
+                            return slot
+                return None
+            if any(
+                slot.actual_start is None or slot.actual_end is None
+                for slot in candidates
+            ):
+                return None
+            if candidates:
+                consumed.add(candidates[0].slot)
+                return candidates[0]
+            return None
         if desired_start is not None and desired_end is not None:
             for slot in candidates:
                 if (
@@ -1150,20 +1170,12 @@ Please update Keymaster to at least v0.1.0-b0
                     consumed.add(slot.slot)
                     return slot
         fallback_candidates = candidates
-        if reserved_date_windows and (
-            require_date_match or block_unknown_date_fallback
-        ):
-            if require_date_match and matching_candidate_count < expected_name_count:
-                return None
+        if reserved_date_windows and block_unknown_date_fallback:
             fallback_candidates = [
                 slot
                 for slot in candidates
                 if slot.actual_start is not None
                 and slot.actual_end is not None
-                and (
-                    not block_unknown_date_fallback
-                    or (slot.actual_start, slot.actual_end) not in reserved_date_windows
-                )
                 and (slot.actual_start, slot.actual_end) not in reserved_date_windows
             ]
         if fallback_candidates:

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -581,7 +581,11 @@ Please update Keymaster to at least v0.1.0-b0
             self._slot_mappings = self._empty_slot_cache("cache_corrupt")
             return
         if schema_version < 1:
-            raw = await self._migrate_slot_store_v1(raw)
+            try:
+                raw = await self._migrate_slot_store_v1(raw)
+            except Exception:
+                self._slot_mappings = self._empty_slot_cache("cache_corrupt")
+                return
         mappings = raw.get("mappings", {})
         if not isinstance(mappings, dict):
             self._slot_mappings = self._empty_slot_cache("cache_corrupt")
@@ -675,6 +679,9 @@ Please update Keymaster to at least v0.1.0-b0
         Returns:
             A dict conforming to schema version 1.
         """
+        migration_notes = raw.get("migration_notes", [])
+        if not isinstance(migration_notes, list):
+            migration_notes = []
         return {
             "schema_version": 1,
             "entry_id": raw.get("entry_id", self._entry_id),
@@ -685,7 +692,7 @@ Please update Keymaster to at least v0.1.0-b0
             "mappings": raw.get("mappings", {}),
             "aliases": raw.get("aliases", {}),
             "migration_notes": [
-                *raw.get("migration_notes", []),
+                *migration_notes,
                 "legacy_authoritative_fields_ignored",
             ],
         }
@@ -1869,7 +1876,9 @@ Please update Keymaster to at least v0.1.0-b0
             and res.start == tracked_start
             and res.end == tracked_end
         ]
-        matches = exact_matches or (name_matches if len(name_matches) == 1 else [])
+        matches = exact_matches
+        if tracked_start is None or tracked_end is None:
+            matches = name_matches if len(name_matches) == 1 else []
         for res in matches[:1]:
             if sensor_state == CHECKIN_STATE_CHECKED_IN:
                 res.protected_active = True

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -225,6 +225,7 @@ class RentalControlCoordinator(DataUpdateCoordinator[list[CalendarEvent]]):
         # Reconciliation state (T022/T031/T033)
         self._latest_plan: _DesiredPlan | None = None
         self._latest_res_by_key: dict[str, _Reservation] = {}
+        self._checkin_restore_pending = False
 
         super().__init__(
             hass=hass,
@@ -2028,6 +2029,8 @@ Please update Keymaster to at least v0.1.0-b0
         domain_data: dict[str, Any] | None = self.hass.data.get(DOMAIN)
         if domain_data is None or self._entry_id not in domain_data:
             return False
+        if not self._checkin_restore_pending:
+            return False
         entry_data: dict[str, Any] = domain_data.get(self._entry_id, {})
         if entry_data.get(CHECKIN_SENSOR) is not None:
             return False
@@ -2040,7 +2043,18 @@ Please update Keymaster to at least v0.1.0-b0
                     for res in reservations
                 )
                 or (
-                    (slot.actual_start is None or slot.actual_end is None)
+                    (
+                        slot.actual_start is None
+                        or slot.actual_end is None
+                        or not any(
+                            slot.actual_start == res.buffered_start
+                            and slot.actual_end == res.buffered_end
+                            for res in reservations
+                            if self._physical_slot_name_matches_reservation(
+                                slot.actual_name, res
+                            )
+                        )
+                    )
                     and any(
                         self._physical_slot_name_matches_reservation(
                             slot.actual_name, res
@@ -2387,8 +2401,6 @@ Please update Keymaster to at least v0.1.0-b0
         self.ignore_non_reserved = bool(config.get(CONF_IGNORE_NON_RESERVED))
         self.verify_ssl = bool(config.get(CONF_VERIFY_SSL))
 
-        await self.async_request_refresh()
-
         buffer_changed = (
             self.code_buffer_before != previous_buffer_before
             or self.code_buffer_after != previous_buffer_after
@@ -2397,6 +2409,7 @@ Please update Keymaster to at least v0.1.0-b0
             await self._async_update_buffer_times(
                 previous_buffer_before, previous_buffer_after
             )
+        await self.async_request_refresh()
 
     async def _async_update_buffer_times(self, old_before: int, old_after: int) -> None:
         """Re-apply buffer to all assigned slots after config change.

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1252,7 +1252,7 @@ Please update Keymaster to at least v0.1.0-b0
                 (slot.actual_end - window[1]).total_seconds()
             )
 
-        @lru_cache
+        @lru_cache(maxsize=None)
         def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
             """Return best ordered subset cost and indices from this position."""
             if desired_index == len(desired_windows):
@@ -1293,7 +1293,7 @@ Please update Keymaster to at least v0.1.0-b0
                 (slot.actual_end - window[1]).total_seconds()
             )
 
-        @lru_cache
+        @lru_cache(maxsize=None)
         def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
             """Return best desired-window indices for remaining physical slots."""
             if slot_index == len(dated_slots):
@@ -1397,10 +1397,9 @@ Please update Keymaster to at least v0.1.0-b0
         """Convert parsed CalendarEvent objects to Reservation objects.
 
         Produces one :class:`~.reconciliation.Reservation` per calendar
-        event that has a usable slot name.  The coordinator's current
-        persisted mappings (``_slot_mappings["mappings"]``) are consulted
-        to populate :attr:`~.reconciliation.Reservation.fingerprint_history`
-        and :attr:`~.reconciliation.Reservation.missing_count`.
+        event that has a usable slot name.  Persisted Store mappings are
+        deliberately not consulted as authority; reservation identity and
+        desired windows come from the current calendar cycle.
 
         Physical Keymaster observations are used only as current-cycle facts
         for stable-name matching and manual PIN preservation; missing feed
@@ -1415,7 +1414,7 @@ Please update Keymaster to at least v0.1.0-b0
 
         Returns:
             List of :class:`~.reconciliation.Reservation` objects ready
-            for the planner; includes ghost reservations for absent slots.
+            for the planner.
         """
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
         reservations: list[_Reservation] = []

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1142,7 +1142,7 @@ Please update Keymaster to at least v0.1.0-b0
                     consumed.add(slot.slot)
                     return slot
         fallback_candidates = candidates
-        if require_date_match and reserved_date_windows:
+        if reserved_date_windows:
             fallback_candidates = [
                 slot
                 for slot in candidates
@@ -1295,6 +1295,9 @@ Please update Keymaster to at least v0.1.0-b0
                 slot_name_date_windows.setdefault(key, set()).add(
                     (buffered_start_dt, buffered_end_dt)
                 )
+                active_windows = self._active_checkin_windows_for_name(slot_name)
+                if active_windows:
+                    slot_name_date_windows.setdefault(key, set()).update(active_windows)
 
         for event in calendar:
             slot_name = get_slot_name(
@@ -1864,8 +1867,12 @@ Please update Keymaster to at least v0.1.0-b0
         guest_name: str | None = attrs.get("guest_name")
         if not guest_name:
             return
-        tracked_start = self._coerce_checkin_datetime(attrs.get("start"))
-        tracked_end = self._coerce_checkin_datetime(attrs.get("end"))
+        tracked_start = RentalControlCoordinator._coerce_checkin_datetime(
+            attrs.get("start")
+        )
+        tracked_end = RentalControlCoordinator._coerce_checkin_datetime(
+            attrs.get("end")
+        )
 
         name_matches = [res for res in reservations if res.slot_name == guest_name]
         exact_matches = [
@@ -1920,7 +1927,11 @@ Please update Keymaster to at least v0.1.0-b0
                 desired_start=buffered_start,
                 desired_end=buffered_end,
             )
-            if matched_physical is None:
+            if (
+                matched_physical is None
+                or matched_physical.actual_start != buffered_start
+                or matched_physical.actual_end != buffered_end
+            ):
                 return
             identity_key = make_reservation_fingerprint(
                 self._entry_id, guest_name, tracked_start, tracked_end
@@ -1957,6 +1968,45 @@ Please update Keymaster to at least v0.1.0-b0
             parsed = dt.parse_datetime(value)
             return parsed if isinstance(parsed, datetime) else None
         return None
+
+    def _active_checkin_windows_for_name(
+        self, slot_name: str
+    ) -> set[tuple[datetime, datetime]]:
+        """Return active check-in windows that physical slots must reserve."""
+        domain_data: dict[str, Any] | None = self.hass.data.get(DOMAIN)
+        entry_data: dict[str, Any] = (
+            domain_data.get(self._entry_id, {}) if domain_data is not None else {}
+        )
+        checkin_sensor = entry_data.get(CHECKIN_SENSOR)
+        if checkin_sensor is None or checkin_sensor.state != CHECKIN_STATE_CHECKED_IN:
+            return set()
+        attrs: dict[str, Any] = checkin_sensor.extra_state_attributes
+        if attrs.get("guest_name") != slot_name:
+            return set()
+        tracked_start = RentalControlCoordinator._coerce_checkin_datetime(
+            attrs.get("start")
+        )
+        tracked_end = RentalControlCoordinator._coerce_checkin_datetime(
+            attrs.get("end")
+        )
+        if tracked_start is None or tracked_end is None:
+            return set()
+        buffered_start_raw, buffered_end_raw = apply_buffer(
+            tracked_start,
+            tracked_end,
+            self.code_buffer_before,
+            self.code_buffer_after,
+            self,
+        )
+        buffered_start = (
+            buffered_start_raw
+            if isinstance(buffered_start_raw, datetime)
+            else tracked_start
+        )
+        buffered_end = (
+            buffered_end_raw if isinstance(buffered_end_raw, datetime) else tracked_end
+        )
+        return {(tracked_start, tracked_end), (buffered_start, buffered_end)}
 
     async def _async_fetch_calendar(self) -> list[CalendarEvent]:
         """Fetch iCalendar data from URL and parse into events."""

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -591,11 +591,15 @@ Please update Keymaster to at least v0.1.0-b0
             self._slot_mappings = self._empty_slot_cache("cache_corrupt")
             return
         aliases = raw.get("aliases", {})
-        if aliases is not None and not isinstance(aliases, dict):
+        if aliases is None:
+            raw["aliases"] = {}
+        elif not isinstance(aliases, dict):
             self._slot_mappings = self._empty_slot_cache("cache_corrupt")
             return
         migration_notes = raw.get("migration_notes", [])
-        if migration_notes is not None and not isinstance(migration_notes, list):
+        if migration_notes is None:
+            raw["migration_notes"] = []
+        elif not isinstance(migration_notes, list):
             self._slot_mappings = self._empty_slot_cache("cache_corrupt")
             return
         for mapping in mappings.values():
@@ -1106,6 +1110,7 @@ Please update Keymaster to at least v0.1.0-b0
         require_date_match: bool = False,
         reserved_date_windows: set[tuple[datetime, datetime]] | None = None,
         block_unknown_date_fallback: bool = False,
+        expected_name_count: int = 1,
     ) -> _ManagedSlot | None:
         """Return the current physical slot matching a stable/display name."""
         prefix = f"{self.event_prefix} " if self.event_prefix else ""
@@ -1115,6 +1120,7 @@ Please update Keymaster to at least v0.1.0-b0
         }
         consumed = consumed_slots if consumed_slots is not None else set()
         candidates: list[_ManagedSlot] = []
+        matching_candidate_count = 0
         for slot in sorted(
             managed_slots,
             key=lambda observed: (
@@ -1122,8 +1128,6 @@ Please update Keymaster to at least v0.1.0-b0
                 observed.slot,
             ),
         ):
-            if slot.slot in consumed:
-                continue
             if not slot.managed or not slot.actual_name:
                 continue
             actual = slot.actual_name
@@ -1133,6 +1137,9 @@ Please update Keymaster to at least v0.1.0-b0
                     normalize_slot_name_for_fingerprint(actual[len(prefix) :])
                 )
             if actual_forms & desired_forms:
+                matching_candidate_count += 1
+                if slot.slot in consumed:
+                    continue
                 candidates.append(slot)
         if desired_start is not None and desired_end is not None:
             for slot in candidates:
@@ -1146,6 +1153,8 @@ Please update Keymaster to at least v0.1.0-b0
         if reserved_date_windows and (
             require_date_match or block_unknown_date_fallback
         ):
+            if require_date_match and matching_candidate_count < expected_name_count:
+                return None
             fallback_candidates = [
                 slot
                 for slot in candidates
@@ -1364,6 +1373,7 @@ Please update Keymaster to at least v0.1.0-b0
                     active_windows
                     and (buffered_start, buffered_end) not in active_windows
                 ),
+                slot_name_counts.get(normalize_slot_name_for_fingerprint(slot_name), 1),
             )
             if matched_physical is not None and matched_physical.actual_code:
                 observed_code = matched_physical.actual_code
@@ -1387,7 +1397,10 @@ Please update Keymaster to at least v0.1.0-b0
                     if observed_start is not None and observed_end is not None
                     else None
                 )
-                if old_generated is not None and observed_code != old_generated:
+                if old_generated is None:
+                    slot_code = observed_code
+                    code_source = "manual_observed"
+                elif observed_code != old_generated:
                     slot_code = observed_code
                     code_source = "manual_observed"
                 elif not self.should_update_code:

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1147,15 +1147,13 @@ Please update Keymaster to at least v0.1.0-b0
             fallback_candidates = [
                 slot
                 for slot in candidates
-                if (
-                    not block_unknown_date_fallback
-                    or (slot.actual_start is not None and slot.actual_end is not None)
-                )
+                if slot.actual_start is not None
+                and slot.actual_end is not None
                 and (
-                    slot.actual_start is None
-                    or slot.actual_end is None
+                    not block_unknown_date_fallback
                     or (slot.actual_start, slot.actual_end) not in reserved_date_windows
                 )
+                and (slot.actual_start, slot.actual_end) not in reserved_date_windows
             ]
         if fallback_candidates:
             consumed.add(fallback_candidates[0].slot)
@@ -1984,6 +1982,25 @@ Please update Keymaster to at least v0.1.0-b0
             return parsed if isinstance(parsed, datetime) else None
         return None
 
+    def _must_defer_for_checkin_restore(
+        self, reservations: list[_Reservation], managed_slots: list[_ManagedSlot]
+    ) -> bool:
+        """Return whether apply should wait for check-in sensor restore."""
+        domain_data: dict[str, Any] | None = self.hass.data.get(DOMAIN)
+        entry_data: dict[str, Any] = (
+            domain_data.get(self._entry_id, {}) if domain_data is not None else {}
+        )
+        if entry_data.get(CHECKIN_SENSOR) is not None:
+            return False
+        reservation_names = {res.slot_name for res in reservations}
+        return any(
+            slot.managed
+            and slot.status is _SlotStatus.OCCUPIED
+            and slot.actual_name in reservation_names
+            and (slot.actual_start is None or slot.actual_end is None)
+            for slot in managed_slots
+        )
+
     def _active_checkin_windows_for_name(
         self, slot_name: str
     ) -> set[tuple[datetime, datetime]]:
@@ -2164,9 +2181,17 @@ Please update Keymaster to at least v0.1.0-b0
                 res_by_key: dict[str, _Reservation] = {
                     r.identity_key: r for r in reservations
                 }
-                operation_results = await self.event_overrides.async_apply_plan(
-                    self, plan, res_by_key
-                )
+                if self._must_defer_for_checkin_restore(reservations, observed_slots):
+                    _LOGGER.warning(
+                        "Deferring reconciliation for %s until check-in state is "
+                        "available; same-name physical slot has missing date state",
+                        self._name,
+                    )
+                    operation_results = []
+                else:
+                    operation_results = await self.event_overrides.async_apply_plan(
+                        self, plan, res_by_key
+                    )
                 self._sync_slot_store_from_plan(plan, res_by_key, operation_results)
 
                 self._latest_plan = plan

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -1157,6 +1157,24 @@ Please update Keymaster to at least v0.1.0-b0
                         ):
                             consumed.add(slot.slot)
                             return slot
+                if ordered_date_windows:
+                    pairings = self._select_partial_ordered_pairings(
+                        all_candidates, ordered_date_windows
+                    )
+                    desired_window = (
+                        (desired_start, desired_end)
+                        if desired_start is not None and desired_end is not None
+                        else None
+                    )
+                    matched_slot = (
+                        pairings.get(desired_window)
+                        if desired_window is not None
+                        else None
+                    )
+                    if matched_slot is not None and matched_slot.slot not in consumed:
+                        consumed.add(matched_slot.slot)
+                        return matched_slot
+                    return None
                 shifted_candidates = [
                     slot
                     for slot in candidates
@@ -1252,6 +1270,50 @@ Please update Keymaster to at least v0.1.0-b0
 
         _, indices = _best(0, 0)
         return [slots[index] for index in indices]
+
+    @staticmethod
+    def _select_partial_ordered_pairings(
+        slots: list[_ManagedSlot], desired_windows: list[tuple[datetime, datetime]]
+    ) -> dict[tuple[datetime, datetime], _ManagedSlot]:
+        """Return ordered pairings when physical duplicates are missing."""
+        dated_slots = [
+            slot
+            for slot in slots
+            if slot.actual_start is not None and slot.actual_end is not None
+        ]
+        if not dated_slots:
+            return {}
+
+        def _distance(slot: _ManagedSlot, window: tuple[datetime, datetime]) -> float:
+            """Return absolute date distance for one physical/desired pair."""
+            assert slot.actual_start is not None
+            assert slot.actual_end is not None
+            return abs((slot.actual_start - window[0]).total_seconds()) + abs(
+                (slot.actual_end - window[1]).total_seconds()
+            )
+
+        @lru_cache
+        def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
+            """Return best desired-window indices for remaining physical slots."""
+            if slot_index == len(dated_slots):
+                return 0.0, ()
+            if desired_index == len(desired_windows):
+                return float("inf"), ()
+            skip_cost, skip_indices = _best(slot_index, desired_index + 1)
+            take_rest_cost, take_indices = _best(slot_index + 1, desired_index + 1)
+            take_cost = (
+                _distance(dated_slots[slot_index], desired_windows[desired_index])
+                + take_rest_cost
+            )
+            if take_cost < skip_cost:
+                return take_cost, (desired_index, *take_indices)
+            return skip_cost, skip_indices
+
+        _, indices = _best(0, 0)
+        return {
+            desired_windows[desired_index]: dated_slots[slot_index]
+            for slot_index, desired_index in enumerate(indices)
+        }
 
     @staticmethod
     def _remap_observed_mappings_to_physical_reservations(

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -30,8 +30,6 @@ import uuid
 from homeassistant.util import dt
 
 from .const import DEFAULT_MAX_RETRY_CYCLES
-from .const import SLOT_STATUS_OCCUPIED
-from .const import SLOT_STATUS_PENDING_CLEAR
 from .reconciliation import ActionKind
 from .reconciliation import DesiredPlan
 from .reconciliation import Reservation
@@ -42,6 +40,8 @@ from .util import async_fire_clear_code
 from .util import async_fire_set_code
 from .util import async_fire_update_times
 from .util import get_event_identities
+from .util import is_cleared_keymaster_text_state
+from .util import is_unreadable_keymaster_text_state
 from .util import normalize_uid
 from .util import trim_name
 
@@ -407,41 +407,8 @@ class EventOverrides:
         }
 
     def load_persisted_mappings(self, mappings: dict[str, dict[str, Any]]) -> None:
-        """Load persisted slot mappings from the HA Store.
-
-        Validates that no two mappings both claim the same slot with
-        status ``occupied``; raises ``ValueError`` on conflict.
-
-        Args:
-            mappings: Identity-key → mapping dict from the HA Store.
-
-        Raises:
-            ValueError: If two mappings claim the same slot and both
-                have ``occupied`` status.
-        """
-        slot_owners: dict[int, str] = {}
-        for identity_key, mapping in mappings.items():
-            slot = mapping.get("slot")
-            status = mapping.get("status")
-            if slot is not None and status == SLOT_STATUS_OCCUPIED:
-                if slot in slot_owners:
-                    raise ValueError(
-                        f"Duplicate occupied slot {slot}: claimed by both "
-                        f"{slot_owners[slot]!r} and {identity_key!r}"
-                    )
-                slot_owners[slot] = identity_key
-
+        """Load cache-only mappings without creating assignment fences."""
         self._persisted_mappings = {k: dict(v) for k, v in mappings.items()}
-
-        self._pending_clear_slots = {}
-        for identity_key, mapping in mappings.items():
-            if mapping.get("status") == SLOT_STATUS_PENDING_CLEAR:
-                slot = mapping.get("slot")
-                if slot is not None:
-                    operation_id = mapping.get("operation_id")
-                    self._pending_clear_slots[slot] = (
-                        operation_id if operation_id is not None else identity_key
-                    )
 
     def update_actual_state(self, slot: int, state: dict[str, Any]) -> None:
         """Store the observed Keymaster state snapshot for a slot.
@@ -462,6 +429,110 @@ class EventOverrides:
             The cached state dict, or ``None`` if not yet observed.
         """
         return self._actual_state_cache.get(slot)
+
+    @staticmethod
+    def _slot_confirmed_empty(coordinator: Any, slot: int) -> bool:
+        """Return whether a fresh Keymaster read shows blank name and PIN."""
+        lockname = getattr(coordinator, "lockname", None)
+        hass = getattr(coordinator, "hass", None)
+        if not lockname or hass is None:
+            return False
+        name_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_name")
+        pin_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_pin")
+        if name_state is None or pin_state is None:
+            return False
+        return is_cleared_keymaster_text_state(
+            name_state.state
+        ) and is_cleared_keymaster_text_state(pin_state.state)
+
+    @staticmethod
+    def _fresh_slot_text_states(coordinator: Any, slot: int) -> tuple[Any, Any] | None:
+        """Return a fresh physical Keymaster name/PIN read for *slot*."""
+        lockname = getattr(coordinator, "lockname", None)
+        hass = getattr(coordinator, "hass", None)
+        if not lockname or hass is None:
+            return None
+        name_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_name")
+        pin_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_pin")
+        if name_state is None or pin_state is None:
+            return None
+        return name_state.state, pin_state.state
+
+    def _preflight_clear_result(
+        self,
+        coordinator: Any,
+        slot: int,
+        expected_name: str | None,
+    ) -> OperationResult | None:
+        """Abort stale clear actions when the physical slot changed after plan."""
+        fresh = self._fresh_slot_text_states(coordinator, slot)
+        if fresh is None:
+            _LOGGER.warning(
+                "Skipping clear for slot %d because a fresh Keymaster read failed",
+                slot,
+            )
+            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
+
+        fresh_name, fresh_pin = fresh
+        if not isinstance(fresh_name, (str, type(None))) or not isinstance(
+            fresh_pin, (str, type(None))
+        ):
+            _LOGGER.debug(
+                "Skipping clear preflight for slot %d because Keymaster text "
+                "states are not concrete strings",
+                slot,
+            )
+            return None
+
+        if is_unreadable_keymaster_text_state(
+            fresh_name
+        ) or is_unreadable_keymaster_text_state(fresh_pin):
+            _LOGGER.warning(
+                "Skipping clear for slot %d because a fresh Keymaster read is unreadable",
+                slot,
+            )
+            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
+
+        fresh_empty = is_cleared_keymaster_text_state(
+            fresh_name
+        ) and is_cleared_keymaster_text_state(fresh_pin)
+        if fresh_empty:
+            self.release_pending_clear_slot(slot)
+            return OperationResult(kind="clear", slot=slot, confirmed=True)
+
+        actual = self._actual_state_cache.get(slot) or {}
+        planned_name = (
+            actual.get("name_state") if "name_state" in actual else expected_name
+        )
+        planned_has_code = actual.get("has_code")
+        fresh_name_text = "" if fresh_name is None else str(fresh_name)
+        fresh_has_code = not is_cleared_keymaster_text_state(fresh_pin)
+
+        if planned_name:
+            if not _states_match(str(planned_name), fresh_name_text):
+                _LOGGER.warning(
+                    "Skipping clear for slot %d because physical name changed "
+                    "after planning",
+                    slot,
+                )
+                return OperationResult(kind="clear", slot=slot, unconfirmed=True)
+        elif not is_cleared_keymaster_text_state(fresh_name):
+            _LOGGER.warning(
+                "Skipping clear for slot %d because physical name appeared "
+                "after planning",
+                slot,
+            )
+            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
+
+        if isinstance(planned_has_code, bool) and planned_has_code != fresh_has_code:
+            _LOGGER.warning(
+                "Skipping clear for slot %d because physical PIN presence changed "
+                "after planning",
+                slot,
+            )
+            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
+
+        return None
 
     def release_pending_clear_slot(self, slot: int) -> None:
         """Release a pending-clear fence after observing an empty slot.
@@ -882,7 +953,11 @@ class EventOverrides:
                 slot = action.slot
                 identity_key = action.identity_key
 
-                if action.kind in {ActionKind.CLEAR, ActionKind.RETRY_CLEAR}:
+                if action.kind in {
+                    ActionKind.CLEAR,
+                    ActionKind.RETRY_CLEAR,
+                    ActionKind.RESET,
+                }:
                     _clear_reason = action.reason
                     clear_warning = None
                     if _clear_reason is not None:
@@ -909,8 +984,10 @@ class EventOverrides:
                             clear_warning,
                             slot,
                         )
-                    result = await self._apply_clear(coordinator, slot)
-                elif action.kind is ActionKind.SET:
+                    result = await self._apply_clear(
+                        coordinator, slot, preflight_read=action.preflight_read
+                    )
+                elif action.kind in {ActionKind.SET, ActionKind.ASSIGN}:
                     res = res_by_key.get(identity_key) if identity_key else None
                     if res is None:
                         _LOGGER.warning(
@@ -928,7 +1005,10 @@ class EventOverrides:
                         )
                         continue
                     result = await self._apply_update_times(coordinator, slot, res)
-                elif action.kind is ActionKind.OVERWRITE_MANUAL_CHANGE:
+                elif action.kind in {
+                    ActionKind.OVERWRITE_MANUAL_CHANGE,
+                    ActionKind.UPDATE_IN_PLACE,
+                }:
                     res = res_by_key.get(identity_key) if identity_key else None
                     if res is None:
                         _LOGGER.warning(
@@ -955,6 +1035,8 @@ class EventOverrides:
         self,
         coordinator: Any,
         slot: int,
+        *,
+        preflight_read: bool = False,
     ) -> OperationResult:
         """Apply a CLEAR or RETRY_CLEAR action for one slot."""
         operation_id = str(uuid.uuid4())
@@ -966,6 +1048,16 @@ class EventOverrides:
             override = self._overrides.get(slot)
             if override is not None:
                 expected_name = override.get("slot_name")
+
+        if preflight_read:
+            preflight_result = self._preflight_clear_result(
+                coordinator, slot, expected_name
+            )
+            if preflight_result is not None:
+                async with self._lock:
+                    self._pending_fences.pop(slot, None)
+                    self._pending_clear_slots.pop(slot, None)
+                return preflight_result
 
         result = await async_fire_clear_code(
             coordinator, slot, expected_name=expected_name
@@ -1031,6 +1123,15 @@ class EventOverrides:
     ) -> OperationResult:
         """Apply a SET action for one slot."""
         import hashlib as _hashlib
+
+        if not self._slot_confirmed_empty(coordinator, slot):
+            self._record_slot_error(slot, "slot not confirmed empty before set")
+            return OperationResult(
+                kind="set",
+                slot=slot,
+                unconfirmed=True,
+                error="slot not confirmed empty",
+            )
 
         operation_id = (
             f"{plan_id}-set-{slot}-"
@@ -1178,8 +1279,6 @@ class EventOverrides:
             An :class:`~.util.OperationResult` from the underlying
             :func:`~.util.async_fire_set_code` call.
         """
-        import hashlib as _hashlib
-
         drift_fields: list[str] = []
         if action.reason and action.reason.startswith("drifted fields: "):
             drift_fields = [
@@ -1212,81 +1311,17 @@ class EventOverrides:
             observed_has_code,
         )
 
-        operation_id = (
-            f"overwrite-{slot}-"
-            f"{_hashlib.sha256(res.identity_key.encode()).hexdigest()[:8]}"
+        clear_result = await self._apply_clear(
+            coordinator, slot, preflight_read=action.preflight_read
         )
-
-        async with self._lock:
-            self._pending_fences[slot] = operation_id
-            self._overrides[slot] = {
-                "slot_name": res.slot_name,
-                "slot_code": res.slot_code,
-                "start_time": res.buffered_start,
-                "end_time": res.buffered_end,
-            }
-            self._slot_miss_counts.pop(slot, None)
-            self.suppress_state_changes(
+        if not clear_result.confirmed:
+            _LOGGER.warning(
+                "Skipping replacement set for slot %d because clear was not "
+                "physically confirmed",
                 slot,
-                {
-                    f"switch.{coordinator.lockname}_code_slot_"
-                    f"{slot}_use_date_range_limits": "on",
-                    f"text.{coordinator.lockname}_code_slot_{slot}_name": (
-                        res.display_slot_name
-                    ),
-                    f"text.{coordinator.lockname}_code_slot_{slot}_pin": res.slot_code,
-                    f"datetime.{coordinator.lockname}_code_slot_"
-                    f"{slot}_date_range_start": res.buffered_start.isoformat(),
-                    f"datetime.{coordinator.lockname}_code_slot_"
-                    f"{slot}_date_range_end": res.buffered_end.isoformat(),
-                },
             )
-
-        event = _SlotEvent(
-            slot_name=res.slot_name,
-            slot_code=res.slot_code,
-            start=res.start,
-            end=res.end,
-        )
-        result = await async_fire_set_code(coordinator, event, slot)
-
-        async with self._lock:
-            current_token = self._pending_fences.get(slot)
-            if current_token != operation_id:
-                _LOGGER.warning(
-                    "Stale overwrite token for slot %d; discarding result", slot
-                )
-                return OperationResult(kind="set", slot=slot, unconfirmed=True)
-
-            if result.confirmed:
-                _LOGGER.debug(
-                    "Overwrite confirmed for slot %d; desired state restored "
-                    "for reservation %s.",
-                    slot,
-                    res.identity_key,
-                )
-                self._pending_fences.pop(slot, None)
-                self._clear_slot_error(slot)
-                # NOTE: __assign_next_slot() is intentionally NOT called here.
-                # Slot selection in the reconciliation path is determined by
-                # compute_desired_plan(), not by the deprecated _next_slot field.
-            elif result.failed:
-                _LOGGER.warning(
-                    "Overwrite failed for slot %d (error: %s); "
-                    "slot may remain drifted.",
-                    slot,
-                    result.error,
-                )
-                self._pending_fences.pop(slot, None)
-                self._record_slot_error(slot, result.error or "overwrite failed")
-            else:
-                _LOGGER.debug(
-                    "Overwrite unconfirmed for slot %d; keeping tentative assignment.",
-                    slot,
-                )
-                self._pending_fences.pop(slot, None)
-
-        return result
+            return clear_result
+        return await self._apply_set(coordinator, slot, res, f"replace-{slot}")
 
     def _slot_has_matching_event(
         self,

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -482,7 +482,7 @@ class EventOverrides:
                 "states are not concrete strings",
                 slot,
             )
-            return None
+            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
 
         if is_unreadable_keymaster_text_state(
             fresh_name

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -1321,7 +1321,12 @@ class EventOverrides:
                 slot,
             )
             return clear_result
-        return await self._apply_set(coordinator, slot, res, f"replace-{slot}")
+        return await self._apply_set(
+            coordinator,
+            slot,
+            res,
+            f"replace-{slot}-{uuid.uuid4()}",
+        )
 
     def _slot_has_matching_event(
         self,

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -1981,23 +1981,37 @@ def compute_desired_plan(
         pairs: list[tuple[ManagedSlot, Reservation]] = []
         paired_slots: set[int] = set()
         paired_reservations: set[str] = set()
-        for res in desired_group:
-            exact_matches = [
-                ms
+        complete_known_duplicate_group = (
+            len(desired_group) > 1
+            and len(physical_group) >= len(desired_group)
+            and all(
+                ms.actual_start is not None and ms.actual_end is not None
                 for ms in physical_group
-                if ms.slot not in paired_slots
-                and _slot_times_match(
-                    ms.actual_start,
-                    ms.actual_end,
-                    res.buffered_start,
-                    res.buffered_end,
-                )
-            ]
-            if exact_matches:
-                ms = exact_matches[0]
+            )
+        )
+        if complete_known_duplicate_group:
+            for ms, res in zip(physical_group, desired_group, strict=False):
                 pairs.append((ms, res))
                 paired_slots.add(ms.slot)
                 paired_reservations.add(res.identity_key)
+        else:
+            for res in desired_group:
+                exact_matches = [
+                    ms
+                    for ms in physical_group
+                    if ms.slot not in paired_slots
+                    and _slot_times_match(
+                        ms.actual_start,
+                        ms.actual_end,
+                        res.buffered_start,
+                        res.buffered_end,
+                    )
+                ]
+                if exact_matches:
+                    ms = exact_matches[0]
+                    pairs.append((ms, res))
+                    paired_slots.add(ms.slot)
+                    paired_reservations.add(res.identity_key)
         remaining_physical = [
             ms for ms in physical_group if ms.slot not in paired_slots
         ]
@@ -2225,7 +2239,8 @@ def compute_stateless_plan(
         physical_group = [
             slot
             for slot in occupied
-            if _names_match(
+            if slot.slot not in slot_to_desired
+            and _names_match(
                 slot.raw_name,
                 group[0].stable_slot_name,
                 group[0].display_slot_name,
@@ -2241,23 +2256,37 @@ def compute_stateless_plan(
         pairs: list[tuple[ObservedSlot, DesiredReservation]] = []
         paired_slots: set[int] = set()
         paired_desired: set[str] = set()
-        for desired in group:
-            exact_matches = [
-                slot
+        complete_known_duplicate_group = (
+            len(group) > 1
+            and len(physical_group) >= len(group)
+            and all(
+                slot.actual_start is not None and slot.actual_end is not None
                 for slot in physical_group
-                if slot.slot not in paired_slots
-                and _slot_times_match(
-                    slot.actual_start,
-                    slot.actual_end,
-                    desired.buffered_start,
-                    desired.buffered_end,
-                )
-            ]
-            if exact_matches:
-                slot = exact_matches[0]
+            )
+        )
+        if complete_known_duplicate_group:
+            for slot, desired in zip(physical_group, group, strict=False):
                 pairs.append((slot, desired))
                 paired_slots.add(slot.slot)
                 paired_desired.add(desired.desired_id)
+        else:
+            for desired in group:
+                exact_matches = [
+                    slot
+                    for slot in physical_group
+                    if slot.slot not in paired_slots
+                    and _slot_times_match(
+                        slot.actual_start,
+                        slot.actual_end,
+                        desired.buffered_start,
+                        desired.buffered_end,
+                    )
+                ]
+                if exact_matches:
+                    slot = exact_matches[0]
+                    pairs.append((slot, desired))
+                    paired_slots.add(slot.slot)
+                    paired_desired.add(desired.desired_id)
         remaining_physical = [
             slot for slot in physical_group if slot.slot not in paired_slots
         ]

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -2073,9 +2073,8 @@ def compute_desired_plan(
     matched_slots: dict[int, str] = {}
     matched_reservations: set[str] = set()
     duplicate_slots: set[int] = set()
-    ambiguous_slots: set[int] = set()
 
-    for name_key, desired_group in selected_by_name.items():
+    for desired_group in selected_by_name.values():
         physical_group = [
             ms
             for ms in occupied_slots
@@ -2101,19 +2100,6 @@ def compute_desired_plan(
                 ms.slot,
             )
         )
-        if (
-            len(
-                {
-                    normalize_slot_name_for_fingerprint(r.slot_name)
-                    for r in desired_group
-                }
-            )
-            > 1
-        ):
-            for ms in physical_group:
-                ambiguous_slots.add(ms.slot)
-            plan.diagnostics.setdefault("ambiguous_name_groups", []).append(name_key)
-            continue
         extra_physical_group: list[ManagedSlot] = []
         if len(desired_group) > 1 and len(physical_group) > len(desired_group):
             canonical_physical = _select_managed_subset(physical_group, desired_group)
@@ -2233,10 +2219,7 @@ def compute_desired_plan(
         action = ActionKind.NOOP
         reason: str | None = None
 
-        if ms.slot in ambiguous_slots:
-            action = ActionKind.BLOCKED
-            pending_reason = "ambiguous_name_group"
-        elif ms.status is SlotStatus.PENDING_CLEAR:
+        if ms.status is SlotStatus.PENDING_CLEAR:
             if ms.persisted_identity_key in plan.protected:
                 action = ActionKind.BLOCKED
                 pending_reason = "protected_active_pending_clear"

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -387,12 +387,14 @@ class ObservedSlot:
         ):
             self.readable = False
             self.empty_confirmed = False
+        if name_present or self.has_pin:
+            self.empty_confirmed = False
         if not self.managed:
             self.classification = ObservedSlotStatus.UNKNOWN
         elif not self.readable:
             self.classification = ObservedSlotStatus.UNKNOWN
             self.empty_confirmed = False
-        elif self.empty_confirmed:
+        elif self.empty_confirmed and not name_present and not self.has_pin:
             self.classification = ObservedSlotStatus.EMPTY
         elif name_present and self.has_pin:
             self.classification = ObservedSlotStatus.OCCUPIED

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -878,6 +878,64 @@ def _select_observed_subset(
     return [slots[index] for index in indices]
 
 
+def _pair_partial_managed(
+    slots: list[ManagedSlot], desired: list[Reservation]
+) -> list[tuple[ManagedSlot, Reservation]]:
+    """Pair fewer managed slots to the best ordered desired reservations."""
+
+    @lru_cache
+    def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
+        """Return best desired indices for remaining managed slots."""
+        if slot_index == len(slots):
+            return 0.0, ()
+        if desired_index == len(desired):
+            return float("inf"), ()
+        skip_cost, skip_indices = _best(slot_index, desired_index + 1)
+        take_rest_cost, take_indices = _best(slot_index + 1, desired_index + 1)
+        take_cost = (
+            _managed_slot_distance(slots[slot_index], desired[desired_index])
+            + take_rest_cost
+        )
+        if take_cost < skip_cost:
+            return take_cost, (desired_index, *take_indices)
+        return skip_cost, skip_indices
+
+    _, desired_indices = _best(0, 0)
+    return [
+        (slots[slot_index], desired[desired_index])
+        for slot_index, desired_index in enumerate(desired_indices)
+    ]
+
+
+def _pair_partial_observed(
+    slots: list[ObservedSlot], desired: list[DesiredReservation]
+) -> list[tuple[ObservedSlot, DesiredReservation]]:
+    """Pair fewer observed slots to the best ordered desired reservations."""
+
+    @lru_cache
+    def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
+        """Return best desired indices for remaining observed slots."""
+        if slot_index == len(slots):
+            return 0.0, ()
+        if desired_index == len(desired):
+            return float("inf"), ()
+        skip_cost, skip_indices = _best(slot_index, desired_index + 1)
+        take_rest_cost, take_indices = _best(slot_index + 1, desired_index + 1)
+        take_cost = (
+            _observed_slot_distance(slots[slot_index], desired[desired_index])
+            + take_rest_cost
+        )
+        if take_cost < skip_cost:
+            return take_cost, (desired_index, *take_indices)
+        return skip_cost, skip_indices
+
+    _, desired_indices = _best(0, 0)
+    return [
+        (slots[slot_index], desired[desired_index])
+        for slot_index, desired_index in enumerate(desired_indices)
+    ]
+
+
 def _dt_to_utc_iso(dt: datetime) -> str:
     """Convert *dt* to a UTC ISO-8601 string for fingerprint computation.
 
@@ -2113,7 +2171,10 @@ def compute_desired_plan(
                 *canonical_physical,
                 *[ms for ms in remaining_physical if ms.slot not in canonical_slots],
             ]
-        pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
+        if len(remaining_physical) < len(remaining_desired):
+            pairs.extend(_pair_partial_managed(remaining_physical, remaining_desired))
+        else:
+            pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
 
         for ms, res in pairs:
             matched_slots[ms.slot] = res.identity_key
@@ -2413,7 +2474,10 @@ def compute_stateless_plan(
                     if slot.slot not in canonical_slots
                 ],
             ]
-        pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
+        if len(remaining_physical) < len(remaining_desired):
+            pairs.extend(_pair_partial_observed(remaining_physical, remaining_desired))
+        else:
+            pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
 
         for slot, desired in pairs:
             slot.matched_desired_id = desired.desired_id

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -350,7 +350,7 @@ def _keymaster_text_cleared(value: str | None) -> bool:
     if value is None:
         return True
     text = value.strip().casefold()
-    return text == "" or text == "unknown"
+    return text in {"", "unknown", "none"}
 
 
 def _keymaster_text_unreadable(value: str | None) -> bool:
@@ -379,6 +379,7 @@ class ObservedSlot:
 
     def __post_init__(self) -> None:
         """Validate and derive normalized physical name forms."""
+        name_present = not _keymaster_text_cleared(self.raw_name)
         if self.has_pin is None and self.raw_pin is not None:
             self.has_pin = not _keymaster_text_cleared(self.raw_pin)
         if _keymaster_text_unreadable(self.raw_name) or _keymaster_text_unreadable(
@@ -393,14 +394,14 @@ class ObservedSlot:
             self.empty_confirmed = False
         elif self.empty_confirmed:
             self.classification = ObservedSlotStatus.EMPTY
-        elif self.raw_name and self.has_pin:
+        elif name_present and self.has_pin:
             self.classification = ObservedSlotStatus.OCCUPIED
-        elif self.raw_name or self.has_pin:
+        elif name_present or self.has_pin:
             self.classification = ObservedSlotStatus.PHANTOM
         else:
             self.classification = ObservedSlotStatus.EMPTY
             self.empty_confirmed = True
-        if self.raw_name:
+        if name_present and self.raw_name:
             self.normalized_name_forms.add(
                 normalize_slot_name_for_fingerprint(self.raw_name)
             )

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -53,6 +53,7 @@ from dataclasses import field
 from datetime import datetime
 from datetime import timezone
 from enum import Enum
+from functools import lru_cache
 import hashlib
 import logging
 import re
@@ -820,6 +821,58 @@ def _observed_slot_distance(slot: ObservedSlot, desired: DesiredReservation) -> 
     return _datetime_distance(
         slot.actual_start, desired.buffered_start
     ) + _datetime_distance(slot.actual_end, desired.buffered_end)
+
+
+def _select_managed_subset(
+    slots: list[ManagedSlot], desired: list[Reservation]
+) -> list[ManagedSlot]:
+    """Return the minimum-distance ordered slot subset for reservations."""
+
+    @lru_cache
+    def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
+        """Return best ordered subset cost and indices from this position."""
+        if desired_index == len(desired):
+            return 0.0, ()
+        if slot_index == len(slots):
+            return float("inf"), ()
+        skip_cost, skip_indices = _best(slot_index + 1, desired_index)
+        take_rest_cost, take_indices = _best(slot_index + 1, desired_index + 1)
+        take_cost = (
+            _managed_slot_distance(slots[slot_index], desired[desired_index])
+            + take_rest_cost
+        )
+        if take_cost < skip_cost:
+            return take_cost, (slot_index, *take_indices)
+        return skip_cost, skip_indices
+
+    _, indices = _best(0, 0)
+    return [slots[index] for index in indices]
+
+
+def _select_observed_subset(
+    slots: list[ObservedSlot], desired: list[DesiredReservation]
+) -> list[ObservedSlot]:
+    """Return the minimum-distance ordered observed subset for reservations."""
+
+    @lru_cache
+    def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
+        """Return best ordered subset cost and indices from this position."""
+        if desired_index == len(desired):
+            return 0.0, ()
+        if slot_index == len(slots):
+            return float("inf"), ()
+        skip_cost, skip_indices = _best(slot_index + 1, desired_index)
+        take_rest_cost, take_indices = _best(slot_index + 1, desired_index + 1)
+        take_cost = (
+            _observed_slot_distance(slots[slot_index], desired[desired_index])
+            + take_rest_cost
+        )
+        if take_cost < skip_cost:
+            return take_cost, (slot_index, *take_indices)
+        return skip_cost, skip_indices
+
+    _, indices = _best(0, 0)
+    return [slots[index] for index in indices]
 
 
 def _dt_to_utc_iso(dt: datetime) -> str:
@@ -2000,6 +2053,14 @@ def compute_desired_plan(
                 ambiguous_slots.add(ms.slot)
             plan.diagnostics.setdefault("ambiguous_name_groups", []).append(name_key)
             continue
+        extra_physical_group: list[ManagedSlot] = []
+        if len(desired_group) > 1 and len(physical_group) > len(desired_group):
+            canonical_physical = _select_managed_subset(physical_group, desired_group)
+            canonical_slots = {ms.slot for ms in canonical_physical}
+            extra_physical_group = [
+                ms for ms in physical_group if ms.slot not in canonical_slots
+            ]
+            physical_group = canonical_physical
         pairs: list[tuple[ManagedSlot, Reservation]] = []
         paired_slots: set[int] = set()
         paired_reservations: set[str] = set()
@@ -2041,14 +2102,14 @@ def compute_desired_plan(
             res for res in desired_group if res.identity_key not in paired_reservations
         ]
         if len(remaining_physical) > len(remaining_desired) and remaining_desired:
-            remaining_physical.sort(
-                key=lambda ms: (
-                    min(_managed_slot_distance(ms, res) for res in remaining_desired),
-                    ms.actual_start or datetime.max.replace(tzinfo=timezone.utc),
-                    ms.actual_end or datetime.max.replace(tzinfo=timezone.utc),
-                    ms.slot,
-                )
+            canonical_physical = _select_managed_subset(
+                remaining_physical, remaining_desired
             )
+            canonical_slots = {ms.slot for ms in canonical_physical}
+            remaining_physical = [
+                *canonical_physical,
+                *[ms for ms in remaining_physical if ms.slot not in canonical_slots],
+            ]
         pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
 
         for ms, res in pairs:
@@ -2060,7 +2121,10 @@ def compute_desired_plan(
                 "identity_key": res.identity_key,
                 "slot_name": res.slot_name,
             }
-        for extra_ms in remaining_physical[len(remaining_desired) :]:
+        for extra_ms in [
+            *remaining_physical[len(remaining_desired) :],
+            *extra_physical_group,
+        ]:
             duplicate_slots.add(extra_ms.slot)
             _LOGGER.warning(
                 "Duplicate physical slot-name match for %s in slot %d; "
@@ -2285,6 +2349,14 @@ def compute_stateless_plan(
                 slot.slot,
             )
         )
+        extra_physical_group: list[ObservedSlot] = []
+        if len(group) > 1 and len(physical_group) > len(group):
+            canonical_physical = _select_observed_subset(physical_group, group)
+            canonical_slots = {slot.slot for slot in canonical_physical}
+            extra_physical_group = [
+                slot for slot in physical_group if slot.slot not in canonical_slots
+            ]
+            physical_group = canonical_physical
         pairs: list[tuple[ObservedSlot, DesiredReservation]] = []
         paired_slots: set[int] = set()
         paired_desired: set[str] = set()
@@ -2326,17 +2398,18 @@ def compute_stateless_plan(
             desired for desired in group if desired.desired_id not in paired_desired
         ]
         if len(remaining_physical) > len(remaining_desired) and remaining_desired:
-            remaining_physical.sort(
-                key=lambda slot: (
-                    min(
-                        _observed_slot_distance(slot, desired)
-                        for desired in remaining_desired
-                    ),
-                    slot.actual_start or datetime.max.replace(tzinfo=timezone.utc),
-                    slot.actual_end or datetime.max.replace(tzinfo=timezone.utc),
-                    slot.slot,
-                )
+            canonical_physical = _select_observed_subset(
+                remaining_physical, remaining_desired
             )
+            canonical_slots = {slot.slot for slot in canonical_physical}
+            remaining_physical = [
+                *canonical_physical,
+                *[
+                    slot
+                    for slot in remaining_physical
+                    if slot.slot not in canonical_slots
+                ],
+            ]
         pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
 
         for slot, desired in pairs:
@@ -2346,7 +2419,10 @@ def compute_stateless_plan(
             slot_to_desired[slot.slot] = desired.desired_id
             matched_desired.add(desired.desired_id)
             plan.selected[desired.desired_id] = slot.slot
-        for extra_slot in remaining_physical[len(remaining_desired) :]:
+        for extra_slot in [
+            *remaining_physical[len(remaining_desired) :],
+            *extra_physical_group,
+        ]:
             duplicate_slots.add(extra_slot.slot)
 
     free_slots = sorted(

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -831,7 +831,7 @@ def _select_managed_subset(
 ) -> list[ManagedSlot]:
     """Return the minimum-distance ordered slot subset for reservations."""
 
-    @lru_cache
+    @lru_cache(maxsize=None)
     def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
         """Return best ordered subset cost and indices from this position."""
         if desired_index == len(desired):
@@ -857,7 +857,7 @@ def _select_observed_subset(
 ) -> list[ObservedSlot]:
     """Return the minimum-distance ordered observed subset for reservations."""
 
-    @lru_cache
+    @lru_cache(maxsize=None)
     def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
         """Return best ordered subset cost and indices from this position."""
         if desired_index == len(desired):
@@ -883,7 +883,7 @@ def _pair_partial_managed(
 ) -> list[tuple[ManagedSlot, Reservation]]:
     """Pair fewer managed slots to the best ordered desired reservations."""
 
-    @lru_cache
+    @lru_cache(maxsize=None)
     def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
         """Return best desired indices for remaining managed slots."""
         if slot_index == len(slots):
@@ -912,7 +912,7 @@ def _pair_partial_observed(
 ) -> list[tuple[ObservedSlot, DesiredReservation]]:
     """Pair fewer observed slots to the best ordered desired reservations."""
 
-    @lru_cache
+    @lru_cache(maxsize=None)
     def _best(slot_index: int, desired_index: int) -> tuple[float, tuple[int, ...]]:
         """Return best desired indices for remaining observed slots."""
         if slot_index == len(slots):

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -345,6 +345,19 @@ class ManagedSlot:
     last_error: str | None = None
 
 
+def _keymaster_text_cleared(value: str | None) -> bool:
+    """Return whether a Keymaster text state represents a cleared value."""
+    if value is None:
+        return True
+    text = value.strip().casefold()
+    return text == "" or text == "unknown"
+
+
+def _keymaster_text_unreadable(value: str | None) -> bool:
+    """Return whether a Keymaster text state is unreadable."""
+    return value is not None and value.strip().casefold() == "unavailable"
+
+
 @dataclass(slots=True)
 class ObservedSlot:
     """Physical Keymaster slot facts read during one stateless refresh."""
@@ -366,6 +379,13 @@ class ObservedSlot:
 
     def __post_init__(self) -> None:
         """Validate and derive normalized physical name forms."""
+        if self.has_pin is None and self.raw_pin is not None:
+            self.has_pin = not _keymaster_text_cleared(self.raw_pin)
+        if _keymaster_text_unreadable(self.raw_name) or _keymaster_text_unreadable(
+            self.raw_pin
+        ):
+            self.readable = False
+            self.empty_confirmed = False
         if not self.managed:
             self.classification = ObservedSlotStatus.UNKNOWN
         elif not self.readable:

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -103,6 +103,15 @@ class SlotStatus(str, Enum):
     UNKNOWN = "unknown"
 
 
+class ObservedSlotStatus(str, Enum):
+    """Stateless physical classification for an observed Keymaster slot."""
+
+    EMPTY = "empty"
+    OCCUPIED = "occupied"
+    PHANTOM = "phantom"
+    UNKNOWN = "unknown"
+
+
 class ActionKind(str, Enum):
     """Reconciliation action type for one managed Keymaster slot.
 
@@ -113,6 +122,15 @@ class ActionKind(str, Enum):
 
     NOOP = "noop"
     """Actual already matches desired; no Keymaster service call needed."""
+
+    ASSIGN = "assign"
+    """Stateless action: write a desired reservation to a confirmed-empty slot."""
+
+    UPDATE_IN_PLACE = "update_in_place"
+    """Stateless action: update an existing name-matched physical slot."""
+
+    RESET = "reset"
+    """Stateless action: clear a stale, duplicate, or phantom physical slot."""
 
     SET = "set"
     """Slot is confirmed free; write name, code, and date range."""
@@ -156,6 +174,12 @@ class SlotAction:
     slot: int
     identity_key: str | None = None
     reason: str | None = None
+    desired_id: str | None = None
+    matched_by: str | None = None
+    requires_confirmed_empty: bool = False
+    sequence: list[str] = field(default_factory=list)
+    preflight_read: bool = False
+    blocked_reason: str | None = None
 
 
 @dataclass(slots=True)
@@ -230,6 +254,8 @@ class Reservation:
     missing_count: int = 0
     desired_slot: int | None = None
     overflow_reason: str | None = None
+    sensor_lookup_keys: set[str] = field(default_factory=set)
+    code_source: str = "generated"
 
     def __post_init__(self) -> None:
         """Validate Reservation field invariants.
@@ -303,6 +329,7 @@ class ManagedSlot:
     managed: bool
     status: SlotStatus = SlotStatus.UNKNOWN
     actual_name: str | None = None
+    actual_code: str | None = field(default=None, repr=False)
     actual_code_present: bool | None = None
     actual_start: datetime | None = None
     actual_end: datetime | None = None
@@ -316,6 +343,112 @@ class ManagedSlot:
     last_operation_id: str | None = None
     dirty_during_operation: bool = False
     last_error: str | None = None
+
+
+@dataclass(slots=True)
+class ObservedSlot:
+    """Physical Keymaster slot facts read during one stateless refresh."""
+
+    slot: int
+    managed: bool
+    raw_name: str | None = None
+    raw_pin: str | None = field(default=None, repr=False)
+    has_pin: bool | None = None
+    actual_start: datetime | None = None
+    actual_end: datetime | None = None
+    date_range_enabled: bool | None = None
+    enabled: bool | None = None
+    readable: bool = True
+    empty_confirmed: bool = False
+    classification: ObservedSlotStatus = ObservedSlotStatus.UNKNOWN
+    normalized_name_forms: set[str] = field(default_factory=set)
+    matched_desired_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate and derive normalized physical name forms."""
+        if not self.managed:
+            self.classification = ObservedSlotStatus.UNKNOWN
+        elif not self.readable:
+            self.classification = ObservedSlotStatus.UNKNOWN
+            self.empty_confirmed = False
+        elif self.empty_confirmed:
+            self.classification = ObservedSlotStatus.EMPTY
+        elif self.raw_name and self.has_pin:
+            self.classification = ObservedSlotStatus.OCCUPIED
+        elif self.raw_name or self.has_pin:
+            self.classification = ObservedSlotStatus.PHANTOM
+        else:
+            self.classification = ObservedSlotStatus.EMPTY
+            self.empty_confirmed = True
+        if self.raw_name:
+            self.normalized_name_forms.add(
+                normalize_slot_name_for_fingerprint(self.raw_name)
+            )
+
+
+@dataclass(slots=True)
+class DesiredReservation:
+    """Calendar reservation facts used by the stateless planner."""
+
+    desired_id: str
+    stable_slot_name: str
+    display_slot_name: str
+    start: datetime
+    end: datetime
+    buffered_start: datetime
+    buffered_end: datetime
+    slot_code: str = field(repr=False)
+    code_source: str = "generated"
+    event_uid: str | None = None
+    booking_aliases: set[str] = field(default_factory=set)
+    eligible: bool = True
+    protected_active: bool = False
+    checked_out: bool = False
+    selected_rank: int | None = None
+    matched_slot: int | None = None
+    assigned_slot: int | None = None
+    sensor_lookup_keys: set[str] = field(default_factory=set)
+    physical_time_override: tuple[datetime, datetime] | None = None
+    overflow_reason: str | None = None
+    normalized_name_forms: set[str] = field(default_factory=set)
+
+    def __post_init__(self) -> None:
+        """Validate desired reservation invariants and name forms."""
+        if self.start >= self.end:
+            raise ValueError(
+                f"DesiredReservation start must be strictly before end: "
+                f"{self.start!r} >= {self.end!r}"
+            )
+        self.normalized_name_forms.update(
+            _desired_name_forms(self.stable_slot_name, self.display_slot_name)
+        )
+
+
+@dataclass(slots=True)
+class StatelessPlan:
+    """Refresh-local stateless physical slot reconciliation result."""
+
+    plan_id: str
+    generated_at: datetime
+    observed_slots: dict[int, ObservedSlot] = field(default_factory=dict)
+    desired_reservations: dict[str, DesiredReservation] = field(default_factory=dict)
+    selected: dict[str, int] = field(default_factory=dict)
+    overflow: dict[str, str] = field(default_factory=dict)
+    actions: list[SlotAction] = field(default_factory=list)
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class CacheOnlyStoreRecord:
+    """Cache-only Store payload metadata; never authoritative for planning."""
+
+    schema_version: int
+    entry_id: str
+    lockname: str | None = None
+    updated_at: str | None = None
+    aliases: dict[str, Any] = field(default_factory=dict)
+    last_plan: dict[str, Any] = field(default_factory=dict)
+    migration_notes: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -583,6 +716,61 @@ def normalize_slot_name_for_fingerprint(slot_name: str) -> str:
         Casefold-normalized, stripped slot name.
     """
     return slot_name.strip().casefold()
+
+
+def _desired_name_forms(
+    slot_name: str, display_slot_name: str | None = None
+) -> set[str]:
+    """Return normalized stable/display forms for stateless name matching."""
+    forms = {normalize_slot_name_for_fingerprint(slot_name)}
+    if display_slot_name:
+        forms.add(normalize_slot_name_for_fingerprint(display_slot_name))
+    return {form for form in forms if form}
+
+
+def _slot_name_variants(name: str, *, prefix: str = "") -> set[str]:
+    """Return normalized physical name variants, including prefix-stripped form."""
+    stripped = name.strip()
+    variants = {normalize_slot_name_for_fingerprint(stripped)}
+    if prefix and stripped.startswith(prefix):
+        variants.add(normalize_slot_name_for_fingerprint(stripped[len(prefix) :]))
+    return {variant for variant in variants if variant}
+
+
+def _names_match(
+    physical_name: str | None,
+    stable_slot_name: str,
+    display_slot_name: str | None = None,
+    *,
+    prefix: str = "",
+) -> bool:
+    """Return whether a physical Keymaster name identifies a desired stay."""
+    if not physical_name:
+        return False
+    physical_forms = _slot_name_variants(physical_name, prefix=prefix)
+    desired_forms = _desired_name_forms(stable_slot_name, display_slot_name)
+    if physical_forms & desired_forms:
+        return True
+    # Conservative trim-aware fallback: an observed display name may be a
+    # shortened form of the stable name.  Require it to be a prefix-like
+    # reduction to avoid matching unrelated names.
+    for actual in physical_forms:
+        for desired in desired_forms:
+            if actual != desired and (
+                desired.startswith(actual) or actual.startswith(desired)
+            ):
+                return True
+    return False
+
+
+def _reservation_name_key(reservation: Reservation) -> str:
+    """Return the stable name grouping key for a legacy Reservation."""
+    return normalize_slot_name_for_fingerprint(reservation.slot_name)
+
+
+def _desired_name_key(reservation: DesiredReservation) -> str:
+    """Return the stable name grouping key for a DesiredReservation."""
+    return normalize_slot_name_for_fingerprint(reservation.stable_slot_name)
 
 
 def _dt_to_utc_iso(dt: datetime) -> str:
@@ -1691,48 +1879,12 @@ def compute_desired_plan(
     protected, selected_np, overflow_list, remaining_capacity = _select_candidates(
         eligible, max_events
     )
-    plan.protected = {r.identity_key for r in protected}
-
-    assigned: dict[int, str] = {}
-    free_slot_numbers: list[int] = sorted(
-        ms.slot for ms in managed_slots if ms.managed and ms.status is SlotStatus.FREE
+    selected_reservations = sorted(
+        [*protected, *selected_np],
+        key=lambda r: (0 if r.protected_active else 1, r.start, r.identity_key),
     )
-
-    def _try_assign(res: Reservation) -> bool:
-        """Try to assign *res* to its persisted slot or the lowest free slot."""
-        persisted = _find_persisted_slot_for_reservation(
-            managed_slots, res.identity_key
-        )
-        if (
-            persisted is not None
-            and _is_slot_assignable(persisted)
-            and persisted.slot not in assigned
-        ):
-            assigned[persisted.slot] = res.identity_key
-            if persisted.slot in free_slot_numbers:
-                free_slot_numbers.remove(persisted.slot)
-            return True
-        if free_slot_numbers:
-            assigned[free_slot_numbers.pop(0)] = res.identity_key
-            return True
-        return False
-
-    for res in protected:
-        if not _try_assign(res):
-            plan.diagnostics.setdefault("protected_capacity_violations", []).append(
-                res.identity_key
-            )
-
-    for res in selected_np:
-        if not _try_assign(res):
-            plan.overflow[res.identity_key] = "no_free_slot"
-            _LOGGER.warning(
-                "Overflow: reservation %s selected but no free managed slot available",
-                res.identity_key,
-            )
-
-    for slot_num, ikey in assigned.items():
-        plan.selected[ikey] = slot_num
+    plan.protected = {r.identity_key for r in protected}
+    res_by_key: dict[str, Reservation] = {r.identity_key: r for r in reservations}
 
     for rank_offset, res in enumerate(overflow_list):
         plan.overflow[res.identity_key] = "capacity"
@@ -1743,79 +1895,208 @@ def compute_desired_plan(
             "identity_key": res.identity_key,
         }
 
-    slot_to_identity: dict[int, str] = {v: k for k, v in plan.selected.items()}
-    res_by_key: dict[str, Reservation] = {r.identity_key: r for r in reservations}
+    managed_by_slot = {ms.slot: ms for ms in managed_slots if ms.managed}
+    occupied_slots = [
+        ms
+        for ms in managed_by_slot.values()
+        if ms.status in {SlotStatus.OCCUPIED, SlotStatus.PHANTOM}
+    ]
+    selected_by_name: dict[str, list[Reservation]] = {}
+    for res in selected_reservations:
+        selected_by_name.setdefault(_reservation_name_key(res), []).append(res)
+    for group in selected_by_name.values():
+        group.sort(key=lambda r: (r.start, r.end, r.identity_key))
 
-    # Detect duplicate persisted assignments: same identity key in multiple OCCUPIED
-    # managed slots.  The canonical slot is the lowest-numbered one.  All others are
-    # non-canonical and will be cleared.
-    _persisted_to_slots: dict[str, list[int]] = {}
-    for _ms in managed_slots:
-        if (
-            _ms.managed
-            and _ms.persisted_identity_key is not None
-            and _ms.status is SlotStatus.OCCUPIED
-        ):
-            _persisted_to_slots.setdefault(_ms.persisted_identity_key, []).append(
-                _ms.slot
-            )
-    _non_canonical_slots: set[int] = set()
-    for _dup_key, _dup_slots in _persisted_to_slots.items():
-        if len(_dup_slots) > 1:
-            _canonical = min(_dup_slots)
-            _non_canonical = [s for s in _dup_slots if s != _canonical]
-            _non_canonical_slots.update(_non_canonical)
-            _LOGGER.warning(
-                "Duplicate assignment: identity %s found in slots %s; "
-                "slot %d is canonical, slots %s will be cleared (duplicate collapse)",
-                _dup_key,
-                sorted(_dup_slots),
-                _canonical,
-                sorted(_non_canonical),
-            )
+    matched_slots: dict[int, str] = {}
+    matched_reservations: set[str] = set()
+    duplicate_slots: set[int] = set()
+    ambiguous_slots: set[int] = set()
 
-    for ms in sorted(managed_slots, key=lambda m: m.slot):
-        if not ms.managed:
+    for name_key, desired_group in selected_by_name.items():
+        physical_group = [
+            ms
+            for ms in occupied_slots
+            if ms.slot not in matched_slots
+            and (
+                _names_match(
+                    ms.actual_name,
+                    desired_group[0].slot_name,
+                    desired_group[0].display_slot_name,
+                )
+                or (
+                    ms.persisted_identity_key
+                    in {desired.identity_key for desired in desired_group}
+                )
+            )
+        ]
+        if not physical_group:
             continue
-        desired_key = slot_to_identity.get(ms.slot)
-        if ms.slot in _non_canonical_slots:
-            action = ActionKind.CLEAR
-            pending_reason = None
-        else:
-            action, pending_reason = _build_slot_action(ms, desired_key, res_by_key)
+        physical_group.sort(
+            key=lambda ms: (
+                ms.actual_start or datetime.max.replace(tzinfo=timezone.utc),
+                ms.slot,
+            )
+        )
         if (
-            action is ActionKind.RETRY_CLEAR
-            and ms.persisted_identity_key in plan.protected
+            len(
+                {
+                    normalize_slot_name_for_fingerprint(r.slot_name)
+                    for r in desired_group
+                }
+            )
+            > 1
         ):
+            for ms in physical_group:
+                ambiguous_slots.add(ms.slot)
+            plan.diagnostics.setdefault("ambiguous_name_groups", []).append(name_key)
+            continue
+        for ms, res in zip(physical_group, desired_group, strict=False):
+            matched_slots[ms.slot] = res.identity_key
+            matched_reservations.add(res.identity_key)
+            duplicate_slots.discard(ms.slot)
+            ms.persisted_identity_key = res.identity_key
+            plan.diagnostics.setdefault("stable_name_matches", {})[ms.slot] = {
+                "identity_key": res.identity_key,
+                "slot_name": res.slot_name,
+            }
+        for extra_ms in physical_group[len(desired_group) :]:
+            duplicate_slots.add(extra_ms.slot)
+            _LOGGER.warning(
+                "Duplicate physical slot-name match for %s in slot %d; "
+                "non-canonical duplicate will reset",
+                desired_group[0].slot_name,
+                extra_ms.slot,
+            )
+
+    free_slot_numbers: list[int] = sorted(
+        ms.slot for ms in managed_by_slot.values() if ms.status is SlotStatus.FREE
+    )
+    occupied_matched_slots = set(matched_slots)
+    for res in selected_reservations:
+        if res.identity_key in matched_reservations:
+            slot = next(
+                (
+                    slot
+                    for slot, key in matched_slots.items()
+                    if key == res.identity_key
+                ),
+                None,
+            )
+            if slot is not None:
+                plan.selected[res.identity_key] = slot
+                continue
+        if free_slot_numbers:
+            slot = free_slot_numbers.pop(0)
+            plan.selected[res.identity_key] = slot
+            matched_slots[slot] = res.identity_key
+        else:
+            plan.overflow[res.identity_key] = "no_empty_slot"
+            _LOGGER.warning(
+                "Overflow: reservation %s selected but no confirmed-empty managed "
+                "slot is available",
+                res.identity_key,
+            )
+
+    slot_to_identity: dict[int, str] = {v: k for k, v in plan.selected.items()}
+
+    for ms in sorted(managed_by_slot.values(), key=lambda m: m.slot):
+        desired_key = slot_to_identity.get(ms.slot)
+        pending_reason: str | None = None
+        action = ActionKind.NOOP
+        reason: str | None = None
+
+        if ms.slot in ambiguous_slots:
             action = ActionKind.BLOCKED
-            pending_reason = "protected_active_pending_clear"
+            pending_reason = "ambiguous_name_group"
+        elif ms.status is SlotStatus.PENDING_CLEAR:
+            if ms.persisted_identity_key in plan.protected:
+                action = ActionKind.BLOCKED
+                pending_reason = "protected_active_pending_clear"
+            else:
+                action = ActionKind.RETRY_CLEAR
+                pending_reason = ms.blocked_reason or "pending_clear"
+        elif ms.status is SlotStatus.UNKNOWN:
+            action = ActionKind.BLOCKED
+            pending_reason = ms.blocked_reason or "unreadable"
+        elif ms.status is SlotStatus.BLOCKED:
+            action = ActionKind.BLOCKED
+            pending_reason = ms.blocked_reason or "blocked"
+        elif ms.slot in duplicate_slots and ms.slot not in matched_slots:
+            action = ActionKind.CLEAR
+            reason = "duplicate_non_canonical"
+        elif desired_key is None:
+            if ms.status is SlotStatus.FREE:
+                action = ActionKind.NOOP
+            else:
+                action = ActionKind.CLEAR
+                reason = "phantom" if ms.status is SlotStatus.PHANTOM else "stale"
+        else:
+            desired_res = res_by_key.get(desired_key)
+            if ms.status is SlotStatus.FREE:
+                action = ActionKind.SET
+            elif ms.slot in occupied_matched_slots and desired_res is not None:
+                drift_fields = _compute_drift_fields(ms, desired_res)
+                code_drift = (
+                    ms.actual_code is not None
+                    and ms.actual_code != desired_res.slot_code
+                )
+                name_drift = (
+                    ms.actual_name is not None
+                    and ms.actual_name != desired_res.display_slot_name
+                )
+                non_date_drift = [
+                    field_name
+                    for field_name in drift_fields
+                    if field_name not in {"start", "end"}
+                ]
+                if code_drift or name_drift or non_date_drift:
+                    action = ActionKind.OVERWRITE_MANUAL_CHANGE
+                    fields = set(drift_fields)
+                    if code_drift:
+                        fields.add("code")
+                    if name_drift:
+                        fields.add("name")
+                    reason = "drifted fields: " + ", ".join(sorted(fields))
+                elif (ms.actual_start is not None or ms.actual_end is not None) and (
+                    ms.actual_start != desired_res.buffered_start
+                    or ms.actual_end != desired_res.buffered_end
+                ):
+                    action = ActionKind.UPDATE_TIMES
+                else:
+                    action = ActionKind.NOOP
+            else:
+                action = ActionKind.CLEAR
+                reason = "mis_assigned"
+
         ms.desired_identity_key = desired_key
         plan.slots[ms.slot] = PlannedSlot(
             slot=ms.slot,
             desired_identity_key=desired_key,
             actual_classification=ms.status.value,
             action=action,
-            pending_reason=pending_reason,
+            pending_reason=pending_reason or reason,
             retry_count=ms.retry_count,
             last_error=ms.last_error,
         )
         if action is not ActionKind.NOOP:
-            clear_reason: str | None = pending_reason
-            if action is ActionKind.CLEAR:
-                if ms.slot in _non_canonical_slots:
-                    clear_reason = "duplicate_non_canonical"
-                elif ms.status is SlotStatus.PHANTOM:
-                    clear_reason = "phantom"
-                elif ms.status is SlotStatus.OCCUPIED and desired_key is None:
-                    clear_reason = "stale"
-                elif ms.status is SlotStatus.OCCUPIED and desired_key is not None:
-                    clear_reason = "mis_assigned"
             plan.actions.append(
                 SlotAction(
                     kind=action,
                     slot=ms.slot,
                     identity_key=desired_key,
-                    reason=clear_reason,
+                    reason=reason or pending_reason,
+                    desired_id=desired_key,
+                    matched_by="name_exact"
+                    if ms.slot in occupied_matched_slots
+                    else "none",
+                    requires_confirmed_empty=action
+                    in {ActionKind.SET, ActionKind.OVERWRITE_MANUAL_CHANGE},
+                    preflight_read=action
+                    in {
+                        ActionKind.SET,
+                        ActionKind.CLEAR,
+                        ActionKind.OVERWRITE_MANUAL_CHANGE,
+                    },
                 )
             )
 
@@ -1828,4 +2109,191 @@ def compute_desired_plan(
         start_slot=start_slot,
     )
 
+    return plan
+
+
+def compute_stateless_plan(
+    observed_slots: list[ObservedSlot],
+    desired_reservations: list[DesiredReservation],
+    max_events: int,
+    plan_id: str,
+    generated_at: datetime,
+    *,
+    prefix: str = "",
+) -> StatelessPlan:
+    """Compute a pure stateless slot plan from physical slots and calendar stays."""
+    plan = StatelessPlan(plan_id=plan_id, generated_at=generated_at)
+    plan.observed_slots = {slot.slot: slot for slot in observed_slots if slot.managed}
+    plan.desired_reservations = {
+        desired.desired_id: desired for desired in desired_reservations
+    }
+
+    eligible = [
+        desired
+        for desired in desired_reservations
+        if desired.eligible and not desired.checked_out
+    ]
+    protected = sorted(
+        [desired for desired in eligible if desired.protected_active],
+        key=lambda desired: (desired.start, desired.desired_id),
+    )
+    non_protected = sorted(
+        [desired for desired in eligible if not desired.protected_active],
+        key=lambda desired: (desired.start, desired.desired_id),
+    )
+    selected = [*protected, *non_protected[: max(0, max_events - len(protected))]]
+    for rank, desired in enumerate(selected, start=1):
+        desired.selected_rank = rank
+    for desired in non_protected[max(0, max_events - len(protected)) :]:
+        desired.overflow_reason = "capacity"
+        plan.overflow[desired.desired_id] = "capacity"
+
+    selected_by_name: dict[str, list[DesiredReservation]] = {}
+    for desired in selected:
+        selected_by_name.setdefault(_desired_name_key(desired), []).append(desired)
+    for group in selected_by_name.values():
+        group.sort(key=lambda desired: (desired.start, desired.end, desired.desired_id))
+
+    slot_to_desired: dict[int, str] = {}
+    matched_desired: set[str] = set()
+    occupied = [
+        slot
+        for slot in plan.observed_slots.values()
+        if slot.classification
+        in {ObservedSlotStatus.OCCUPIED, ObservedSlotStatus.PHANTOM}
+        and slot.raw_name
+    ]
+    duplicate_slots: set[int] = set()
+
+    for group in selected_by_name.values():
+        physical_group = [
+            slot
+            for slot in occupied
+            if _names_match(
+                slot.raw_name,
+                group[0].stable_slot_name,
+                group[0].display_slot_name,
+                prefix=prefix,
+            )
+        ]
+        physical_group.sort(
+            key=lambda slot: (
+                slot.actual_start or datetime.max.replace(tzinfo=timezone.utc),
+                slot.slot,
+            )
+        )
+        for slot, desired in zip(physical_group, group, strict=False):
+            slot.matched_desired_id = desired.desired_id
+            desired.matched_slot = slot.slot
+            desired.assigned_slot = slot.slot
+            slot_to_desired[slot.slot] = desired.desired_id
+            matched_desired.add(desired.desired_id)
+            plan.selected[desired.desired_id] = slot.slot
+        for extra_slot in physical_group[len(group) :]:
+            duplicate_slots.add(extra_slot.slot)
+
+    free_slots = sorted(
+        slot.slot
+        for slot in plan.observed_slots.values()
+        if slot.classification is ObservedSlotStatus.EMPTY and slot.empty_confirmed
+    )
+    for desired in selected:
+        if desired.desired_id in matched_desired:
+            continue
+        if free_slots:
+            slot_number = free_slots.pop(0)
+            desired.assigned_slot = slot_number
+            slot_to_desired[slot_number] = desired.desired_id
+            plan.selected[desired.desired_id] = slot_number
+        else:
+            desired.overflow_reason = "no_empty_slot"
+            plan.overflow[desired.desired_id] = "no_empty_slot"
+
+    for slot in sorted(plan.observed_slots.values(), key=lambda item: item.slot):
+        desired_id = slot_to_desired.get(slot.slot)
+        action_desired = (
+            plan.desired_reservations.get(desired_id) if desired_id else None
+        )
+        if slot.classification is ObservedSlotStatus.UNKNOWN:
+            plan.actions.append(
+                SlotAction(
+                    kind=ActionKind.BLOCKED,
+                    slot=slot.slot,
+                    desired_id=desired_id,
+                    blocked_reason="unreadable",
+                    reason="unreadable",
+                )
+            )
+        elif slot.slot in duplicate_slots:
+            plan.actions.append(
+                SlotAction(
+                    kind=ActionKind.RESET,
+                    slot=slot.slot,
+                    reason="duplicate_non_canonical",
+                    preflight_read=True,
+                )
+            )
+        elif action_desired is None:
+            if slot.classification is not ObservedSlotStatus.EMPTY:
+                plan.actions.append(
+                    SlotAction(
+                        kind=ActionKind.RESET,
+                        slot=slot.slot,
+                        reason="stale",
+                        preflight_read=True,
+                    )
+                )
+        elif slot.classification is ObservedSlotStatus.EMPTY:
+            plan.actions.append(
+                SlotAction(
+                    kind=ActionKind.ASSIGN,
+                    slot=slot.slot,
+                    desired_id=action_desired.desired_id,
+                    requires_confirmed_empty=True,
+                    preflight_read=True,
+                )
+            )
+        elif slot.raw_pin != action_desired.slot_code or (
+            slot.raw_name and slot.raw_name != action_desired.display_slot_name
+        ):
+            plan.actions.append(
+                SlotAction(
+                    kind=ActionKind.UPDATE_IN_PLACE,
+                    slot=slot.slot,
+                    desired_id=action_desired.desired_id,
+                    matched_by="name_exact",
+                    requires_confirmed_empty=True,
+                    preflight_read=True,
+                    reason="replace_code_or_name",
+                )
+            )
+        elif (
+            slot.actual_start != action_desired.buffered_start
+            or slot.actual_end != action_desired.buffered_end
+        ):
+            plan.actions.append(
+                SlotAction(
+                    kind=ActionKind.UPDATE_IN_PLACE,
+                    slot=slot.slot,
+                    desired_id=action_desired.desired_id,
+                    matched_by="name_exact",
+                    reason="date_drift",
+                )
+            )
+
+    plan.diagnostics = {
+        "plan_id": plan_id,
+        "generated_at": generated_at.isoformat(),
+        "selected": dict(plan.selected),
+        "overflow": dict(plan.overflow),
+        "actions": [
+            {
+                "kind": action.kind.value,
+                "slot": action.slot,
+                "desired_id": action.desired_id,
+                "reason": action.reason or action.blocked_reason,
+            }
+            for action in plan.actions
+        ],
+    }
     return plan

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -771,15 +771,10 @@ def _names_match(
     desired_forms = _desired_name_forms(stable_slot_name, display_slot_name)
     if physical_forms & desired_forms:
         return True
-    # Conservative trim-aware fallback: an observed display name may be a
-    # shortened form of the stable name.  Require it to be a prefix-like
-    # reduction to avoid matching unrelated names.
-    for actual in physical_forms:
-        for desired in desired_forms:
-            if actual != desired and (
-                desired.startswith(actual) or actual.startswith(desired)
-            ):
-                return True
+    # Trim-aware matching is handled by requiring callers to provide the exact
+    # display_slot_name that Rental Control would write to Keymaster.  Do not use
+    # generic prefix matching here: names like "Ann" and "Anna" are distinct
+    # stable identities even though one is a string prefix of the other.
     return False
 
 
@@ -791,6 +786,16 @@ def _reservation_name_key(reservation: Reservation) -> str:
 def _desired_name_key(reservation: DesiredReservation) -> str:
     """Return the stable name grouping key for a DesiredReservation."""
     return normalize_slot_name_for_fingerprint(reservation.stable_slot_name)
+
+
+def _slot_times_match(
+    actual_start: datetime | None,
+    actual_end: datetime | None,
+    desired_start: datetime,
+    desired_end: datetime,
+) -> bool:
+    """Return whether observed Keymaster dates exactly match desired dates."""
+    return actual_start == desired_start and actual_end == desired_end
 
 
 def _dt_to_utc_iso(dt: datetime) -> str:
@@ -1970,7 +1975,35 @@ def compute_desired_plan(
                 ambiguous_slots.add(ms.slot)
             plan.diagnostics.setdefault("ambiguous_name_groups", []).append(name_key)
             continue
-        for ms, res in zip(physical_group, desired_group, strict=False):
+        pairs: list[tuple[ManagedSlot, Reservation]] = []
+        paired_slots: set[int] = set()
+        paired_reservations: set[str] = set()
+        for res in desired_group:
+            exact_matches = [
+                ms
+                for ms in physical_group
+                if ms.slot not in paired_slots
+                and _slot_times_match(
+                    ms.actual_start,
+                    ms.actual_end,
+                    res.buffered_start,
+                    res.buffered_end,
+                )
+            ]
+            if exact_matches:
+                ms = exact_matches[0]
+                pairs.append((ms, res))
+                paired_slots.add(ms.slot)
+                paired_reservations.add(res.identity_key)
+        remaining_physical = [
+            ms for ms in physical_group if ms.slot not in paired_slots
+        ]
+        remaining_desired = [
+            res for res in desired_group if res.identity_key not in paired_reservations
+        ]
+        pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
+
+        for ms, res in pairs:
             matched_slots[ms.slot] = res.identity_key
             matched_reservations.add(res.identity_key)
             duplicate_slots.discard(ms.slot)
@@ -1979,7 +2012,7 @@ def compute_desired_plan(
                 "identity_key": res.identity_key,
                 "slot_name": res.slot_name,
             }
-        for extra_ms in physical_group[len(desired_group) :]:
+        for extra_ms in remaining_physical[len(remaining_desired) :]:
             duplicate_slots.add(extra_ms.slot)
             _LOGGER.warning(
                 "Duplicate physical slot-name match for %s in slot %d; "
@@ -2202,14 +2235,42 @@ def compute_stateless_plan(
                 slot.slot,
             )
         )
-        for slot, desired in zip(physical_group, group, strict=False):
+        pairs: list[tuple[ObservedSlot, DesiredReservation]] = []
+        paired_slots: set[int] = set()
+        paired_desired: set[str] = set()
+        for desired in group:
+            exact_matches = [
+                slot
+                for slot in physical_group
+                if slot.slot not in paired_slots
+                and _slot_times_match(
+                    slot.actual_start,
+                    slot.actual_end,
+                    desired.buffered_start,
+                    desired.buffered_end,
+                )
+            ]
+            if exact_matches:
+                slot = exact_matches[0]
+                pairs.append((slot, desired))
+                paired_slots.add(slot.slot)
+                paired_desired.add(desired.desired_id)
+        remaining_physical = [
+            slot for slot in physical_group if slot.slot not in paired_slots
+        ]
+        remaining_desired = [
+            desired for desired in group if desired.desired_id not in paired_desired
+        ]
+        pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
+
+        for slot, desired in pairs:
             slot.matched_desired_id = desired.desired_id
             desired.matched_slot = slot.slot
             desired.assigned_slot = slot.slot
             slot_to_desired[slot.slot] = desired.desired_id
             matched_desired.add(desired.desired_id)
             plan.selected[desired.desired_id] = slot.slot
-        for extra_slot in physical_group[len(group) :]:
+        for extra_slot in remaining_physical[len(remaining_desired) :]:
             duplicate_slots.add(extra_slot.slot)
 
     free_slots = sorted(
@@ -2268,6 +2329,7 @@ def compute_stateless_plan(
                 SlotAction(
                     kind=ActionKind.ASSIGN,
                     slot=slot.slot,
+                    identity_key=action_desired.desired_id,
                     desired_id=action_desired.desired_id,
                     requires_confirmed_empty=True,
                     preflight_read=True,
@@ -2280,6 +2342,7 @@ def compute_stateless_plan(
                 SlotAction(
                     kind=ActionKind.UPDATE_IN_PLACE,
                     slot=slot.slot,
+                    identity_key=action_desired.desired_id,
                     desired_id=action_desired.desired_id,
                     matched_by="name_exact",
                     requires_confirmed_empty=True,
@@ -2295,6 +2358,7 @@ def compute_stateless_plan(
                 SlotAction(
                     kind=ActionKind.UPDATE_TIMES,
                     slot=slot.slot,
+                    identity_key=action_desired.desired_id,
                     desired_id=action_desired.desired_id,
                     matched_by="name_exact",
                     reason="date_drift",

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -2180,7 +2180,6 @@ def compute_desired_plan(
             matched_slots[ms.slot] = res.identity_key
             matched_reservations.add(res.identity_key)
             duplicate_slots.discard(ms.slot)
-            ms.persisted_identity_key = res.identity_key
             plan.diagnostics.setdefault("stable_name_matches", {})[ms.slot] = {
                 "identity_key": res.identity_key,
                 "slot_name": res.slot_name,

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -1962,6 +1962,7 @@ def compute_desired_plan(
         physical_group.sort(
             key=lambda ms: (
                 ms.actual_start or datetime.max.replace(tzinfo=timezone.utc),
+                ms.actual_end or datetime.max.replace(tzinfo=timezone.utc),
                 ms.slot,
             )
         )
@@ -2250,6 +2251,7 @@ def compute_stateless_plan(
         physical_group.sort(
             key=lambda slot: (
                 slot.actual_start or datetime.max.replace(tzinfo=timezone.utc),
+                slot.actual_end or datetime.max.replace(tzinfo=timezone.utc),
                 slot.slot,
             )
         )

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -383,6 +383,9 @@ class ObservedSlot:
         name_present = not _keymaster_text_cleared(self.raw_name)
         if self.has_pin is None and self.raw_pin is not None:
             self.has_pin = not _keymaster_text_cleared(self.raw_pin)
+        if self.raw_pin is None and self.has_pin is None:
+            self.readable = False
+            self.empty_confirmed = False
         if _keymaster_text_unreadable(self.raw_name) or _keymaster_text_unreadable(
             self.raw_pin
         ):

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -801,6 +801,27 @@ def _slot_times_match(
     return actual_start == desired_start and actual_end == desired_end
 
 
+def _datetime_distance(left: datetime | None, right: datetime) -> float:
+    """Return absolute seconds between two datetimes, or infinity if absent."""
+    if left is None:
+        return float("inf")
+    return abs((left - right).total_seconds())
+
+
+def _managed_slot_distance(slot: ManagedSlot, reservation: Reservation) -> float:
+    """Return date distance between a managed slot and desired reservation."""
+    return _datetime_distance(
+        slot.actual_start, reservation.buffered_start
+    ) + _datetime_distance(slot.actual_end, reservation.buffered_end)
+
+
+def _observed_slot_distance(slot: ObservedSlot, desired: DesiredReservation) -> float:
+    """Return date distance between an observed slot and desired reservation."""
+    return _datetime_distance(
+        slot.actual_start, desired.buffered_start
+    ) + _datetime_distance(slot.actual_end, desired.buffered_end)
+
+
 def _dt_to_utc_iso(dt: datetime) -> str:
     """Convert *dt* to a UTC ISO-8601 string for fingerprint computation.
 
@@ -2019,6 +2040,15 @@ def compute_desired_plan(
         remaining_desired = [
             res for res in desired_group if res.identity_key not in paired_reservations
         ]
+        if len(remaining_physical) > len(remaining_desired) and remaining_desired:
+            remaining_physical.sort(
+                key=lambda ms: (
+                    min(_managed_slot_distance(ms, res) for res in remaining_desired),
+                    ms.actual_start or datetime.max.replace(tzinfo=timezone.utc),
+                    ms.actual_end or datetime.max.replace(tzinfo=timezone.utc),
+                    ms.slot,
+                )
+            )
         pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
 
         for ms, res in pairs:
@@ -2295,6 +2325,18 @@ def compute_stateless_plan(
         remaining_desired = [
             desired for desired in group if desired.desired_id not in paired_desired
         ]
+        if len(remaining_physical) > len(remaining_desired) and remaining_desired:
+            remaining_physical.sort(
+                key=lambda slot: (
+                    min(
+                        _observed_slot_distance(slot, desired)
+                        for desired in remaining_desired
+                    ),
+                    slot.actual_start or datetime.max.replace(tzinfo=timezone.utc),
+                    slot.actual_end or datetime.max.replace(tzinfo=timezone.utc),
+                    slot.slot,
+                )
+            )
         pairs.extend(zip(remaining_physical, remaining_desired, strict=False))
 
         for slot, desired in pairs:

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -1983,7 +1983,7 @@ def compute_desired_plan(
         paired_reservations: set[str] = set()
         complete_known_duplicate_group = (
             len(desired_group) > 1
-            and len(physical_group) >= len(desired_group)
+            and len(physical_group) == len(desired_group)
             and all(
                 ms.actual_start is not None and ms.actual_end is not None
                 for ms in physical_group
@@ -2258,7 +2258,7 @@ def compute_stateless_plan(
         paired_desired: set[str] = set()
         complete_known_duplicate_group = (
             len(group) > 1
-            and len(physical_group) >= len(group)
+            and len(physical_group) == len(group)
             and all(
                 slot.actual_start is not None and slot.actual_end is not None
                 for slot in physical_group

--- a/custom_components/rental_control/reconciliation.py
+++ b/custom_components/rental_control/reconciliation.py
@@ -2293,7 +2293,7 @@ def compute_stateless_plan(
         ):
             plan.actions.append(
                 SlotAction(
-                    kind=ActionKind.UPDATE_IN_PLACE,
+                    kind=ActionKind.UPDATE_TIMES,
                     slot=slot.slot,
                     desired_id=action_desired.desired_id,
                     matched_by="name_exact",

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -583,7 +583,7 @@ async def async_fire_set_code(coordinator, event, slot: int) -> OperationResult:
             buffered_end = _ensure_datetime(buffered_end, coordinator)
         except (TypeError, ValueError) as exc:
             return OperationResult(
-                kind="update_times",
+                kind="set",
                 slot=slot,
                 failed=True,
                 error=str(exc),

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -61,7 +61,7 @@ from .const import EARLY_CHECKOUT_GRACE_MINUTES
 from .const import NAME
 
 _LOGGER = logging.getLogger(__name__)
-_CLEARED_KEYMASTER_TEXT_STATES = frozenset(("", str(STATE_UNKNOWN).casefold()))
+_CLEARED_KEYMASTER_TEXT_STATES = frozenset(("", str(STATE_UNKNOWN).casefold(), "none"))
 _UNREADABLE_KEYMASTER_TEXT_STATE = str(STATE_UNAVAILABLE).casefold()
 _SET_CODE_CONFIRMATION_TIMEOUT = 5.0
 

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -779,12 +779,20 @@ def _ensure_datetime(value: str | date | datetime, rc) -> datetime:
     override timestamps.  Falls back to UTC when no valid
     timezone is available.
     """
+    tz = getattr(rc, "timezone", None)
+    if not isinstance(tz, tzinfo):
+        tz = dt.UTC
     if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=tz)
         return value
     if isinstance(value, str):
         parsed = dt.parse_datetime(value)
         if parsed is not None:
-            return cast("datetime", parsed)
+            parsed_dt = cast("datetime", parsed)
+            if parsed_dt.tzinfo is None:
+                return parsed_dt.replace(tzinfo=tz)
+            return parsed_dt
         parsed_date = dt.parse_date(value)
         if parsed_date is not None:
             value = cast("date", parsed_date)
@@ -794,9 +802,6 @@ def _ensure_datetime(value: str | date | datetime, rc) -> datetime:
     if not isinstance(value, date):
         msg = f"Cannot coerce {value!r} to datetime"
         raise ValueError(msg)
-    tz = getattr(rc, "timezone", None)
-    if not isinstance(tz, tzinfo):
-        tz = dt.UTC
     return datetime.combine(value, time.min, tz)
 
 

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -540,6 +540,27 @@ async def async_fire_set_code(coordinator, event, slot: int) -> OperationResult:
         return OperationResult(kind="set", slot=slot, unconfirmed=True)
 
     try:
+        # Compute buffered validity window for Keymaster before mutating state.
+        before = getattr(coordinator, "code_buffer_before", 0)
+        after = getattr(coordinator, "code_buffer_after", 0)
+        buffered_start, buffered_end = apply_buffer(
+            event.extra_state_attributes["start"],
+            event.extra_state_attributes["end"],
+            before if isinstance(before, int) else 0,
+            after if isinstance(after, int) else 0,
+            coordinator,
+        )
+        buffered_start = _ensure_datetime(buffered_start, coordinator)
+        buffered_end = _ensure_datetime(buffered_end, coordinator)
+    except (TypeError, ValueError) as exc:
+        return OperationResult(
+            kind="set",
+            slot=slot,
+            failed=True,
+            error=str(exc),
+        )
+
+    try:
         # Disable the slot, this should help avoid notices from Keymaster
         # about pin changes
         coro = add_call(
@@ -569,25 +590,6 @@ async def async_fire_set_code(coordinator, event, slot: int) -> OperationResult:
             },
             blocking=True,
         )
-
-        try:
-            # Compute buffered validity window for Keymaster
-            buffered_start, buffered_end = apply_buffer(
-                event.extra_state_attributes["start"],
-                event.extra_state_attributes["end"],
-                coordinator.code_buffer_before,
-                coordinator.code_buffer_after,
-                coordinator,
-            )
-            buffered_start = _ensure_datetime(buffered_start, coordinator)
-            buffered_end = _ensure_datetime(buffered_end, coordinator)
-        except (TypeError, ValueError) as exc:
-            return OperationResult(
-                kind="set",
-                slot=slot,
-                failed=True,
-                error=str(exc),
-            )
 
         coro = add_call(
             coordinator.hass,

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -578,6 +578,8 @@ async def async_fire_set_code(coordinator, event, slot: int) -> OperationResult:
             coordinator.code_buffer_after,
             coordinator,
         )
+        buffered_start = _ensure_datetime(buffered_start, coordinator)
+        buffered_end = _ensure_datetime(buffered_end, coordinator)
 
         coro = add_call(
             coordinator.hass,
@@ -696,6 +698,8 @@ async def async_fire_update_times(coordinator, event, slot: int) -> OperationRes
         coordinator.code_buffer_after,
         coordinator,
     )
+    buffered_start = _ensure_datetime(buffered_start, coordinator)
+    buffered_end = _ensure_datetime(buffered_end, coordinator)
 
     coro = add_call(
         coordinator.hass,
@@ -727,10 +731,6 @@ async def async_fire_update_times(coordinator, event, slot: int) -> OperationRes
             failed=True,
             error=str(exc),
         )
-    if not isinstance(buffered_start, datetime) or not isinstance(
-        buffered_end, datetime
-    ):
-        return OperationResult(kind="update_times", slot=slot, unconfirmed=True)
     start_entity_id = f"datetime.{lockname}_code_slot_{slot}_date_range_start"
     end_entity_id = f"datetime.{lockname}_code_slot_{slot}_date_range_end"
     start_confirmed, end_confirmed = await asyncio.gather(
@@ -752,7 +752,7 @@ async def async_fire_update_times(coordinator, event, slot: int) -> OperationRes
     return OperationResult(kind="update_times", slot=slot, confirmed=True)
 
 
-def _ensure_datetime(value: date | datetime, rc) -> datetime:
+def _ensure_datetime(value: str | date | datetime, rc) -> datetime:
     """Coerce a bare ``date`` to a timezone-aware ``datetime``.
 
     ``CalendarEvent`` may carry ``date`` values for all-day
@@ -763,6 +763,17 @@ def _ensure_datetime(value: date | datetime, rc) -> datetime:
     """
     if isinstance(value, datetime):
         return value
+    if isinstance(value, str):
+        parsed = dt.parse_datetime(value)
+        if parsed is not None:
+            return cast("datetime", parsed)
+        parsed_date = dt.parse_date(value)
+        if parsed_date is not None:
+            value = cast("date", parsed_date)
+        else:
+            return cast("datetime", dt.now())
+    if not isinstance(value, date):
+        return cast("datetime", dt.now())
     tz = getattr(rc, "timezone", None)
     if not isinstance(tz, tzinfo):
         tz = dt.UTC

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -260,6 +260,8 @@ async def _async_wait_for_expected_datetime(
     """Wait briefly for one datetime entity to match the expected value."""
     if _state_matches_expected_datetime(hass, entity_id, expected):
         return True
+    if _state_has_non_string_value(hass, entity_id):
+        return False
 
     matched = asyncio.Event()
 
@@ -276,6 +278,8 @@ async def _async_wait_for_expected_datetime(
     try:
         if _state_matches_expected_datetime(hass, entity_id, expected):
             return True
+        if _state_has_non_string_value(hass, entity_id):
+            return False
         try:
             async with asyncio.timeout(timeout):
                 await matched.wait()

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -570,16 +570,24 @@ async def async_fire_set_code(coordinator, event, slot: int) -> OperationResult:
             blocking=True,
         )
 
-        # Compute buffered validity window for Keymaster
-        buffered_start, buffered_end = apply_buffer(
-            event.extra_state_attributes["start"],
-            event.extra_state_attributes["end"],
-            coordinator.code_buffer_before,
-            coordinator.code_buffer_after,
-            coordinator,
-        )
-        buffered_start = _ensure_datetime(buffered_start, coordinator)
-        buffered_end = _ensure_datetime(buffered_end, coordinator)
+        try:
+            # Compute buffered validity window for Keymaster
+            buffered_start, buffered_end = apply_buffer(
+                event.extra_state_attributes["start"],
+                event.extra_state_attributes["end"],
+                coordinator.code_buffer_before,
+                coordinator.code_buffer_after,
+                coordinator,
+            )
+            buffered_start = _ensure_datetime(buffered_start, coordinator)
+            buffered_end = _ensure_datetime(buffered_end, coordinator)
+        except (TypeError, ValueError) as exc:
+            return OperationResult(
+                kind="update_times",
+                slot=slot,
+                failed=True,
+                error=str(exc),
+            )
 
         coro = add_call(
             coordinator.hass,
@@ -690,16 +698,24 @@ async def async_fire_update_times(coordinator, event, slot: int) -> OperationRes
         )
         return OperationResult(kind="update_times", slot=slot, unconfirmed=True)
 
-    # Compute buffered validity window for Keymaster
-    buffered_start, buffered_end = apply_buffer(
-        event.extra_state_attributes["start"],
-        event.extra_state_attributes["end"],
-        coordinator.code_buffer_before,
-        coordinator.code_buffer_after,
-        coordinator,
-    )
-    buffered_start = _ensure_datetime(buffered_start, coordinator)
-    buffered_end = _ensure_datetime(buffered_end, coordinator)
+    try:
+        # Compute buffered validity window for Keymaster
+        buffered_start, buffered_end = apply_buffer(
+            event.extra_state_attributes["start"],
+            event.extra_state_attributes["end"],
+            coordinator.code_buffer_before,
+            coordinator.code_buffer_after,
+            coordinator,
+        )
+        buffered_start = _ensure_datetime(buffered_start, coordinator)
+        buffered_end = _ensure_datetime(buffered_end, coordinator)
+    except (TypeError, ValueError) as exc:
+        return OperationResult(
+            kind="update_times",
+            slot=slot,
+            failed=True,
+            error=str(exc),
+        )
 
     coro = add_call(
         coordinator.hass,
@@ -771,9 +787,11 @@ def _ensure_datetime(value: str | date | datetime, rc) -> datetime:
         if parsed_date is not None:
             value = cast("date", parsed_date)
         else:
-            return cast("datetime", dt.now())
+            msg = f"Cannot coerce {value!r} to datetime"
+            raise ValueError(msg)
     if not isinstance(value, date):
-        return cast("datetime", dt.now())
+        msg = f"Cannot coerce {value!r} to datetime"
+        raise ValueError(msg)
     tz = getattr(rc, "timezone", None)
     if not isinstance(tz, tzinfo):
         tz = dt.UTC

--- a/custom_components/rental_control/util.py
+++ b/custom_components/rental_control/util.py
@@ -243,6 +243,49 @@ async def _async_wait_for_expected_name(
         unsub()
 
 
+def _state_matches_expected_datetime(
+    hass: HomeAssistant, entity_id: str, expected: datetime
+) -> bool:
+    """Return whether the entity state matches the expected datetime."""
+    state = hass.states.get(entity_id)
+    if state is None or not isinstance(state.state, str):
+        return False
+    parsed = dt.parse_datetime(state.state)
+    return parsed is not None and dt.as_utc(parsed) == dt.as_utc(expected)
+
+
+async def _async_wait_for_expected_datetime(
+    hass: HomeAssistant, entity_id: str, expected: datetime, timeout: float
+) -> bool:
+    """Wait briefly for one datetime entity to match the expected value."""
+    if _state_matches_expected_datetime(hass, entity_id, expected):
+        return True
+
+    matched = asyncio.Event()
+
+    def _handle_state_change(event: Event[EventStateChangedData]) -> None:
+        """Set the wait flag when the target entity reaches the expected time."""
+        new_state = event.data.get("new_state")
+        if new_state is None or not isinstance(new_state.state, str):
+            return
+        parsed = dt.parse_datetime(new_state.state)
+        if parsed is not None and dt.as_utc(parsed) == dt.as_utc(expected):
+            matched.set()
+
+    unsub = async_track_state_change_event(hass, [entity_id], _handle_state_change)
+    try:
+        if _state_matches_expected_datetime(hass, entity_id, expected):
+            return True
+        try:
+            async with asyncio.timeout(timeout):
+                await matched.wait()
+        except TimeoutError:
+            return False
+        return _state_matches_expected_datetime(hass, entity_id, expected)
+    finally:
+        unsub()
+
+
 def delete_rc_and_base_folder(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Delete packages folder for RC and base rental_control folder if empty."""
     base_path = Path(hass.config.path(), config_entry.data.get(CONF_PATH, DEFAULT_PATH))
@@ -684,6 +727,28 @@ async def async_fire_update_times(coordinator, event, slot: int) -> OperationRes
             failed=True,
             error=str(exc),
         )
+    if not isinstance(buffered_start, datetime) or not isinstance(
+        buffered_end, datetime
+    ):
+        return OperationResult(kind="update_times", slot=slot, unconfirmed=True)
+    start_entity_id = f"datetime.{lockname}_code_slot_{slot}_date_range_start"
+    end_entity_id = f"datetime.{lockname}_code_slot_{slot}_date_range_end"
+    start_confirmed, end_confirmed = await asyncio.gather(
+        _async_wait_for_expected_datetime(
+            coordinator.hass,
+            start_entity_id,
+            buffered_start,
+            _SET_CODE_CONFIRMATION_TIMEOUT,
+        ),
+        _async_wait_for_expected_datetime(
+            coordinator.hass,
+            end_entity_id,
+            buffered_end,
+            _SET_CODE_CONFIRMATION_TIMEOUT,
+        ),
+    )
+    if not start_confirmed or not end_confirmed:
+        return OperationResult(kind="update_times", slot=slot, unconfirmed=True)
     return OperationResult(kind="update_times", slot=slot, confirmed=True)
 
 

--- a/specs/013-stateless-reconciliation/spec.md
+++ b/specs/013-stateless-reconciliation/spec.md
@@ -207,6 +207,12 @@ contents.
    generation, check-in tracking sensors, and read-only event sensors are in
    use, **When** reconciliation runs, **Then** their existing observable
    behavior is preserved.
+6. **Given** Honor Event Times is on and non-zero lock-code buffers are
+   configured, **When** a PMS calendar event changes its check-in or checkout
+   time, **Then** a physical slot already matching the previously buffered
+   window is treated as system-managed and updated to the new calendar time
+   after applying the configured before/after buffer; only a physical time that
+   deviates from the buffered expected window is treated as a manual override.
 
 ---
 
@@ -325,6 +331,14 @@ refreshes converge to the desired state without using persisted data as truth.
   after buffers, Honor Event Times, deterministic code generation,
   should-update-code behavior, check-in tracking sensors, and read-only
   `event_N` sensors MUST be preserved.
+- **FR-022**: Manual time override detection MUST compare physical Keymaster
+  times against the expected calendar/default time after applying configured
+  lock-code before and after buffers. A physical slot time equal to the
+  buffered expected check-in or checkout time MUST be treated as
+  system-managed, not a manual/local override; with Honor Event Times enabled,
+  calendar check-in or checkout changes MUST update the slot to the newly
+  buffered time, while a true deviation from the buffered expected time MUST
+  remain a preserved manual override.
 - **FR-018**: The system MUST correct stale, phantom, duplicate, manually
   drifted, and physically empty managed-slot states during normal refresh
   cycles without requiring Home Assistant restart, integration reload, manual

--- a/specs/013-stateless-reconciliation/tasks.md
+++ b/specs/013-stateless-reconciliation/tasks.md
@@ -20,7 +20,7 @@ Store fences, ghost reservations, adoption machinery, and per-event greedy
 allocation with one stateless per-refresh planner. `event_N` sensors remain
 read-only reflections of the latest calendar data and stateless plan.
 
-## Format: `- [ ] T### [P?] [Story?] Description with file path`
+## Format: `- [X] T### [P?] [Story?] Description with file path`
 
 - **[P]**: Can run in parallel (different files, no dependency on incomplete
   tasks)
@@ -64,14 +64,14 @@ when the obsolete machinery is retired.
 **Purpose**: Establish artifact, code, and existing-test baselines before
 changing reconciliation behavior.
 
-- [ ] T001 Inspect spec.md user stories US1-US6, FR-001 through FR-021, and SC-001 through SC-011 in specs/013-stateless-reconciliation/spec.md
-- [ ] T002 Inspect R-001 through R-008 decisions and retired machinery notes in specs/013-stateless-reconciliation/research.md
-- [ ] T003 Inspect ObservedSlot, DesiredReservation, SlotAction, StatelessPlan, CacheOnlyStoreRecord, matching rules, and state transitions in specs/013-stateless-reconciliation/data-model.md
-- [ ] T004 Inspect validation scenarios and expected commands in specs/013-stateless-reconciliation/quickstart.md
-- [ ] T005 Inventory current persisted-authoritative and greedy allocation paths in custom_components/rental_control/coordinator.py, custom_components/rental_control/event_overrides.py, and custom_components/rental_control/reconciliation.py
-- [ ] T006 Inventory current sensor, check-in, Store setup, and Keymaster helper dependencies in custom_components/rental_control/sensors/calsensor.py, custom_components/rental_control/sensors/checkinsensor.py, custom_components/rental_control/__init__.py, custom_components/rental_control/util.py, and custom_components/rental_control/const.py
-- [ ] T007 Inventory obsolete persisted-authoritative tests to migrate or remove in tests/unit/test_event_overrides.py, tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_slot_concurrency.py
-- [ ] T008 Run baseline targeted tests for tests/unit/test_slot_reconciliation.py, tests/unit/test_event_overrides.py, tests/unit/test_coordinator.py, tests/unit/test_util.py, tests/unit/test_sensors.py, tests/unit/test_checkin_sensor.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_slot_concurrency.py
+- [X] T001 Inspect spec.md user stories US1-US6, FR-001 through FR-021, and SC-001 through SC-011 in specs/013-stateless-reconciliation/spec.md
+- [X] T002 Inspect R-001 through R-008 decisions and retired machinery notes in specs/013-stateless-reconciliation/research.md
+- [X] T003 Inspect ObservedSlot, DesiredReservation, SlotAction, StatelessPlan, CacheOnlyStoreRecord, matching rules, and state transitions in specs/013-stateless-reconciliation/data-model.md
+- [X] T004 Inspect validation scenarios and expected commands in specs/013-stateless-reconciliation/quickstart.md
+- [X] T005 Inventory current persisted-authoritative and greedy allocation paths in custom_components/rental_control/coordinator.py, custom_components/rental_control/event_overrides.py, and custom_components/rental_control/reconciliation.py
+- [X] T006 Inventory current sensor, check-in, Store setup, and Keymaster helper dependencies in custom_components/rental_control/sensors/calsensor.py, custom_components/rental_control/sensors/checkinsensor.py, custom_components/rental_control/__init__.py, custom_components/rental_control/util.py, and custom_components/rental_control/const.py
+- [X] T007 Inventory obsolete persisted-authoritative tests to migrate or remove in tests/unit/test_event_overrides.py, tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_slot_concurrency.py
+- [X] T008 Run baseline targeted tests for tests/unit/test_slot_reconciliation.py, tests/unit/test_event_overrides.py, tests/unit/test_coordinator.py, tests/unit/test_util.py, tests/unit/test_sensors.py, tests/unit/test_checkin_sensor.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_slot_concurrency.py
 
 ---
 
@@ -86,25 +86,25 @@ complete.
 
 ### Foundational Tests
 
-- [ ] T009 [P] Add ObservedSlot, DesiredReservation, SlotAction, StatelessPlan, CacheOnlyStoreRecord validation tests in tests/unit/test_slot_reconciliation.py
-- [ ] T010 [P] Add physical empty, occupied, phantom, unknown, unreadable, and unmanaged ObservedSlot classification tests in tests/unit/test_slot_reconciliation.py
-- [ ] T011 [P] Add stable slot-name normalization tests for exact, case-insensitive, prefix-stripped, trimmed, and prefixed-trimmed names in tests/unit/test_slot_reconciliation.py
-- [ ] T012 Add duplicate-name start-time pairing, trim-collision blocking, and one-slot-per-desired invariant tests in tests/unit/test_slot_reconciliation.py
-- [ ] T013 Add pure planner invariant tests proving Store/cache fields do not affect selected reservations, actions, overflow, or blocked slots in tests/unit/test_slot_reconciliation.py
-- [ ] T014 [P] Add cache-only Store v1 migration tests for ignored legacy status, slot, operation_id, pending_clear_since, blocked_slots, and missing_count fields in tests/unit/test_coordinator.py
-- [ ] T015 Add cache load failure, corrupt cache, duplicate cache claims, no-raw-PIN, and best-effort save tests in tests/unit/test_coordinator.py
-- [ ] T016 [P] Add shared stateless fixtures for observed slots, desired reservations, legacy cache records, Keymaster snapshots, and operation results in tests/fixtures/event_data.py
-- [ ] T017 Run foundational failing-test check for tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, and tests/fixtures/event_data.py
+- [X] T009 [P] Add ObservedSlot, DesiredReservation, SlotAction, StatelessPlan, CacheOnlyStoreRecord validation tests in tests/unit/test_slot_reconciliation.py
+- [X] T010 [P] Add physical empty, occupied, phantom, unknown, unreadable, and unmanaged ObservedSlot classification tests in tests/unit/test_slot_reconciliation.py
+- [X] T011 [P] Add stable slot-name normalization tests for exact, case-insensitive, prefix-stripped, trimmed, and prefixed-trimmed names in tests/unit/test_slot_reconciliation.py
+- [X] T012 Add duplicate-name start-time pairing, trim-collision blocking, and one-slot-per-desired invariant tests in tests/unit/test_slot_reconciliation.py
+- [X] T013 Add pure planner invariant tests proving Store/cache fields do not affect selected reservations, actions, overflow, or blocked slots in tests/unit/test_slot_reconciliation.py
+- [X] T014 [P] Add cache-only Store v1 migration tests for ignored legacy status, slot, operation_id, pending_clear_since, blocked_slots, and missing_count fields in tests/unit/test_coordinator.py
+- [X] T015 Add cache load failure, corrupt cache, duplicate cache claims, no-raw-PIN, and best-effort save tests in tests/unit/test_coordinator.py
+- [X] T016 [P] Add shared stateless fixtures for observed slots, desired reservations, legacy cache records, Keymaster snapshots, and operation results in tests/fixtures/event_data.py
+- [X] T017 Run foundational failing-test check for tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, and tests/fixtures/event_data.py
 
 ### Foundational Implementation
 
-- [ ] T018 Create ObservedSlotStatus, ObservedSlot, DesiredReservation, SlotAction, StatelessPlan, and CacheOnlyStoreRecord types in custom_components/rental_control/reconciliation.py
-- [ ] T019 Implement stable-name normalization, prefix removal, trim-aware matching, duplicate-name start-order grouping, and ambiguity diagnostics in custom_components/rental_control/reconciliation.py
-- [ ] T020 Implement the stateless pure planner entry point that accepts only ObservedSlot records, DesiredReservation records, and immutable configuration in custom_components/rental_control/reconciliation.py
-- [ ] T021 Implement cache-only Store load and legacy migration helpers that return aliases and diagnostics without statuses or fences in custom_components/rental_control/coordinator.py
-- [ ] T022 Implement cache-only Store constants and diagnostic field names without authoritative status constants in custom_components/rental_control/const.py
-- [ ] T023 Add stateless observed-slot fixture builders and legacy-cache builders used by planner and coordinator tests in tests/fixtures/event_data.py
-- [ ] T024 Run foundational validation for tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, and tests/fixtures/event_data.py
+- [X] T018 Create ObservedSlotStatus, ObservedSlot, DesiredReservation, SlotAction, StatelessPlan, and CacheOnlyStoreRecord types in custom_components/rental_control/reconciliation.py
+- [X] T019 Implement stable-name normalization, prefix removal, trim-aware matching, duplicate-name start-order grouping, and ambiguity diagnostics in custom_components/rental_control/reconciliation.py
+- [X] T020 Implement the stateless pure planner entry point that accepts only ObservedSlot records, DesiredReservation records, and immutable configuration in custom_components/rental_control/reconciliation.py
+- [X] T021 Implement cache-only Store load and legacy migration helpers that return aliases and diagnostics without statuses or fences in custom_components/rental_control/coordinator.py
+- [X] T022 Implement cache-only Store constants and diagnostic field names without authoritative status constants in custom_components/rental_control/const.py
+- [X] T023 Add stateless observed-slot fixture builders and legacy-cache builders used by planner and coordinator tests in tests/fixtures/event_data.py
+- [X] T024 Run foundational validation for tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, and tests/fixtures/event_data.py
 
 **Checkpoint**: The stateless planner model, stable-name matcher, cache-only Store
 loader, and fixtures exist beside the current runtime path without switching
@@ -127,23 +127,23 @@ most one managed slot.
 > **NOTE: Write these tests FIRST and ensure they fail until US1 behavior is
 > implemented.**
 
-- [ ] T025 [P] [US1] Add planner tests for reservation length increase updating the same physical slot with no duplicate in tests/unit/test_slot_reconciliation.py
-- [ ] T026 [P] [US1] Add planner tests for reservation length decrease updating the same physical slot with no duplicate in tests/unit/test_slot_reconciliation.py
-- [ ] T027 [US1] Add planner tests for full date shift with date_based code change emitting same-slot replace_code and no second assignment in tests/unit/test_slot_reconciliation.py
-- [ ] T028 [US1] Add planner tests for same-guest rebooking and back-to-back stays using trim-aware name plus start-time order without duplicate slots in tests/unit/test_slot_reconciliation.py
-- [ ] T029 [US1] Add planner tests for duplicate guest names across two concurrent reservations disambiguated by start time with each reservation in exactly one slot in tests/unit/test_slot_reconciliation.py
-- [ ] T030 [US1] Add planner tests for simultaneous date shift plus duplicate guest names with deterministic pairing and ambiguous reorder blocking diagnostics in tests/unit/test_slot_reconciliation.py
-- [ ] T031 [US1] Add no-op tests proving already-correct physical name, PIN, and dates perform no Keymaster action in tests/unit/test_slot_reconciliation.py
-- [ ] T032 [US1] Add integration scenario for length increase then length decrease preserving one physical slot in tests/integration/test_refresh_cycle.py
-- [ ] T033 [US1] Add integration scenario for full date shift replacing old date_based code in the same slot and no duplicate slot in tests/integration/test_refresh_cycle.py
-- [ ] T034 [US1] Add integration scenario for duplicate names plus date shift and back-to-back rebooking with each stay in exactly one slot in tests/integration/test_refresh_cycle.py
+- [X] T025 [P] [US1] Add planner tests for reservation length increase updating the same physical slot with no duplicate in tests/unit/test_slot_reconciliation.py
+- [X] T026 [P] [US1] Add planner tests for reservation length decrease updating the same physical slot with no duplicate in tests/unit/test_slot_reconciliation.py
+- [X] T027 [US1] Add planner tests for full date shift with date_based code change emitting same-slot replace_code and no second assignment in tests/unit/test_slot_reconciliation.py
+- [X] T028 [US1] Add planner tests for same-guest rebooking and back-to-back stays using trim-aware name plus start-time order without duplicate slots in tests/unit/test_slot_reconciliation.py
+- [X] T029 [US1] Add planner tests for duplicate guest names across two concurrent reservations disambiguated by start time with each reservation in exactly one slot in tests/unit/test_slot_reconciliation.py
+- [X] T030 [US1] Add planner tests for simultaneous date shift plus duplicate guest names with deterministic pairing and ambiguous reorder blocking diagnostics in tests/unit/test_slot_reconciliation.py
+- [X] T031 [US1] Add no-op tests proving already-correct physical name, PIN, and dates perform no Keymaster action in tests/unit/test_slot_reconciliation.py
+- [X] T032 [US1] Add integration scenario for length increase then length decrease preserving one physical slot in tests/integration/test_refresh_cycle.py
+- [X] T033 [US1] Add integration scenario for full date shift replacing old date_based code in the same slot and no duplicate slot in tests/integration/test_refresh_cycle.py
+- [X] T034 [US1] Add integration scenario for duplicate names plus date shift and back-to-back rebooking with each stay in exactly one slot in tests/integration/test_refresh_cycle.py
 
 ### Implementation for User Story 1
 
-- [ ] T035 [US1] Implement in-place planner actions for same stable slot-name identity with date drift, display-name drift, or generated-code drift in custom_components/rental_control/reconciliation.py
-- [ ] T036 [US1] Implement duplicate-name start-time disambiguation and selected-reservation uniqueness enforcement in custom_components/rental_control/reconciliation.py
-- [ ] T037 [US1] Add diagnostics for stable-name matches, in-place updates, duplicate-name pairing, ambiguous groups, and duplicate-prevention blocks in custom_components/rental_control/reconciliation.py
-- [ ] T038 [US1] Run US1 validation for tests/unit/test_slot_reconciliation.py and tests/integration/test_refresh_cycle.py
+- [X] T035 [US1] Implement in-place planner actions for same stable slot-name identity with date drift, display-name drift, or generated-code drift in custom_components/rental_control/reconciliation.py
+- [X] T036 [US1] Implement duplicate-name start-time disambiguation and selected-reservation uniqueness enforcement in custom_components/rental_control/reconciliation.py
+- [X] T037 [US1] Add diagnostics for stable-name matches, in-place updates, duplicate-name pairing, ambiguous groups, and duplicate-prevention blocks in custom_components/rental_control/reconciliation.py
+- [X] T038 [US1] Run US1 validation for tests/unit/test_slot_reconciliation.py and tests/integration/test_refresh_cycle.py
 
 **Checkpoint**: US1 proves SC-001, SC-002, SC-003, FR-004, FR-005, FR-006,
 FR-007, FR-013, and the headline duplicate-avoidance scenarios.
@@ -161,25 +161,25 @@ same physical actions and resulting managed slots.
 
 ### Tests for User Story 2
 
-- [ ] T039 [P] [US2] Add coordinator tests proving _observe_managed_slots ignores Store status, pending clear, blocked slot, and missing count fields when classifying physical slots in tests/unit/test_coordinator.py
-- [ ] T040 [US2] Add store-non-authoritative matrix tests for cache present, missing, stale, contradictory, corrupt, and deleted mid-run producing identical plans in tests/unit/test_coordinator.py
-- [ ] T041 [US2] Add cold start, deleted Store, and first-upgrade tests proving existing coded slots are recognized by physical name and reconciled in place without wipe or adoption in tests/unit/test_coordinator.py
-- [ ] T042 [US2] Add contradictory Store tests where physical Bob beats cached Alice and no manual Store deletion is required in tests/unit/test_coordinator.py
-- [ ] T043 [US2] Add stale pending-clear cache tests proving a physically empty slot is assignable and no persisted fence remains load-bearing in tests/unit/test_coordinator.py
-- [ ] T044 [US2] Add unreadable Keymaster entity tests proving unavailable slots block for one cycle and re-evaluate normally on later refresh in tests/unit/test_coordinator.py
-- [ ] T045 [US2] Add no-calendar-reservation reset-and-free tests proving stale physical occupants reset only through confirmed empty state in tests/unit/test_slot_reconciliation.py
-- [ ] T046 [US2] Add integration scenario for deleted Store cold start recognizing existing coded slots by name without wiping them in tests/integration/test_refresh_cycle.py
-- [ ] T047 [US2] Add integration scenario for deleting or corrupting the Store mid-run and verifying identical refresh behavior in tests/integration/test_refresh_cycle.py
+- [X] T039 [P] [US2] Add coordinator tests proving _observe_managed_slots ignores Store status, pending clear, blocked slot, and missing count fields when classifying physical slots in tests/unit/test_coordinator.py
+- [X] T040 [US2] Add store-non-authoritative matrix tests for cache present, missing, stale, contradictory, corrupt, and deleted mid-run producing identical plans in tests/unit/test_coordinator.py
+- [X] T041 [US2] Add cold start, deleted Store, and first-upgrade tests proving existing coded slots are recognized by physical name and reconciled in place without wipe or adoption in tests/unit/test_coordinator.py
+- [X] T042 [US2] Add contradictory Store tests where physical Bob beats cached Alice and no manual Store deletion is required in tests/unit/test_coordinator.py
+- [X] T043 [US2] Add stale pending-clear cache tests proving a physically empty slot is assignable and no persisted fence remains load-bearing in tests/unit/test_coordinator.py
+- [X] T044 [US2] Add unreadable Keymaster entity tests proving unavailable slots block for one cycle and re-evaluate normally on later refresh in tests/unit/test_coordinator.py
+- [X] T045 [US2] Add no-calendar-reservation reset-and-free tests proving stale physical occupants reset only through confirmed empty state in tests/unit/test_slot_reconciliation.py
+- [X] T046 [US2] Add integration scenario for deleted Store cold start recognizing existing coded slots by name without wiping them in tests/integration/test_refresh_cycle.py
+- [X] T047 [US2] Add integration scenario for deleting or corrupting the Store mid-run and verifying identical refresh behavior in tests/integration/test_refresh_cycle.py
 
 ### Implementation for User Story 2
 
-- [ ] T048 [US2] Switch coordinator refresh to build ObservedSlot records from physical Keymaster entities without persisted status or fence inputs in custom_components/rental_control/coordinator.py
-- [ ] T049 [US2] Switch coordinator reservation building to DesiredReservation records from current calendar, current check-in state, and observed physical override inputs without ghost reservations in custom_components/rental_control/coordinator.py
-- [ ] T050 [US2] Replace refresh-level Store loading as runtime authority with cache-only alias and diagnostics inputs in custom_components/rental_control/coordinator.py
-- [ ] T051 [US2] Remove first-upgrade adoption as a correctness path from async_setup_entry while keeping a safe optional one-shot readability refresh in custom_components/rental_control/__init__.py
-- [ ] T052 [US2] Publish latest StatelessPlan and desired-reservation lookup accessors for sensors and check-in consumers in custom_components/rental_control/coordinator.py
-- [ ] T053 [US2] Write cache-only aliases and redacted last-plan diagnostics after refresh without raw PINs or authoritative statuses in custom_components/rental_control/coordinator.py
-- [ ] T054 [US2] Run US2 validation for tests/unit/test_coordinator.py, tests/unit/test_slot_reconciliation.py, and tests/integration/test_refresh_cycle.py
+- [X] T048 [US2] Switch coordinator refresh to build ObservedSlot records from physical Keymaster entities without persisted status or fence inputs in custom_components/rental_control/coordinator.py
+- [X] T049 [US2] Switch coordinator reservation building to DesiredReservation records from current calendar, current check-in state, and observed physical override inputs without ghost reservations in custom_components/rental_control/coordinator.py
+- [X] T050 [US2] Replace refresh-level Store loading as runtime authority with cache-only alias and diagnostics inputs in custom_components/rental_control/coordinator.py
+- [X] T051 [US2] Remove first-upgrade adoption as a correctness path from async_setup_entry while keeping a safe optional one-shot readability refresh in custom_components/rental_control/__init__.py
+- [X] T052 [US2] Publish latest StatelessPlan and desired-reservation lookup accessors for sensors and check-in consumers in custom_components/rental_control/coordinator.py
+- [X] T053 [US2] Write cache-only aliases and redacted last-plan diagnostics after refresh without raw PINs or authoritative statuses in custom_components/rental_control/coordinator.py
+- [X] T054 [US2] Run US2 validation for tests/unit/test_coordinator.py, tests/unit/test_slot_reconciliation.py, and tests/integration/test_refresh_cycle.py
 
 **Checkpoint**: US2 proves SC-005, FR-001, FR-002, FR-018 cold-start recovery,
 and the STORE-IS-NON-AUTHORITATIVE acceptance gate.
@@ -197,21 +197,21 @@ equal the protected-active plus soonest-N set after confirmed operations.
 
 ### Tests for User Story 3
 
-- [ ] T055 [P] [US3] Add pure soonest-N overflow tests selecting earliest starts up to managed capacity in tests/unit/test_slot_reconciliation.py
-- [ ] T056 [US3] Add active-guest protection tests proving checked-in guests remain selected first and count against slot capacity in tests/unit/test_slot_reconciliation.py
-- [ ] T057 [US3] Add reservation-dropout tests proving a reservation leaving soonest-N resets and frees its slot before a newly eligible reservation is programmed in tests/unit/test_slot_reconciliation.py
-- [ ] T058 [US3] Add farther-full-nearer-arrives tests proving the nearer reservation enters and farthest unprotected reservation overflows after confirmed reset in tests/unit/test_slot_reconciliation.py
-- [ ] T059 [US3] Add overflow diagnostics tests for capacity, no_empty_slot, unreadable_slot, and active_protected reasons in tests/unit/test_slot_reconciliation.py
-- [ ] T060 [US3] Add integration scenario for soonest-N overflow plus active-guest protection in tests/integration/test_refresh_cycle.py
-- [ ] T061 [US3] Add integration scenario for reservation dropout from soonest-N followed by confirmed reset and newly eligible programming in tests/integration/test_refresh_cycle.py
+- [X] T055 [P] [US3] Add pure soonest-N overflow tests selecting earliest starts up to managed capacity in tests/unit/test_slot_reconciliation.py
+- [X] T056 [US3] Add active-guest protection tests proving checked-in guests remain selected first and count against slot capacity in tests/unit/test_slot_reconciliation.py
+- [X] T057 [US3] Add reservation-dropout tests proving a reservation leaving soonest-N resets and frees its slot before a newly eligible reservation is programmed in tests/unit/test_slot_reconciliation.py
+- [X] T058 [US3] Add farther-full-nearer-arrives tests proving the nearer reservation enters and farthest unprotected reservation overflows after confirmed reset in tests/unit/test_slot_reconciliation.py
+- [X] T059 [US3] Add overflow diagnostics tests for capacity, no_empty_slot, unreadable_slot, and active_protected reasons in tests/unit/test_slot_reconciliation.py
+- [X] T060 [US3] Add integration scenario for soonest-N overflow plus active-guest protection in tests/integration/test_refresh_cycle.py
+- [X] T061 [US3] Add integration scenario for reservation dropout from soonest-N followed by confirmed reset and newly eligible programming in tests/integration/test_refresh_cycle.py
 
 ### Implementation for User Story 3
 
-- [ ] T062 [US3] Implement protected-active selection before non-protected soonest-N capacity fill in custom_components/rental_control/reconciliation.py
-- [ ] T063 [US3] Implement deterministic overflow, dropout, farthest-unprotected reset, and newly eligible assignment planning in custom_components/rental_control/reconciliation.py
-- [ ] T064 [US3] Wire active check-in state and checked-out state into DesiredReservation construction in custom_components/rental_control/coordinator.py
-- [ ] T065 [US3] Preserve check-in tracking active-reservation surfaces while reading latest plan ownership for protection in custom_components/rental_control/sensors/checkinsensor.py
-- [ ] T066 [US3] Run US3 validation for tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, tests/unit/test_checkin_sensor.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_checkin_tracking.py
+- [X] T062 [US3] Implement protected-active selection before non-protected soonest-N capacity fill in custom_components/rental_control/reconciliation.py
+- [X] T063 [US3] Implement deterministic overflow, dropout, farthest-unprotected reset, and newly eligible assignment planning in custom_components/rental_control/reconciliation.py
+- [X] T064 [US3] Wire active check-in state and checked-out state into DesiredReservation construction in custom_components/rental_control/coordinator.py
+- [X] T065 [US3] Preserve check-in tracking active-reservation surfaces while reading latest plan ownership for protection in custom_components/rental_control/sensors/checkinsensor.py
+- [X] T066 [US3] Run US3 validation for tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, tests/unit/test_checkin_sensor.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_checkin_tracking.py
 
 **Checkpoint**: US3 proves SC-004, SC-009, FR-003, FR-008, FR-016, and the
 soonest-N overflow/dropout acceptance gates.
@@ -230,23 +230,23 @@ fresh Keymaster reads.
 
 ### Tests for User Story 4
 
-- [ ] T067 [P] [US4] Add util tests proving async_fire_clear_code reports confirmed only when physical name and PIN are cleared in tests/unit/test_util.py
-- [ ] T068 [P] [US4] Add util tests proving lingering name, lingering PIN, service failure, and unavailable text state leave clear unconfirmed in tests/unit/test_util.py
-- [ ] T069 [P] [US4] Add util tests proving async_fire_set_code and async_fire_update_times use bounded confirmation and return unconfirmed on timeout in tests/unit/test_util.py
-- [ ] T070 [US4] Add apply-path tests proving update_in_place(replace_code) fresh-reads, clears, confirms empty, then sets the same desired reservation into the same slot in tests/unit/test_event_overrides.py
-- [ ] T071 [US4] Add apply-path tests proving unconfirmed clear skips replacement set and the next planner run retries from physical state without Store fences in tests/unit/test_event_overrides.py
-- [ ] T072 [US4] Add physical-empty tests for blank, unknown, UNKNOWN, None, and case-insensitive text states, plus unavailable-not-free in tests/unit/test_slot_reconciliation.py
-- [ ] T073 [US4] Add integration scenario for confirmed-reset-before-reapply with lagging clear then later empty confirmation in tests/integration/test_refresh_cycle.py
-- [ ] T074 [US4] Add callback re-entrancy tests proving callbacks never launch nested reconciliation and compatibility updates use request_refresh=False in tests/integration/test_slot_concurrency.py
+- [X] T067 [P] [US4] Add util tests proving async_fire_clear_code reports confirmed only when physical name and PIN are cleared in tests/unit/test_util.py
+- [X] T068 [P] [US4] Add util tests proving lingering name, lingering PIN, service failure, and unavailable text state leave clear unconfirmed in tests/unit/test_util.py
+- [X] T069 [P] [US4] Add util tests proving async_fire_set_code and async_fire_update_times use bounded confirmation and return unconfirmed on timeout in tests/unit/test_util.py
+- [X] T070 [US4] Add apply-path tests proving update_in_place(replace_code) fresh-reads, clears, confirms empty, then sets the same desired reservation into the same slot in tests/unit/test_event_overrides.py
+- [X] T071 [US4] Add apply-path tests proving unconfirmed clear skips replacement set and the next planner run retries from physical state without Store fences in tests/unit/test_event_overrides.py
+- [X] T072 [US4] Add physical-empty tests for blank, unknown, UNKNOWN, None, and case-insensitive text states, plus unavailable-not-free in tests/unit/test_slot_reconciliation.py
+- [X] T073 [US4] Add integration scenario for confirmed-reset-before-reapply with lagging clear then later empty confirmation in tests/integration/test_refresh_cycle.py
+- [X] T074 [US4] Add callback re-entrancy tests proving callbacks never launch nested reconciliation and compatibility updates use request_refresh=False in tests/integration/test_slot_concurrency.py
 
 ### Implementation for User Story 4
 
-- [ ] T075 [US4] Implement fresh preflight reads and confirmed-empty gates before clear, assign, and replacement set operations in custom_components/rental_control/event_overrides.py
-- [ ] T076 [US4] Preserve bounded confirmation OperationResult semantics for clear, set, and update_times helpers in custom_components/rental_control/util.py
-- [ ] T077 [US4] Implement apply ordering for clear/update before assign and same-slot replace_code without cross-slot double-programming in custom_components/rental_control/event_overrides.py
-- [ ] T078 [US4] Remove persisted pending-clear fences from assignment safety and rely on observed physical occupied/empty/unknown state in custom_components/rental_control/event_overrides.py
-- [ ] T079 [US4] Keep callback suppression and single-lock reconciliation apply behavior without nested refreshes in custom_components/rental_control/util.py and custom_components/rental_control/event_overrides.py
-- [ ] T080 [US4] Run US4 validation for tests/unit/test_util.py, tests/unit/test_event_overrides.py, tests/unit/test_slot_reconciliation.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_slot_concurrency.py
+- [X] T075 [US4] Implement fresh preflight reads and confirmed-empty gates before clear, assign, and replacement set operations in custom_components/rental_control/event_overrides.py
+- [X] T076 [US4] Preserve bounded confirmation OperationResult semantics for clear, set, and update_times helpers in custom_components/rental_control/util.py
+- [X] T077 [US4] Implement apply ordering for clear/update before assign and same-slot replace_code without cross-slot double-programming in custom_components/rental_control/event_overrides.py
+- [X] T078 [US4] Remove persisted pending-clear fences from assignment safety and rely on observed physical occupied/empty/unknown state in custom_components/rental_control/event_overrides.py
+- [X] T079 [US4] Keep callback suppression and single-lock reconciliation apply behavior without nested refreshes in custom_components/rental_control/util.py and custom_components/rental_control/event_overrides.py
+- [X] T080 [US4] Run US4 validation for tests/unit/test_util.py, tests/unit/test_event_overrides.py, tests/unit/test_slot_reconciliation.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_slot_concurrency.py
 
 **Checkpoint**: US4 proves SC-006, SC-007 safety behavior, FR-009, FR-010,
 FR-011, FR-012, and confirmed-reset-before-reapply.
@@ -265,25 +265,25 @@ tracking, and display attributes.
 
 ### Tests for User Story 5
 
-- [ ] T081 [P] [US5] Add manual check-in and checkout time-of-day override regression tests with Honor Event Times off in tests/unit/test_coordinator.py
-- [ ] T082 [P] [US5] Add Honor Event Times regression tests for timed events, all-day events, description fallback, and configured defaults in tests/unit/test_coordinator.py
-- [ ] T083 [P] [US5] Add manual door-code override tests proving observed manual PINs are preserved in memory and never persisted or logged in tests/unit/test_slot_reconciliation.py
-- [ ] T084 [P] [US5] Add buffer regression tests proving lock-code before and after buffers produce existing Keymaster date ranges in tests/unit/test_util.py
-- [ ] T085 [P] [US5] Add slot-name trimming, prefixing, deterministic code generation, and should_update_code regression tests in tests/unit/test_util.py and tests/unit/test_slot_reconciliation.py
-- [ ] T086 [US5] Add event_N sensor tests proving slot_number and slot_code read from latest StatelessPlan, including date-shift fingerprint-to-desired-id bridge, without calling async_reserve_or_get_slot in tests/unit/test_sensors.py
-- [ ] T087 [US5] Add check-in tracking tests proving sensor attributes, active protection, checked-out release, and unlock validation use latest plan ownership rather than override maps in tests/unit/test_checkin_sensor.py
-- [ ] T088 [US5] Add integration scenario preserving manual time-of-day overrides, manual door-code overrides, buffers, Honor PMS times, check-in tracking, and event_N sensors in tests/integration/test_refresh_cycle.py
-- [ ] T089 [US5] Add integration scenario preserving check-in tracking through reconciliation changes in tests/integration/test_checkin_tracking.py
+- [X] T081 [P] [US5] Add manual check-in and checkout time-of-day override regression tests with Honor Event Times off in tests/unit/test_coordinator.py
+- [X] T082 [P] [US5] Add Honor Event Times regression tests for timed events, all-day events, description fallback, and configured defaults in tests/unit/test_coordinator.py
+- [X] T083 [P] [US5] Add manual door-code override tests proving observed manual PINs are preserved in memory and never persisted or logged in tests/unit/test_slot_reconciliation.py
+- [X] T084 [P] [US5] Add buffer regression tests proving lock-code before and after buffers produce existing Keymaster date ranges in tests/unit/test_util.py
+- [X] T085 [P] [US5] Add slot-name trimming, prefixing, deterministic code generation, and should_update_code regression tests in tests/unit/test_util.py and tests/unit/test_slot_reconciliation.py
+- [X] T086 [US5] Add event_N sensor tests proving slot_number and slot_code read from latest StatelessPlan, including date-shift fingerprint-to-desired-id bridge, without calling async_reserve_or_get_slot in tests/unit/test_sensors.py
+- [X] T087 [US5] Add check-in tracking tests proving sensor attributes, active protection, checked-out release, and unlock validation use latest plan ownership rather than override maps in tests/unit/test_checkin_sensor.py
+- [X] T088 [US5] Add integration scenario preserving manual time-of-day overrides, manual door-code overrides, buffers, Honor PMS times, check-in tracking, and event_N sensors in tests/integration/test_refresh_cycle.py
+- [X] T089 [US5] Add integration scenario preserving check-in tracking through reconciliation changes in tests/integration/test_checkin_tracking.py
 
 ### Implementation for User Story 5
 
-- [ ] T090 [US5] Derive manual time-of-day override input from matched physical slot dates when Honor Event Times does not override them in custom_components/rental_control/coordinator.py
-- [ ] T091 [US5] Preserve manual observed PINs as in-memory desired codes while keeping raw PINs out of Store and logs in custom_components/rental_control/reconciliation.py and custom_components/rental_control/coordinator.py
-- [ ] T092 [US5] Preserve existing buffer, Honor Event Times, deterministic code generation, should_update_code, prefix, and trimming semantics in custom_components/rental_control/coordinator.py and custom_components/rental_control/util.py
-- [ ] T093 [US5] Make event_N sensors read slot_number and slot_code from latest StatelessPlan compatibility lookup without reserving slots in custom_components/rental_control/sensors/calsensor.py
-- [ ] T094 [US5] Make check-in unlock validation read latest stateless plan and observed slot ownership rather than deleted EventOverrides maps in custom_components/rental_control/sensors/checkinsensor.py
-- [ ] T095 [US5] Keep sensor platform setup and entity naming unchanged in custom_components/rental_control/sensor.py
-- [ ] T096 [US5] Run US5 validation for tests/unit/test_coordinator.py, tests/unit/test_util.py, tests/unit/test_sensors.py, tests/unit/test_checkin_sensor.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_checkin_tracking.py
+- [X] T090 [US5] Derive manual time-of-day override input from matched physical slot dates when Honor Event Times does not override them in custom_components/rental_control/coordinator.py
+- [X] T091 [US5] Preserve manual observed PINs as in-memory desired codes while keeping raw PINs out of Store and logs in custom_components/rental_control/reconciliation.py and custom_components/rental_control/coordinator.py
+- [X] T092 [US5] Preserve existing buffer, Honor Event Times, deterministic code generation, should_update_code, prefix, and trimming semantics in custom_components/rental_control/coordinator.py and custom_components/rental_control/util.py
+- [X] T093 [US5] Make event_N sensors read slot_number and slot_code from latest StatelessPlan compatibility lookup without reserving slots in custom_components/rental_control/sensors/calsensor.py
+- [X] T094 [US5] Make check-in unlock validation read latest stateless plan and observed slot ownership rather than deleted EventOverrides maps in custom_components/rental_control/sensors/checkinsensor.py
+- [X] T095 [US5] Keep sensor platform setup and entity naming unchanged in custom_components/rental_control/sensor.py
+- [X] T096 [US5] Run US5 validation for tests/unit/test_coordinator.py, tests/unit/test_util.py, tests/unit/test_sensors.py, tests/unit/test_checkin_sensor.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_checkin_tracking.py
 
 **Checkpoint**: US5 proves SC-008, SC-010, FR-014, FR-015, FR-017, and preserved
 sensor/check-in semantics.
@@ -302,20 +302,20 @@ readable and required operations are confirmed.
 
 ### Tests for User Story 6
 
-- [ ] T097 [P] [US6] Add physical-empty self-heal tests for empty, blank, unknown, UNKNOWN, and None name/PIN states regardless of stale cache in tests/unit/test_slot_reconciliation.py
-- [ ] T098 [P] [US6] Add stale occupant, phantom name-only, duplicate physical occupant, and manually drifted name/PIN/date planner tests in tests/unit/test_slot_reconciliation.py
-- [ ] T099 [P] [US6] Add unmanaged-slot ignored tests proving slots outside the Rental-Control-managed range never receive actions in tests/unit/test_slot_reconciliation.py
-- [ ] T100 [P] [US6] Add caplog and diagnostics tests for reset, blocked, stable-name update, manual drift correction, duplicate collapse, and outside-should-be skip without raw PINs in tests/unit/test_event_overrides.py
-- [ ] T101 [US6] Add integration scenario for physical-empty self-heal from stale cache and assigning a selected reservation in tests/integration/test_refresh_cycle.py
-- [ ] T102 [US6] Add integration scenario for stale, phantom, duplicate, and manually drifted slots converging without restart, reload, clear-all, or Store deletion in tests/integration/test_refresh_cycle.py
-- [ ] T103 [US6] Add integration scenario proving unmanaged Keymaster slots are never modified during stale or duplicate recovery in tests/integration/test_refresh_cycle.py
+- [X] T097 [P] [US6] Add physical-empty self-heal tests for empty, blank, unknown, UNKNOWN, and None name/PIN states regardless of stale cache in tests/unit/test_slot_reconciliation.py
+- [X] T098 [P] [US6] Add stale occupant, phantom name-only, duplicate physical occupant, and manually drifted name/PIN/date planner tests in tests/unit/test_slot_reconciliation.py
+- [X] T099 [P] [US6] Add unmanaged-slot ignored tests proving slots outside the Rental-Control-managed range never receive actions in tests/unit/test_slot_reconciliation.py
+- [X] T100 [P] [US6] Add caplog and diagnostics tests for reset, blocked, stable-name update, manual drift correction, duplicate collapse, and outside-should-be skip without raw PINs in tests/unit/test_event_overrides.py
+- [X] T101 [US6] Add integration scenario for physical-empty self-heal from stale cache and assigning a selected reservation in tests/integration/test_refresh_cycle.py
+- [X] T102 [US6] Add integration scenario for stale, phantom, duplicate, and manually drifted slots converging without restart, reload, clear-all, or Store deletion in tests/integration/test_refresh_cycle.py
+- [X] T103 [US6] Add integration scenario proving unmanaged Keymaster slots are never modified during stale or duplicate recovery in tests/integration/test_refresh_cycle.py
 
 ### Implementation for User Story 6
 
-- [ ] T104 [US6] Implement stale, phantom, duplicate, manual drift, physical-empty, unknown, and unmanaged-slot action planning in custom_components/rental_control/reconciliation.py
-- [ ] T105 [US6] Apply stale, phantom, duplicate, and manual drift corrections through the single apply lock and confirmed-clear safety path in custom_components/rental_control/event_overrides.py
-- [ ] T106 [US6] Add redacted logs and diagnostics for reset, blocked, stable-name update, drift correction, duplicate collapse, and outside-should-be skip in custom_components/rental_control/reconciliation.py and custom_components/rental_control/event_overrides.py
-- [ ] T107 [US6] Run US6 validation for tests/unit/test_slot_reconciliation.py, tests/unit/test_event_overrides.py, and tests/integration/test_refresh_cycle.py
+- [X] T104 [US6] Implement stale, phantom, duplicate, manual drift, physical-empty, unknown, and unmanaged-slot action planning in custom_components/rental_control/reconciliation.py
+- [X] T105 [US6] Apply stale, phantom, duplicate, and manual drift corrections through the single apply lock and confirmed-clear safety path in custom_components/rental_control/event_overrides.py
+- [X] T106 [US6] Add redacted logs and diagnostics for reset, blocked, stable-name update, drift correction, duplicate collapse, and outside-should-be skip in custom_components/rental_control/reconciliation.py and custom_components/rental_control/event_overrides.py
+- [X] T107 [US6] Run US6 validation for tests/unit/test_slot_reconciliation.py, tests/unit/test_event_overrides.py, and tests/integration/test_refresh_cycle.py
 
 **Checkpoint**: US6 proves SC-011, FR-018, FR-019, FR-020, and P2 self-healing
 supportability behavior.
@@ -329,36 +329,36 @@ coverage and repository quality gates, and document final validation.
 
 ### Obsolete Machinery Retirement
 
-- [ ] T108 Remove _next_slot, next_slot, __assign_next_slot, and greedy slot selection from custom_components/rental_control/event_overrides.py
-- [ ] T109 Remove _slot_uids and UID-authoritative matching phases from _find_overlapping_slot in custom_components/rental_control/event_overrides.py
-- [ ] T110 Remove _slot_miss_counts and Store ghost reservation correctness logic from custom_components/rental_control/event_overrides.py and custom_components/rental_control/coordinator.py
-- [ ] T111 Remove _pending_clear_slots, _pending_fences, persisted operation IDs, and persisted blocked slots as assignment fences from custom_components/rental_control/event_overrides.py and custom_components/rental_control/coordinator.py
-- [ ] T112 Remove load_persisted_mappings validation as runtime authority and replace it with cache-only alias/diagnostic loading in custom_components/rental_control/event_overrides.py
-- [ ] T113 Remove async_reserve_or_get_slot, _find_overlapping_slot, async_check_overrides, and production callers from custom_components/rental_control/event_overrides.py and custom_components/rental_control/sensors/calsensor.py
-- [ ] T114 Remove async_adopt_keymaster_slots, _adopt_observed_coded_slots, Store rematch/re-key helpers, find_reservation_rematch production use, and ghost reservation construction from custom_components/rental_control/coordinator.py and custom_components/rental_control/reconciliation.py
-- [ ] T115 Remove obsolete Store status, pending operation, blocked slot, miss count, and adopted-slot constants that are no longer needed from custom_components/rental_control/const.py
+- [X] T108 Remove _next_slot, next_slot, __assign_next_slot, and greedy slot selection from custom_components/rental_control/event_overrides.py
+- [X] T109 Remove _slot_uids and UID-authoritative matching phases from _find_overlapping_slot in custom_components/rental_control/event_overrides.py
+- [X] T110 Remove _slot_miss_counts and Store ghost reservation correctness logic from custom_components/rental_control/event_overrides.py and custom_components/rental_control/coordinator.py
+- [X] T111 Remove _pending_clear_slots, _pending_fences, persisted operation IDs, and persisted blocked slots as assignment fences from custom_components/rental_control/event_overrides.py and custom_components/rental_control/coordinator.py
+- [X] T112 Remove load_persisted_mappings validation as runtime authority and replace it with cache-only alias/diagnostic loading in custom_components/rental_control/event_overrides.py
+- [X] T113 Remove async_reserve_or_get_slot, _find_overlapping_slot, async_check_overrides, and production callers from custom_components/rental_control/event_overrides.py and custom_components/rental_control/sensors/calsensor.py
+- [X] T114 Remove async_adopt_keymaster_slots, _adopt_observed_coded_slots, Store rematch/re-key helpers, find_reservation_rematch production use, and ghost reservation construction from custom_components/rental_control/coordinator.py and custom_components/rental_control/reconciliation.py
+- [X] T115 Remove obsolete Store status, pending operation, blocked slot, miss count, and adopted-slot constants that are no longer needed from custom_components/rental_control/const.py
 
 ### Obsolete Test Migration
 
-- [ ] T116 Migrate or remove tests that assert next_slot, async_reserve_or_get_slot, _find_overlapping_slot phases, UID-authoritative matching, and greedy overflow in tests/unit/test_event_overrides.py
-- [ ] T117 Migrate or remove tests that assert persisted fingerprints, find_reservation_rematch, Store ghost reservations, miss counts, pending fences, and adoption-on-observe as correctness inputs in tests/unit/test_slot_reconciliation.py
-- [ ] T118 Migrate or remove tests that assert async_adopt_keymaster_slots, _adopt_observed_coded_slots, Store re-keying, persisted status classification, and pending-clear import in tests/unit/test_coordinator.py
-- [ ] T119 Migrate or remove integration tests that assert missing Store adoption, persisted UID churn, two-cycle slot-mapping miss tolerance, and reappearing-before-third-miss Store behavior in tests/integration/test_refresh_cycle.py
-- [ ] T120 Migrate or remove concurrency tests that assert legacy reserve-or-get-slot locking instead of stateless apply locking in tests/integration/test_slot_concurrency.py
-- [ ] T121 Run migrated obsolete-test validation for tests/unit/test_event_overrides.py, tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_slot_concurrency.py
+- [X] T116 Migrate or remove tests that assert next_slot, async_reserve_or_get_slot, _find_overlapping_slot phases, UID-authoritative matching, and greedy overflow in tests/unit/test_event_overrides.py
+- [X] T117 Migrate or remove tests that assert persisted fingerprints, find_reservation_rematch, Store ghost reservations, miss counts, pending fences, and adoption-on-observe as correctness inputs in tests/unit/test_slot_reconciliation.py
+- [X] T118 Migrate or remove tests that assert async_adopt_keymaster_slots, _adopt_observed_coded_slots, Store re-keying, persisted status classification, and pending-clear import in tests/unit/test_coordinator.py
+- [X] T119 Migrate or remove integration tests that assert missing Store adoption, persisted UID churn, two-cycle slot-mapping miss tolerance, and reappearing-before-third-miss Store behavior in tests/integration/test_refresh_cycle.py
+- [X] T120 Migrate or remove concurrency tests that assert legacy reserve-or-get-slot locking instead of stateless apply locking in tests/integration/test_slot_concurrency.py
+- [X] T121 Run migrated obsolete-test validation for tests/unit/test_event_overrides.py, tests/unit/test_slot_reconciliation.py, tests/unit/test_coordinator.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_slot_concurrency.py
 
 ### Acceptance and Quality Gates
 
-- [ ] T122 Verify every FR-001 through FR-021 has a unit or integration acceptance test task mapped in specs/013-stateless-reconciliation/tasks.md
-- [ ] T123 Verify every SC-001 through SC-011 has a unit or integration acceptance test task mapped in specs/013-stateless-reconciliation/tasks.md
-- [ ] T124 Verify duplicate-avoidance must-pass scenarios cover length increase, length decrease, full date shift with code change, same-guest back-to-back rebooking, duplicate guest names, and duplicate names plus date shift in tests/unit/test_slot_reconciliation.py and tests/integration/test_refresh_cycle.py
-- [ ] T125 Verify store-non-authoritative must-pass scenarios cover missing, deleted, stale, contradictory, corrupt, mid-run deletion, and save failure cases in tests/unit/test_coordinator.py and tests/integration/test_refresh_cycle.py
-- [ ] T126 Run targeted acceptance tests from quickstart.md for tests/unit/test_slot_reconciliation.py, tests/unit/test_event_overrides.py, tests/unit/test_util.py, tests/unit/test_coordinator.py, tests/unit/test_sensors.py, tests/unit/test_checkin_sensor.py, tests/integration/test_refresh_cycle.py, tests/integration/test_slot_concurrency.py, and tests/integration/test_checkin_tracking.py
-- [ ] T127 Run full test suite with uv run pytest tests/ -x -q
-- [ ] T128 Run linting with uv run ruff check custom_components/ tests/
-- [ ] T129 Run type and documentation quality gates with uv run pre-commit run mypy --all-files and uv run pre-commit run interrogate --all-files
-- [ ] T130 Run all pre-commit hooks with uv run pre-commit run --all-files
-- [ ] T131 Validate quickstart manual verification notes and final expected commands in specs/013-stateless-reconciliation/quickstart.md
+- [X] T122 Verify every FR-001 through FR-021 has a unit or integration acceptance test task mapped in specs/013-stateless-reconciliation/tasks.md
+- [X] T123 Verify every SC-001 through SC-011 has a unit or integration acceptance test task mapped in specs/013-stateless-reconciliation/tasks.md
+- [X] T124 Verify duplicate-avoidance must-pass scenarios cover length increase, length decrease, full date shift with code change, same-guest back-to-back rebooking, duplicate guest names, and duplicate names plus date shift in tests/unit/test_slot_reconciliation.py and tests/integration/test_refresh_cycle.py
+- [X] T125 Verify store-non-authoritative must-pass scenarios cover missing, deleted, stale, contradictory, corrupt, mid-run deletion, and save failure cases in tests/unit/test_coordinator.py and tests/integration/test_refresh_cycle.py
+- [X] T126 Run targeted acceptance tests from quickstart.md for tests/unit/test_slot_reconciliation.py, tests/unit/test_event_overrides.py, tests/unit/test_util.py, tests/unit/test_coordinator.py, tests/unit/test_sensors.py, tests/unit/test_checkin_sensor.py, tests/integration/test_refresh_cycle.py, tests/integration/test_slot_concurrency.py, and tests/integration/test_checkin_tracking.py
+- [X] T127 Run full test suite with uv run pytest tests/ -x -q
+- [X] T128 Run linting with uv run ruff check custom_components/ tests/
+- [X] T129 Run type and documentation quality gates with uv run pre-commit run mypy --all-files and uv run pre-commit run interrogate --all-files
+- [X] T130 Run all pre-commit hooks with uv run pre-commit run --all-files
+- [X] T131 Validate quickstart manual verification notes and final expected commands in specs/013-stateless-reconciliation/quickstart.md
 
 ---
 

--- a/specs/013-stateless-reconciliation/tasks.md
+++ b/specs/013-stateless-reconciliation/tasks.md
@@ -274,6 +274,11 @@ tracking, and display attributes.
 - [X] T087 [US5] Add check-in tracking tests proving sensor attributes, active protection, checked-out release, and unlock validation use latest plan ownership rather than override maps in tests/unit/test_checkin_sensor.py
 - [X] T088 [US5] Add integration scenario preserving manual time-of-day overrides, manual door-code overrides, buffers, Honor PMS times, check-in tracking, and event_N sensors in tests/integration/test_refresh_cycle.py
 - [X] T089 [US5] Add integration scenario preserving check-in tracking through reconciliation changes in tests/integration/test_checkin_tracking.py
+- [X] T132 [US5] Add buffer-aware manual-override regression tests proving
+  Honor Event Times follows calendar check-in/check-out changes after applying
+  before/after buffers, buffer=0 still follows calendar time changes, and true
+  manual deviations from the buffered expected time remain preserved in
+  tests/unit/test_coordinator.py and tests/unit/test_slot_reconciliation.py
 
 ### Implementation for User Story 5
 
@@ -285,8 +290,8 @@ tracking, and display attributes.
 - [X] T095 [US5] Keep sensor platform setup and entity naming unchanged in custom_components/rental_control/sensor.py
 - [X] T096 [US5] Run US5 validation for tests/unit/test_coordinator.py, tests/unit/test_util.py, tests/unit/test_sensors.py, tests/unit/test_checkin_sensor.py, tests/integration/test_refresh_cycle.py, and tests/integration/test_checkin_tracking.py
 
-**Checkpoint**: US5 proves SC-008, SC-010, FR-014, FR-015, FR-017, and preserved
-sensor/check-in semantics.
+**Checkpoint**: US5 proves SC-008, SC-010, FR-014, FR-015, FR-017, FR-022, and
+preserved sensor/check-in semantics.
 
 ---
 
@@ -349,7 +354,7 @@ coverage and repository quality gates, and document final validation.
 
 ### Acceptance and Quality Gates
 
-- [X] T122 Verify every FR-001 through FR-021 has a unit or integration acceptance test task mapped in specs/013-stateless-reconciliation/tasks.md
+- [X] T122 Verify every FR-001 through FR-022 has a unit or integration acceptance test task mapped in specs/013-stateless-reconciliation/tasks.md
 - [X] T123 Verify every SC-001 through SC-011 has a unit or integration acceptance test task mapped in specs/013-stateless-reconciliation/tasks.md
 - [X] T124 Verify duplicate-avoidance must-pass scenarios cover length increase, length decrease, full date shift with code change, same-guest back-to-back rebooking, duplicate guest names, and duplicate names plus date shift in tests/unit/test_slot_reconciliation.py and tests/integration/test_refresh_cycle.py
 - [X] T125 Verify store-non-authoritative must-pass scenarios cover missing, deleted, stale, contradictory, corrupt, mid-run deletion, and save failure cases in tests/unit/test_coordinator.py and tests/integration/test_refresh_cycle.py

--- a/specs/013-stateless-reconciliation/tasks.md
+++ b/specs/013-stateless-reconciliation/tasks.md
@@ -20,7 +20,7 @@ Store fences, ghost reservations, adoption machinery, and per-event greedy
 allocation with one stateless per-refresh planner. `event_N` sensors remain
 read-only reflections of the latest calendar data and stateless plan.
 
-## Format: `- [X] T### [P?] [Story?] Description with file path`
+## Format: `- [ ] T### [P?] [Story?] Description with file path`
 
 - **[P]**: Can run in parallel (different files, no dependency on incomplete
   tasks)

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -23,6 +23,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
@@ -391,7 +392,7 @@ async def test_missing_store_adopts_coded_slots_when_unavailable_at_setup(
         assert not identity_key.startswith("adopted.")
         mapping = next(iter(mappings.values()))
         assert mapping["slot"] == 10
-        assert mapping["status"] == "occupied"
+        assert mapping["status"] == "cache"
         assert mapping["identity"]["slot_name"] == "Current Guest"
         assert mapping["last_observed_actual"]["has_code"] is True
         assert coordinator._latest_plan is not None
@@ -503,7 +504,7 @@ async def test_deleted_store_reenable_recovers_coded_slots(
         assert not identity_key.startswith("adopted.")
         mapping = next(iter(mappings.values()))
         assert mapping["slot"] == 10
-        assert mapping["status"] == "occupied"
+        assert mapping["status"] == "cache"
         assert mapping["identity"]["slot_name"] == "Reenabled Guest"
         assert coordinator._latest_plan is not None
         assert coordinator._latest_plan.selected == {identity_key: 10}
@@ -909,9 +910,9 @@ class TestClearFailureSlotNotReused:
         coordinator.code_buffer_after = 0
         coordinator.hass.services.async_call = AsyncMock()
         coordinator.event_overrides = eo
-        name_state = MagicMock()
-        name_state.state = "New Guest"
-        coordinator.hass.states.get.return_value = name_state
+        empty_state = MagicMock()
+        empty_state.state = ""
+        coordinator.hass.states.get.return_value = empty_state
 
         failed_result = OperationResult(
             kind="clear",
@@ -1233,10 +1234,18 @@ class TestManualDriftCorrection:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        empty_state = MagicMock()
+        empty_state.state = ""
+        coordinator.hass.states.get.return_value = empty_state
 
+        clear_confirmed = OperationResult(kind="clear", slot=5, confirmed=True)
         confirmed = OperationResult(kind="set", slot=5, confirmed=True)
         with (
             caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                return_value=clear_confirmed,
+            ),
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_set_code",
                 return_value=confirmed,
@@ -1782,9 +1791,9 @@ class TestStaleMisassignedSlot:
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
         coordinator.event_prefix = ""
-        name_state = MagicMock()
-        name_state.state = "Desired Guest"
-        coordinator.hass.states.get.return_value = name_state
+        empty_state = MagicMock()
+        empty_state.state = ""
+        coordinator.hass.states.get.return_value = empty_state
 
         async def mock_clear(coord, slot, **kwargs):
             """Return a confirmed clear result for the given slot."""
@@ -2706,6 +2715,7 @@ class TestTwoCycleTransientMissTolerance:
         a persisted occupied mapping exists.  After three cycles the
         mapping's missing_count must be 3.
         """
+        pytest.skip("Store mappings are cache-only; missing_count is non-authoritative")
         from unittest.mock import AsyncMock
         from unittest.mock import MagicMock
         from unittest.mock import patch
@@ -2874,6 +2884,7 @@ class TestReappearingBeforeThirdMiss:
           Cycle 3: PRESENT → missing_count 2→0 (reset)
         After cycle 3, _slot_mappings missing_count must be 0.
         """
+        pytest.skip("Store mappings are cache-only; missing_count is non-authoritative")
         from datetime import timezone as _tz
         from unittest.mock import AsyncMock
         from unittest.mock import MagicMock

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import cast
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -59,6 +60,7 @@ def _install_keymaster_text_states(
     pins: dict[int, str],
 ) -> None:
     """Install concrete Keymaster name/PIN reads for preflight tests."""
+    previous_side_effect = coordinator.hass.states.get.side_effect
 
     def _get_state(entity_id: str) -> MagicMock | None:
         """Return configured name or PIN state for a Keymaster text entity."""
@@ -68,6 +70,8 @@ def _install_keymaster_text_states(
         for slot, pin in pins.items():
             if entity_id.endswith(f"_code_slot_{slot}_pin"):
                 return _state(pin)
+        if callable(previous_side_effect):
+            return cast("MagicMock | None", previous_side_effect(entity_id))
         return None
 
     coordinator.hass.states.get.side_effect = _get_state

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -46,6 +46,33 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 
+def _state(value: str) -> MagicMock:
+    """Return a fake Home Assistant state object with a concrete string state."""
+    state = MagicMock()
+    state.state = value
+    return state
+
+
+def _install_keymaster_text_states(
+    coordinator: MagicMock,
+    names: dict[int, str],
+    pins: dict[int, str],
+) -> None:
+    """Install concrete Keymaster name/PIN reads for preflight tests."""
+
+    def _get_state(entity_id: str) -> MagicMock | None:
+        """Return configured name or PIN state for a Keymaster text entity."""
+        for slot, name in names.items():
+            if entity_id.endswith(f"_code_slot_{slot}_name"):
+                return _state(name)
+        for slot, pin in pins.items():
+            if entity_id.endswith(f"_code_slot_{slot}_pin"):
+                return _state(pin)
+        return None
+
+    coordinator.hass.states.get.side_effect = _get_state
+
+
 # ---------------------------------------------------------------------------
 # T112 – initial data load
 # ---------------------------------------------------------------------------
@@ -844,6 +871,16 @@ class TestClearFailureSlotNotReused:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        _install_keymaster_text_states(
+            coordinator,
+            {4: "Guest r-far2-535"},
+            {4: "PINr-far2-535"},
+        )
+        _install_keymaster_text_states(
+            coordinator,
+            {1: "OldGuest"},
+            {1: "c1"},
+        )
 
         failed_result = OperationResult(
             kind="clear",
@@ -1234,17 +1271,28 @@ class TestManualDriftCorrection:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
-        empty_state = MagicMock()
-        empty_state.state = ""
-        coordinator.hass.states.get.return_value = empty_state
+        _install_keymaster_text_states(
+            coordinator,
+            {3: "Guest r-far-546"},
+            {3: "PINr-far-546"},
+        )
+        _install_keymaster_text_states(
+            coordinator,
+            {5: "Guest Drift"},
+            {5: "SECRETPIN72"},
+        )
 
-        clear_confirmed = OperationResult(kind="clear", slot=5, confirmed=True)
+        async def mock_clear(coord, slot, **kwargs):
+            """Return confirmed clear and expose empty state for replacement set."""
+            _install_keymaster_text_states(coordinator, {5: ""}, {5: ""})
+            return OperationResult(kind="clear", slot=slot, confirmed=True)
+
         confirmed = OperationResult(kind="set", slot=5, confirmed=True)
         with (
             caplog.at_level(logging.WARNING, logger="custom_components.rental_control"),
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_clear_code",
-                return_value=clear_confirmed,
+                side_effect=mock_clear,
             ),
             patch(
                 "custom_components.rental_control.event_overrides.async_fire_set_code",
@@ -1454,6 +1502,11 @@ class TestTripleAssignmentCollapse:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        _install_keymaster_text_states(
+            coordinator,
+            {4: "Guest 589", 5: "Guest 589"},
+            {4: "PIN589", 5: "PIN589"},
+        )
 
         async def mock_clear(coord, slot, **kwargs):
             """Return a confirmed clear result for the given slot."""
@@ -1549,6 +1602,11 @@ class TestPhantomNameOnlySlot:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        _install_keymaster_text_states(
+            coordinator,
+            {5: "OldPhantomGuest"},
+            {5: ""},
+        )
 
         confirmed_clear = OperationResult(kind="clear", slot=5, confirmed=True)
         with patch(
@@ -1667,6 +1725,11 @@ class TestStaleExpiredAssignment:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        _install_keymaster_text_states(
+            coordinator,
+            {5: "OldExpiredGuest"},
+            {5: "PIN-EXPIRED"},
+        )
 
         confirmed_clear = OperationResult(kind="clear", slot=5, confirmed=True)
         with patch(
@@ -1950,6 +2013,11 @@ class TestNearerNotProgrammedWhenFull:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        _install_keymaster_text_states(
+            coordinator,
+            {4: "Guest r-far2-535"},
+            {4: "PINr-far2-535"},
+        )
 
         async def mock_clear(coord, slot, **kwargs):
             """Return a confirmed clear result for the given slot."""
@@ -2105,6 +2173,11 @@ class TestFartherEvictsNearer:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        _install_keymaster_text_states(
+            coordinator,
+            {3: "Guest r-far-546"},
+            {3: "PINr-far-546"},
+        )
 
         async def mock_clear(coord, slot, **kwargs):
             """Return a confirmed clear result for the given slot."""

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -122,6 +122,43 @@ async def test_duplicate_name_manual_pin_lookup_pairs_by_start_order(
     ]
 
 
+async def test_duplicate_name_manual_pin_lookup_does_not_steal_later_slot(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """An earlier same-name stay cannot consume a later stay's observed PIN."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    start_one = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    end_one = start_one + timedelta(days=7)
+    start_two = dt_util.as_utc(datetime(2026, 8, 15, 14))
+    end_two = start_two + timedelta(days=7)
+    calendar = [
+        CalendarEvent(start=start_one, end=end_one, summary="Bob", description=""),
+        CalendarEvent(start=start_two, end=end_two, summary="Bob", description=""),
+    ]
+    observed_slots = [
+        ManagedSlot(
+            slot=2,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="2222",
+            actual_code_present=True,
+            actual_start=start_two,
+            actual_end=end_two,
+        )
+    ]
+
+    reservations = coordinator._build_reservations(calendar, observed_slots)
+
+    assert reservations[0].code_source == "generated"
+    assert reservations[1].slot_code == "2222"
+    assert reservations[1].code_source == "manual_observed"
+
+
 async def test_coordinator_first_refresh(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -379,6 +379,60 @@ async def test_checkin_missing_active_does_not_protect_future_same_name(
     assert reservations[1].slot_code == "1111"
 
 
+async def test_build_reservations_does_not_copy_active_pin_to_future_same_name(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Manual PIN lookup skips the checked-in physical slot for future stays."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    active_start = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    active_end = active_start + timedelta(days=7)
+    future_start = dt_util.as_utc(datetime(2026, 9, 1, 14))
+    future_end = future_start + timedelta(days=7)
+    hass.data[DOMAIN] = {
+        coordinator._entry_id: {
+            CHECKIN_SENSOR: MagicMock(
+                state=CHECKIN_STATE_CHECKED_IN,
+                extra_state_attributes={
+                    "guest_name": "Bob",
+                    "start": active_start,
+                    "end": active_end,
+                    "summary": "Bob",
+                },
+            )
+        }
+    }
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=active_start,
+            actual_end=active_end,
+        )
+    ]
+
+    reservations = coordinator._build_reservations(
+        [CalendarEvent(start=future_start, end=future_end, summary="Bob")],
+        observed_slots,
+    )
+    coordinator._apply_checkin_protection(reservations, observed_slots)
+
+    assert reservations[0].start == future_start
+    assert reservations[0].slot_code != "1111"
+    assert reservations[0].code_source == "generated"
+    assert not reservations[0].protected_active
+    assert len(reservations) == 2
+    assert reservations[1].protected_active
+    assert reservations[1].slot_code == "1111"
+
+
 async def test_coordinator_first_refresh(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -433,6 +433,44 @@ async def test_build_reservations_does_not_copy_active_pin_to_future_same_name(
     assert reservations[1].slot_code == "1111"
 
 
+async def test_missing_checkin_restore_defers_unknown_date_same_name_apply(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Startup apply waits when check-in state may own an unknown-date slot."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import Reservation
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    start = dt_util.as_utc(datetime(2026, 9, 1, 14))
+    end = start + timedelta(days=7)
+    reservations = [
+        Reservation(
+            identity_key="future-bob",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Bob",
+            slot_name="Bob",
+            display_slot_name="Bob",
+            slot_code="2222",
+        )
+    ]
+    slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code_present=True,
+        )
+    ]
+
+    assert coordinator._must_defer_for_checkin_restore(reservations, slots)
+
+
 async def test_coordinator_first_refresh(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -364,8 +364,8 @@ async def test_checkin_missing_active_does_not_protect_future_same_name(
             actual_name="Bob",
             actual_code="1111",
             actual_code_present=True,
-            actual_start=active_start,
-            actual_end=active_end,
+            actual_start=None,
+            actual_end=None,
         )
     ]
     reservations = [future]
@@ -413,8 +413,8 @@ async def test_build_reservations_does_not_copy_active_pin_to_future_same_name(
             actual_name="Bob",
             actual_code="1111",
             actual_code_present=True,
-            actual_start=active_start,
-            actual_end=active_end,
+            actual_start=None,
+            actual_end=None,
         )
     ]
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -52,6 +52,76 @@ async def test_coordinator_initialization(
     assert coordinator.url == "https://example.com/calendar.ics"
 
 
+async def test_observed_slot_lookup_does_not_use_arbitrary_prefix_match(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Observed manual PIN lookup does not treat Ann and Anna as the same guest."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    ann_slot = ManagedSlot(
+        slot=1,
+        managed=True,
+        status=SlotStatus.OCCUPIED,
+        actual_name="Ann",
+        actual_code="1111",
+        actual_code_present=True,
+    )
+
+    assert coordinator._find_observed_slot_by_name([ann_slot], "Anna", "Anna") is None
+
+
+async def test_duplicate_name_manual_pin_lookup_pairs_by_start_order(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Same-name reservations inherit manual observed PINs from paired slots."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    start_one = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    end_one = start_one + timedelta(days=7)
+    start_two = dt_util.as_utc(datetime(2026, 8, 15, 14))
+    end_two = start_two + timedelta(days=7)
+    calendar = [
+        CalendarEvent(start=start_one, end=end_one, summary="Bob", description=""),
+        CalendarEvent(start=start_two, end=end_two, summary="Bob", description=""),
+    ]
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=start_one,
+            actual_end=end_one,
+        ),
+        ManagedSlot(
+            slot=2,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="2222",
+            actual_code_present=True,
+            actual_start=start_two,
+            actual_end=end_two,
+        ),
+    ]
+
+    reservations = coordinator._build_reservations(calendar, observed_slots)
+
+    assert [reservation.slot_code for reservation in reservations] == ["1111", "2222"]
+    assert [reservation.code_source for reservation in reservations] == [
+        "manual_observed",
+        "manual_observed",
+    ]
+
+
 async def test_coordinator_first_refresh(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -1602,7 +1672,10 @@ class TestLocknameSlugification:
             await coordinator.update_config(config)
 
         assert coordinator.event_overrides is not None
-        assert coordinator.event_overrides.persisted_mappings == {}
+        assert coordinator.event_overrides.persisted_mappings == {
+            "dup-a": {"slot": 10, "status": "occupied"},
+            "dup-b": {"slot": 10, "status": "occupied"},
+        }
 
     async def test_update_config_bootstraps_overrides_after_recreation(
         self,
@@ -4416,12 +4489,12 @@ class TestStoreFirstUpgradeMigration:
         # Initial load
         eo = EventOverrides(start_slot=10, max_slots=3)
         eo.load_persisted_mappings(stored_mappings)
-        assert 10 in eo.pending_clear_slots
+        assert eo.pending_clear_slots == {}
 
         # Simulate restart: create fresh EventOverrides, reload same data
         eo2 = EventOverrides(start_slot=10, max_slots=3)
         eo2.load_persisted_mappings(stored_mappings)
-        assert 10 in eo2.pending_clear_slots, "Fence should be restored after restart"
+        assert eo2.pending_clear_slots == {}
 
 
 class TestStaleStorePhysicalReconciliation:
@@ -4709,7 +4782,9 @@ class TestStaleStorePhysicalReconciliation:
         ):
             await coordinator._async_update_data()
 
-        clear_mock.assert_not_awaited()
+        clear_mock.assert_awaited_once()
+        assert clear_mock.await_args is not None
+        assert clear_mock.await_args.args[1] == 7
         set_mock.assert_not_awaited()
         assert coordinator._latest_plan is not None
         assert coordinator._latest_plan.selected[current_key] == 6
@@ -4847,11 +4922,13 @@ class TestStaleStorePhysicalReconciliation:
         ):
             await coordinator._async_update_data()
 
-        clear_mock.assert_not_awaited()
+        clear_mock.assert_awaited_once()
+        assert clear_mock.await_args is not None
+        assert clear_mock.await_args.args[1] == 6
         set_mock.assert_not_awaited()
         assert coordinator._latest_plan is not None
         assert coordinator._latest_plan.selected.get(new_key) is None
-        assert coordinator._latest_plan.overflow[new_key] == "no_free_slot"
+        assert coordinator._latest_plan.overflow[new_key] == "no_empty_slot"
 
     async def test_exact_store_identity_yields_to_conflicting_physical_slot(
         self, hass: HomeAssistant
@@ -5026,14 +5103,16 @@ class TestStaleStorePhysicalReconciliation:
         ):
             await coordinator._async_update_data()
 
-        clear_mock.assert_not_awaited()
+        clear_mock.assert_awaited_once()
+        assert clear_mock.await_args is not None
+        assert clear_mock.await_args.args[1] == 6
         set_slots = [call.args[1] for call in set_mock.await_args_list]
         assert 6 not in set_slots
         assert coordinator._latest_plan is not None
         assert coordinator._latest_plan.selected[alice_key] == 7
-        assert any(
-            mapping["slot"] == 6 and key.startswith("observed.")
-            for key, mapping in coordinator._slot_mappings["mappings"].items()
+        assert all(
+            not key.startswith("observed.")
+            for key in coordinator._slot_mappings["mappings"]
         )
 
     async def test_physical_reclaim_replaces_stale_empty_exact_mapping(
@@ -5204,16 +5283,15 @@ class TestStaleStorePhysicalReconciliation:
         ):
             await coordinator._async_update_data()
 
-        clear_mock.assert_not_awaited()
+        clear_mock.assert_awaited_once()
+        assert clear_mock.await_args is not None
+        assert clear_mock.await_args.args[1] == 7
         set_mock.assert_not_awaited()
         assert coordinator._latest_plan is not None
         assert coordinator._latest_plan.selected[alice_key] == 6
         mappings = coordinator._slot_mappings["mappings"]
         assert mappings[alice_key]["slot"] == 6
-        assert any(
-            mapping["slot"] == 7 and key.startswith("observed.")
-            for key, mapping in mappings.items()
-        )
+        assert all(not key.startswith("observed.") for key in mappings)
 
     def test_trimmed_prefixed_physical_name_does_not_skip_ghost(
         self, hass: HomeAssistant
@@ -5898,10 +5976,9 @@ class TestCoordinatorRehydration:
         coordinator._slot_mappings = store_data
         coordinator.event_overrides.load_persisted_mappings(store_data["mappings"])
 
-        # pending_clear_slots maps slot→operation_id
+        # Pending-clear cache fields are non-authoritative.
         pcs = coordinator.event_overrides.pending_clear_slots
-        assert 10 in pcs
-        assert pcs[10] == "op-abc123"
+        assert pcs == {}
 
     # ------------------------------------------------------------------
     # T087-4: uid_aliases and booking_aliases rehydrated from identity dict
@@ -6152,7 +6229,7 @@ class TestCoordinatorPersistenceUpdate:
                 coordinator, plan, {res.identity_key: res for res in reservations}
             )
 
-        mock_clear.assert_not_called()
+        assert mock_clear.await_count == 3
 
     def test_pending_clear_self_heals_when_physically_empty(
         self, hass: "HomeAssistant"
@@ -6510,7 +6587,7 @@ class TestCoordinatorPersistenceUpdate:
         observed = coordinator._observe_managed_slots()
         slot10 = next(slot for slot in observed if slot.slot == 10)
 
-        assert slot10.status is SlotStatus.PENDING_CLEAR
+        assert slot10.status is SlotStatus.OCCUPIED
         assert slot10.actual_code_present is True
 
         reservation = Reservation(
@@ -6533,7 +6610,7 @@ class TestCoordinatorPersistenceUpdate:
         )
 
         assert plan.selected == {}
-        assert plan.overflow == {"new-real-pin": "no_free_slot"}
+        assert plan.overflow == {"new-real-pin": "no_empty_slot"}
 
     async def test_adoption_fences_unnamed_real_pin(
         self, hass: "HomeAssistant"
@@ -6604,7 +6681,7 @@ class TestCoordinatorPersistenceUpdate:
             generated_at=start,
         )
         assert plan.selected == {}
-        assert plan.overflow == {"new-after-unavailable": "no_free_slot"}
+        assert plan.overflow == {"new-after-unavailable": "no_empty_slot"}
         from custom_components.rental_control.reconciliation import ActionKind
 
         assert plan.slots[10].action is ActionKind.BLOCKED
@@ -6679,17 +6756,13 @@ class TestCoordinatorPersistenceUpdate:
         )
 
         assert plan.selected == {}
-        assert plan.overflow == {"new-unreadable": "no_free_slot"}
+        assert plan.overflow == {"new-unreadable": "no_empty_slot"}
         assert plan.slots[10].action is ActionKind.BLOCKED
 
     def test_adoption_rematch_uses_buffered_observed_dates(
         self, hass: "HomeAssistant"
     ) -> None:
         """Ambiguous trimmed adopted names use observed buffered dates."""
-        from custom_components.rental_control.reconciliation import (
-            make_reservation_fingerprint,
-        )
-
         entry = self._make_persist_entry(max_events=2)
         entry.add_to_hass(hass)
         coordinator = RentalControlCoordinator(hass, entry)
@@ -6740,19 +6813,12 @@ class TestCoordinatorPersistenceUpdate:
             event.uid = None
             events.append(event)
 
-        coordinator._build_reservations(events)
+        reservations = coordinator._build_reservations(events)
 
-        expected_a = make_reservation_fingerprint(
-            entry.entry_id, "Repeat Guest Family A", start_a, end_a
-        )
-        expected_b = make_reservation_fingerprint(
-            entry.entry_id, "Repeat Guest Family B", start_b, end_b
-        )
         mappings = coordinator._slot_mappings["mappings"]
-        assert mappings[expected_a]["slot"] == 10
-        assert mappings[expected_b]["slot"] == 11
-        assert adopted_a not in mappings
-        assert adopted_b not in mappings
+        assert len(reservations) == 2
+        assert adopted_a in mappings
+        assert adopted_b in mappings
 
     def test_empty_slot_not_adopted_as_occupied(self, hass: "HomeAssistant") -> None:
         """Physically empty unmapped slots stay free, not adopted occupied."""
@@ -6817,7 +6883,7 @@ class TestCoordinatorPersistenceUpdate:
             plan_id="idempotent-readopt",
             generated_at=start,
         )
-        assert plan.selected == {next(iter(mappings)): 10}
+        assert plan.selected == {reservations[0].identity_key: 10}
         assert plan.overflow == {}
 
     def test_unavailable_slot_not_adopted_until_readable(
@@ -7002,16 +7068,15 @@ class TestCoordinatorPersistenceUpdate:
             mock_session.get("https://example.com/calendar.ics", body=empty_ics)
             await coordinator._async_update_data()
 
-        # missing_count in _slot_mappings must have been incremented to 1
+        # Store cache missing_count is no longer authoritative.
         updated_mc = coordinator._slot_mappings["mappings"][fp]["missing_count"]
-        assert updated_mc == 1, (
-            f"Expected missing_count=1 after one missed cycle, got {updated_mc}"
-        )
+        assert updated_mc == 0
 
     def test_pending_set_with_dates_uses_missing_lifecycle(
         self, hass: "HomeAssistant"
     ) -> None:
         """T088-11: Vanished pending SET with dates fences then clears."""
+        pytest.skip("legacy Store ghost lifecycle retired by stateless reconciliation")
         from custom_components.rental_control.reconciliation import ActionKind
         from custom_components.rental_control.reconciliation import ManagedSlot
         from custom_components.rental_control.reconciliation import Reservation
@@ -7118,6 +7183,7 @@ class TestCoordinatorPersistenceUpdate:
         self, hass: "HomeAssistant"
     ) -> None:
         """T088-12: Vanished pending SET without dates cannot orphan."""
+        pytest.skip("legacy Store ghost lifecycle retired by stateless reconciliation")
         from custom_components.rental_control.reconciliation import ActionKind
         from custom_components.rental_control.reconciliation import Reservation
         from custom_components.rental_control.reconciliation import SlotStatus
@@ -7310,9 +7376,7 @@ class TestCoordinatorPersistenceUpdate:
             await coordinator._async_update_data()
 
         updated_mc = coordinator._slot_mappings["mappings"][fp]["missing_count"]
-        assert updated_mc == 0, (
-            f"Expected missing_count=0 after reappearance, got {updated_mc}"
-        )
+        assert updated_mc == 1
 
     def test_sync_store_records_confirmed_selected_mapping(
         self, hass: "HomeAssistant"
@@ -7353,7 +7417,7 @@ class TestCoordinatorPersistenceUpdate:
 
         mapping = coordinator._slot_mappings["mappings"][identity_key]
         assert mapping["slot"] == 10
-        assert mapping["status"] == "occupied"
+        assert mapping["status"] == "cache"
         assert mapping["operation_id"] is None
         assert mapping["operation_kind"] is None
         assert mapping["pending_set_since"] is None
@@ -7436,10 +7500,10 @@ class TestCoordinatorPersistenceUpdate:
 
         mapping = coordinator._slot_mappings["mappings"][identity_key]
         assert mapping["slot"] == 10
-        assert mapping["status"] == "pending_set"
-        assert mapping["operation_id"] == "persist-unconfirmed"
-        assert mapping["operation_kind"] == "set"
-        assert mapping["pending_set_since"] is not None
+        assert mapping["status"] == "cache"
+        assert mapping["operation_id"] is None
+        assert mapping["operation_kind"] is None
+        assert mapping["pending_set_since"] is None
 
     def test_sync_store_skips_failed_set_mapping(self, hass: "HomeAssistant") -> None:
         """T088-5: Failed SET results are not persisted as occupied."""
@@ -7625,11 +7689,8 @@ class TestCoordinatorPersistenceUpdate:
         reservations = coordinator._build_reservations([event])
 
         assert [res.identity_key for res in reservations] == [new_key]
-        assert old_key not in coordinator._slot_mappings["mappings"]
-        migrated = coordinator._slot_mappings["mappings"][new_key]
-        assert migrated["slot"] == 10
-        assert old_key in migrated["fingerprint_history"]
-        assert migrated["identity"]["identity_key"] == new_key
+        assert old_key in coordinator._slot_mappings["mappings"]
+        assert new_key not in coordinator._slot_mappings["mappings"]
 
     def test_observe_slots_uses_rematched_store_identity(
         self, hass: "HomeAssistant"
@@ -7685,7 +7746,8 @@ class TestCoordinatorPersistenceUpdate:
         observed = coordinator._observe_managed_slots()
 
         slot10 = next(slot for slot in observed if slot.slot == 10)
-        assert slot10.persisted_identity_key == fingerprint
+        assert fingerprint
+        assert slot10.persisted_identity_key is None
 
     def test_build_reservations_uses_full_set_for_ambiguous_rematch(
         self, hass: "HomeAssistant"

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1300,10 +1300,10 @@ async def test_buffer_config_updates_override_cache(
     )
 
 
-async def test_buffer_config_service_failure_keeps_override_cache(
+async def test_buffer_config_service_failure_advances_override_cache(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
-    """Failed buffer writes do not advance in-memory override times."""
+    """Failed buffer writes still prevent stale override reinterpretation."""
     from zoneinfo import ZoneInfo
 
     from custom_components.rental_control.event_overrides import EventOverrides
@@ -1357,8 +1357,31 @@ async def test_buffer_config_service_failure_keeps_override_cache(
 
     override = coordinator.event_overrides.overrides[10]
     assert override is not None
-    assert override["start_time"] == old_start
-    assert override["end_time"] == old_end
+    assert override["start_time"] == utc_time(25, 15, 0)
+    assert override["end_time"] == utc_time(30, 11, 15)
+
+
+async def test_buffer_datetime_match_treats_naive_values_as_local(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Naive Keymaster datetimes compare as local wall-clock values."""
+    from zoneinfo import ZoneInfo
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    coordinator.timezone = ZoneInfo("America/New_York")
+    aware_expected: datetime = dt.as_utc(
+        datetime.combine(
+            datetime(2024, 12, 25).date(),
+            datetime(2024, 12, 25, 15, 30).time(),
+            coordinator.timezone,
+        )
+    )
+
+    assert coordinator._datetimes_match(
+        datetime(2024, 12, 25, 15, 30),
+        aware_expected,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -25,6 +25,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.rental_control.const import CHECKIN_SENSOR
 from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_IN
+from custom_components.rental_control.const import CONF_CODE_BUFFER_BEFORE
 from custom_components.rental_control.const import CONF_LOCK_ENTRY
 from custom_components.rental_control.const import CONF_MAX_EVENTS
 from custom_components.rental_control.const import CONF_REFRESH_FREQUENCY
@@ -605,6 +606,7 @@ async def test_missing_checkin_restore_defers_unknown_date_same_name_apply(
         )
     ]
     hass.data[DOMAIN] = {coordinator._entry_id: {}}
+    coordinator._checkin_restore_pending = True
 
     assert coordinator._must_defer_for_checkin_restore(reservations, slots)
 
@@ -646,6 +648,49 @@ async def test_missing_checkin_restore_defers_stale_physical_occupant(
         )
     ]
     hass.data[DOMAIN] = {coordinator._entry_id: {}}
+    coordinator._checkin_restore_pending = True
+
+    assert coordinator._must_defer_for_checkin_restore(reservations, slots)
+
+
+async def test_missing_checkin_restore_defers_same_name_different_dates(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Startup waits before rewriting a possible active same-name slot."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import Reservation
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    start = dt_util.as_utc(datetime(2026, 9, 1, 14))
+    end = start + timedelta(days=7)
+    reservations = [
+        Reservation(
+            identity_key="future-bob",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Bob",
+            slot_name="Bob",
+            display_slot_name="Bob",
+            slot_code="2222",
+        )
+    ]
+    slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code_present=True,
+            actual_start=start - timedelta(days=14),
+            actual_end=end - timedelta(days=14),
+        )
+    ]
+    hass.data[DOMAIN] = {coordinator._entry_id: {}}
+    coordinator._checkin_restore_pending = True
 
     assert coordinator._must_defer_for_checkin_restore(reservations, slots)
 
@@ -686,6 +731,7 @@ async def test_missing_checkin_restore_defers_prefixed_unknown_date_apply(
         )
     ]
     hass.data[DOMAIN] = {coordinator._entry_id: {}}
+    coordinator._checkin_restore_pending = True
 
     assert coordinator._must_defer_for_checkin_restore(reservations, slots)
 
@@ -969,6 +1015,43 @@ async def test_coordinator_update_interval_change(
     assert coordinator.refresh_frequency != initial_frequency
     assert coordinator.update_interval == timedelta(minutes=30)
     assert coordinator.async_request_refresh.called
+
+
+async def test_buffer_config_updates_times_before_refresh(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Buffer changes update existing overrides before refreshing plans."""
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    calls: list[str] = []
+
+    async def update_buffer_times(_old_before: int, _old_after: int) -> None:
+        """Record buffer update ordering."""
+        calls.append("buffer")
+
+    async def request_refresh() -> None:
+        """Record refresh ordering."""
+        calls.append("refresh")
+
+    new_config = dict(mock_config_entry.data)
+    new_config[CONF_REFRESH_FREQUENCY] = DEFAULT_REFRESH_FREQUENCY
+    new_config[CONF_CODE_BUFFER_BEFORE] = 60
+
+    with (
+        patch.object(
+            coordinator,
+            "_async_update_buffer_times",
+            side_effect=update_buffer_times,
+        ),
+        patch.object(
+            coordinator,
+            "async_request_refresh",
+            side_effect=request_refresh,
+        ),
+    ):
+        await coordinator.update_config(new_config)
+
+    assert calls == ["buffer", "refresh"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -471,6 +471,45 @@ async def test_missing_checkin_restore_defers_unknown_date_same_name_apply(
     assert coordinator._must_defer_for_checkin_restore(reservations, slots)
 
 
+async def test_missing_checkin_restore_defers_prefixed_unknown_date_apply(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Startup deferral compares prefixed physical display names."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import Reservation
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    coordinator.event_prefix = "RC"
+    start = dt_util.as_utc(datetime(2026, 9, 1, 14))
+    end = start + timedelta(days=7)
+    reservations = [
+        Reservation(
+            identity_key="future-bob",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Bob",
+            slot_name="Bob",
+            display_slot_name="RC Bob",
+            slot_code="2222",
+        )
+    ]
+    slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="RC Bob",
+            actual_code_present=True,
+        )
+    ]
+
+    assert coordinator._must_defer_for_checkin_restore(reservations, slots)
+
+
 async def test_coordinator_first_refresh(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -314,6 +314,63 @@ async def test_duplicate_same_start_feed_order_preserves_manual_pins(
     assert [reservation.slot_code for reservation in reservations] == ["1111", "2222"]
 
 
+async def test_duplicate_name_extra_stale_slot_does_not_steal_pins(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Overfull same-name physical groups inherit PINs from canonical slots."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    desired_one = dt_util.as_utc(datetime(2026, 8, 15, 14))
+    desired_two = dt_util.as_utc(datetime(2026, 8, 22, 14))
+    calendar = [
+        CalendarEvent(
+            start=desired_one, end=desired_one + timedelta(days=7), summary="Bob"
+        ),
+        CalendarEvent(
+            start=desired_two, end=desired_two + timedelta(days=7), summary="Bob"
+        ),
+    ]
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="9999",
+            actual_code_present=True,
+            actual_start=dt_util.as_utc(datetime(2026, 8, 1, 14)),
+            actual_end=dt_util.as_utc(datetime(2026, 8, 8, 14)),
+        ),
+        ManagedSlot(
+            slot=2,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=dt_util.as_utc(datetime(2026, 8, 8, 14)),
+            actual_end=dt_util.as_utc(datetime(2026, 8, 15, 14)),
+        ),
+        ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="2222",
+            actual_code_present=True,
+            actual_start=dt_util.as_utc(datetime(2026, 8, 15, 14)),
+            actual_end=dt_util.as_utc(datetime(2026, 8, 22, 14)),
+        ),
+    ]
+
+    reservations = coordinator._build_reservations(calendar, observed_slots)
+
+    assert [reservation.slot_code for reservation in reservations] == ["1111", "2222"]
+
+
 async def test_checkin_protection_matches_duplicate_by_start_end(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -215,6 +215,59 @@ async def test_duplicate_name_date_shift_preserves_ordered_manual_pins(
     ]
 
 
+async def test_duplicate_name_shift_into_old_date_preserves_order(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Same-name date shifts pair by physical order, not exact old dates."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    old_start_one = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    old_end_one = old_start_one + timedelta(days=7)
+    old_start_two = old_end_one
+    old_end_two = old_start_two + timedelta(days=7)
+    new_start_one = old_start_two
+    new_end_one = old_end_two
+    new_start_two = old_end_two
+    new_end_two = new_start_two + timedelta(days=7)
+    calendar = [
+        CalendarEvent(start=new_start_one, end=new_end_one, summary="Bob"),
+        CalendarEvent(start=new_start_two, end=new_end_two, summary="Bob"),
+    ]
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=old_start_one,
+            actual_end=old_end_one,
+        ),
+        ManagedSlot(
+            slot=2,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="2222",
+            actual_code_present=True,
+            actual_start=old_start_two,
+            actual_end=old_end_two,
+        ),
+    ]
+
+    reservations = coordinator._build_reservations(calendar, observed_slots)
+
+    assert [reservation.slot_code for reservation in reservations] == ["1111", "2222"]
+    assert [reservation.code_source for reservation in reservations] == [
+        "manual_observed",
+        "manual_observed",
+    ]
+
+
 async def test_checkin_protection_matches_duplicate_by_start_end(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -202,6 +202,43 @@ async def test_partial_duplicate_shift_preserves_unreserved_manual_pin(
     assert reservations[1].code_source == "generated"
 
 
+async def test_partial_duplicate_shift_pairs_closest_reservation(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """A lone shifted duplicate physical slot pairs with the closest stay."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    early_start = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    early_end = early_start + timedelta(days=7)
+    late_start = dt_util.as_utc(datetime(2026, 8, 15, 14))
+    late_end = late_start + timedelta(days=7)
+    calendar = [
+        CalendarEvent(start=early_start, end=early_end, summary="Bob"),
+        CalendarEvent(start=late_start, end=late_end, summary="Bob"),
+    ]
+    observed_slots = [
+        ManagedSlot(
+            slot=2,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="2222",
+            actual_code_present=True,
+            actual_start=late_start - timedelta(days=1),
+            actual_end=late_end - timedelta(days=1),
+        )
+    ]
+
+    reservations = coordinator._build_reservations(calendar, observed_slots)
+
+    assert reservations[0].code_source == "generated"
+    assert reservations[1].slot_code == "2222"
+    assert reservations[1].code_source == "manual_observed"
+
+
 async def test_duplicate_name_date_shift_preserves_ordered_manual_pins(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -371,6 +371,56 @@ async def test_checkin_protection_synthesizes_missing_active_physical_stay(
     assert reservations[0].slot_code == "1111"
 
 
+async def test_checkin_missing_active_survives_buffer_config_change(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """A changed buffer does not make an active physical stay clearable."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import Reservation
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    coordinator.code_buffer_before = 60
+    coordinator.code_buffer_after = 60
+    start = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    end = start + timedelta(days=7)
+    old_buffered_start = start
+    old_buffered_end = end
+    hass.data[DOMAIN] = {
+        coordinator._entry_id: {
+            CHECKIN_SENSOR: MagicMock(
+                state=CHECKIN_STATE_CHECKED_IN,
+                extra_state_attributes={
+                    "guest_name": "Bob",
+                    "start": start,
+                    "end": end,
+                    "summary": "Bob",
+                },
+            )
+        }
+    }
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=old_buffered_start,
+            actual_end=old_buffered_end,
+        )
+    ]
+    reservations: list[Reservation] = []
+
+    coordinator._apply_checkin_protection(reservations, observed_slots)
+
+    assert len(reservations) == 1
+    assert reservations[0].protected_active
+    assert reservations[0].slot_code == "1111"
+
+
 async def test_checkin_missing_active_does_not_protect_future_same_name(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -554,6 +604,48 @@ async def test_missing_checkin_restore_defers_unknown_date_same_name_apply(
             actual_code_present=True,
         )
     ]
+    hass.data[DOMAIN] = {coordinator._entry_id: {}}
+
+    assert coordinator._must_defer_for_checkin_restore(reservations, slots)
+
+
+async def test_missing_checkin_restore_defers_stale_physical_occupant(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Startup apply waits before clearing a possible active missing stay."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import Reservation
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    start = dt_util.as_utc(datetime(2026, 9, 1, 14))
+    end = start + timedelta(days=7)
+    reservations = [
+        Reservation(
+            identity_key="future-alice",
+            start=start,
+            end=end,
+            buffered_start=start,
+            buffered_end=end,
+            summary="Alice",
+            slot_name="Alice",
+            display_slot_name="Alice",
+            slot_code="2222",
+        )
+    ]
+    slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code_present=True,
+            actual_start=start - timedelta(days=14),
+            actual_end=end - timedelta(days=14),
+        )
+    ]
+    hass.data[DOMAIN] = {coordinator._entry_id: {}}
 
     assert coordinator._must_defer_for_checkin_restore(reservations, slots)
 
@@ -593,6 +685,7 @@ async def test_missing_checkin_restore_defers_prefixed_unknown_date_apply(
             actual_code_present=True,
         )
     ]
+    hass.data[DOMAIN] = {coordinator._entry_id: {}}
 
     assert coordinator._must_defer_for_checkin_restore(reservations, slots)
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1233,6 +1233,63 @@ async def test_buffer_config_updates_times_before_refresh(
     assert calls == ["buffer", "refresh"]
 
 
+async def test_buffer_config_updates_override_cache(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Buffer changes keep in-memory physical override times current."""
+    from zoneinfo import ZoneInfo
+
+    from custom_components.rental_control.event_overrides import EventOverrides
+
+    def utc_time(day: int, hour: int, minute: int) -> datetime:
+        """Return an America/New_York local time converted to UTC."""
+        result: datetime = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, day).date(),
+                datetime(2024, 12, day, hour, minute).time(),
+                ZoneInfo("America/New_York"),
+            )
+        )
+        return result
+
+    async def noop_service_call() -> None:
+        """Stand in for a Home Assistant service coroutine."""
+
+    def fake_add_call(
+        _hass: HomeAssistant,
+        coro: list[Any],
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> list[Any]:
+        """Collect a no-op service coroutine."""
+        coro.append(noop_service_call())
+        return coro
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    coordinator.lockname = "front_door"
+    coordinator.event_overrides = EventOverrides(10, 3)
+    coordinator.event_overrides._overrides[10] = {
+        "slot_name": "Buffer Guest",
+        "slot_code": "1234",
+        "start_time": utc_time(25, 15, 30),
+        "end_time": utc_time(30, 11, 30),
+    }
+    coordinator.code_buffer_before = 60
+    coordinator.code_buffer_after = 15
+
+    with patch(
+        "custom_components.rental_control.coordinator.add_call",
+        side_effect=fake_add_call,
+    ):
+        await coordinator._async_update_buffer_times(old_before=30, old_after=30)
+
+    override = coordinator.event_overrides.overrides[10]
+    assert override is not None
+    assert override["start_time"] == utc_time(25, 15, 0)
+    assert override["end_time"] == utc_time(30, 11, 15)
+
+
 # ---------------------------------------------------------------------------
 # Phase 7 – targeted coverage tests for coordinator.py
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -23,10 +23,13 @@ import homeassistant.util.dt as dt_util
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.rental_control.const import CHECKIN_SENSOR
+from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_IN
 from custom_components.rental_control.const import CONF_LOCK_ENTRY
 from custom_components.rental_control.const import CONF_MAX_EVENTS
 from custom_components.rental_control.const import CONF_REFRESH_FREQUENCY
 from custom_components.rental_control.const import DEFAULT_REFRESH_FREQUENCY
+from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.coordinator import RentalControlCoordinator
 
 from tests.fixtures import calendar_data
@@ -157,6 +160,162 @@ async def test_duplicate_name_manual_pin_lookup_does_not_steal_later_slot(
     assert reservations[0].code_source == "generated"
     assert reservations[1].slot_code == "2222"
     assert reservations[1].code_source == "manual_observed"
+
+
+async def test_duplicate_name_date_shift_preserves_ordered_manual_pins(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Same-name shifted stays preserve manual PINs by physical start order."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    old_start_one = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    old_end_one = old_start_one + timedelta(days=7)
+    old_start_two = dt_util.as_utc(datetime(2026, 8, 15, 14))
+    old_end_two = old_start_two + timedelta(days=7)
+    new_start_one = old_start_one + timedelta(days=1)
+    new_end_one = old_end_one + timedelta(days=1)
+    new_start_two = old_start_two + timedelta(days=1)
+    new_end_two = old_end_two + timedelta(days=1)
+    calendar = [
+        CalendarEvent(start=new_start_one, end=new_end_one, summary="Bob"),
+        CalendarEvent(start=new_start_two, end=new_end_two, summary="Bob"),
+    ]
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=old_start_one,
+            actual_end=old_end_one,
+        ),
+        ManagedSlot(
+            slot=2,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="2222",
+            actual_code_present=True,
+            actual_start=old_start_two,
+            actual_end=old_end_two,
+        ),
+    ]
+
+    reservations = coordinator._build_reservations(calendar, observed_slots)
+
+    assert [reservation.slot_code for reservation in reservations] == ["1111", "2222"]
+    assert [reservation.code_source for reservation in reservations] == [
+        "manual_observed",
+        "manual_observed",
+    ]
+
+
+async def test_checkin_protection_matches_duplicate_by_start_end(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Checked-in duplicate-name stays are protected by tracked dates."""
+    from custom_components.rental_control.reconciliation import Reservation
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    start_one = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    end_one = start_one + timedelta(days=7)
+    start_two = dt_util.as_utc(datetime(2026, 8, 15, 14))
+    end_two = start_two + timedelta(days=7)
+    reservations = [
+        Reservation(
+            identity_key="bob-one",
+            start=start_one,
+            end=end_one,
+            buffered_start=start_one,
+            buffered_end=end_one,
+            summary="Bob",
+            slot_name="Bob",
+            display_slot_name="Bob",
+            slot_code="1111",
+        ),
+        Reservation(
+            identity_key="bob-two",
+            start=start_two,
+            end=end_two,
+            buffered_start=start_two,
+            buffered_end=end_two,
+            summary="Bob",
+            slot_name="Bob",
+            display_slot_name="Bob",
+            slot_code="2222",
+        ),
+    ]
+    hass.data[DOMAIN] = {
+        coordinator._entry_id: {
+            CHECKIN_SENSOR: MagicMock(
+                state=CHECKIN_STATE_CHECKED_IN,
+                extra_state_attributes={
+                    "guest_name": "Bob",
+                    "start": start_two,
+                    "end": end_two,
+                    "summary": "Bob",
+                },
+            )
+        }
+    }
+
+    coordinator._apply_checkin_protection(reservations)
+
+    assert not reservations[0].protected_active
+    assert reservations[1].protected_active
+
+
+async def test_checkin_protection_synthesizes_missing_active_physical_stay(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """A checked-in physical stay missing from the feed remains protected."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import Reservation
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    start = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    end = start + timedelta(days=7)
+    hass.data[DOMAIN] = {
+        coordinator._entry_id: {
+            CHECKIN_SENSOR: MagicMock(
+                state=CHECKIN_STATE_CHECKED_IN,
+                extra_state_attributes={
+                    "guest_name": "Bob",
+                    "start": start,
+                    "end": end,
+                    "summary": "Bob",
+                },
+            )
+        }
+    }
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=start,
+            actual_end=end,
+        )
+    ]
+    reservations: list[Reservation] = []
+
+    coordinator._apply_checkin_protection(reservations, observed_slots)
+
+    assert len(reservations) == 1
+    assert reservations[0].protected_active
+    assert reservations[0].slot_name == "Bob"
+    assert reservations[0].slot_code == "1111"
 
 
 async def test_coordinator_first_refresh(
@@ -6115,6 +6274,39 @@ class TestCoordinatorRehydration:
             assert "pin" not in last_obs
             assert "code" not in last_obs
             assert "slot_code" not in last_obs
+
+    @pytest.mark.parametrize(
+        "store_payload",
+        [
+            {"schema_version": "bad", "mappings": {}},
+            {"schema_version": 1, "mappings": []},
+            {"schema_version": 1, "mappings": {"bad": "shape"}},
+            {
+                "schema_version": 1,
+                "mappings": {"bad": {"last_observed_actual": "shape"}},
+            },
+            {"schema_version": 1, "mappings": {}, "aliases": []},
+            {"schema_version": 1, "mappings": {}, "migration_notes": "bad"},
+        ],
+    )
+    async def test_corrupt_cache_shapes_are_ignored(
+        self, hass: "HomeAssistant", store_payload: dict[str, Any]
+    ) -> None:
+        """Malformed cache shapes load as an empty non-authoritative cache."""
+        entry = self._make_rehydrate_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+
+        with patch("custom_components.rental_control.coordinator.Store") as MockStore:
+            mock_store_instance = AsyncMock()
+            mock_store_instance.async_load = AsyncMock(return_value=store_payload)
+            mock_store_instance.async_save = AsyncMock()
+            MockStore.return_value = mock_store_instance
+
+            await coordinator.async_load_slot_store()
+
+        assert coordinator._slot_mappings["mappings"] == {}
+        assert coordinator._slot_mappings["migration_notes"] == ["cache_corrupt"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -269,6 +269,51 @@ async def test_duplicate_name_shift_into_old_date_preserves_order(
     ]
 
 
+async def test_duplicate_same_start_feed_order_preserves_manual_pins(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Same-start duplicate PIN lookup uses start/end order, not feed order."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    start = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    short_end = start + timedelta(days=7)
+    long_end = start + timedelta(days=14)
+    calendar = [
+        CalendarEvent(start=start, end=long_end, summary="Bob"),
+        CalendarEvent(start=start, end=short_end, summary="Bob"),
+    ]
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="2222",
+            actual_code_present=True,
+            actual_start=start,
+            actual_end=long_end,
+        ),
+        ManagedSlot(
+            slot=2,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=start,
+            actual_end=short_end,
+        ),
+    ]
+
+    reservations = coordinator._build_reservations(calendar, observed_slots)
+
+    assert [reservation.end for reservation in reservations] == [short_end, long_end]
+    assert [reservation.slot_code for reservation in reservations] == ["1111", "2222"]
+
+
 async def test_checkin_protection_matches_duplicate_by_start_end(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -318,6 +318,67 @@ async def test_checkin_protection_synthesizes_missing_active_physical_stay(
     assert reservations[0].slot_code == "1111"
 
 
+async def test_checkin_missing_active_does_not_protect_future_same_name(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """A future same-name stay cannot replace a missing checked-in stay."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import Reservation
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    active_start = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    active_end = active_start + timedelta(days=7)
+    future_start = dt_util.as_utc(datetime(2026, 9, 1, 14))
+    future_end = future_start + timedelta(days=7)
+    future = Reservation(
+        identity_key="future-bob",
+        start=future_start,
+        end=future_end,
+        buffered_start=future_start,
+        buffered_end=future_end,
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="2222",
+    )
+    hass.data[DOMAIN] = {
+        coordinator._entry_id: {
+            CHECKIN_SENSOR: MagicMock(
+                state=CHECKIN_STATE_CHECKED_IN,
+                extra_state_attributes={
+                    "guest_name": "Bob",
+                    "start": active_start,
+                    "end": active_end,
+                    "summary": "Bob",
+                },
+            )
+        }
+    }
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=active_start,
+            actual_end=active_end,
+        )
+    ]
+    reservations = [future]
+
+    coordinator._apply_checkin_protection(reservations, observed_slots)
+
+    assert not future.protected_active
+    assert len(reservations) == 2
+    assert reservations[1].protected_active
+    assert reservations[1].start == active_start
+    assert reservations[1].slot_code == "1111"
+
+
 async def test_coordinator_first_refresh(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -6307,6 +6368,31 @@ class TestCoordinatorRehydration:
 
         assert coordinator._slot_mappings["mappings"] == {}
         assert coordinator._slot_mappings["migration_notes"] == ["cache_corrupt"]
+
+    async def test_legacy_cache_with_null_notes_does_not_abort_setup(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Legacy cache migration tolerates malformed diagnostic notes."""
+        entry = self._make_rehydrate_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        store_payload: dict[str, Any] = {
+            "mappings": {},
+            "migration_notes": None,
+        }
+
+        with patch("custom_components.rental_control.coordinator.Store") as MockStore:
+            mock_store_instance = AsyncMock()
+            mock_store_instance.async_load = AsyncMock(return_value=store_payload)
+            mock_store_instance.async_save = AsyncMock()
+            MockStore.return_value = mock_store_instance
+
+            await coordinator.async_load_slot_store()
+
+        assert coordinator._slot_mappings["mappings"] == {}
+        assert coordinator._slot_mappings["migration_notes"] == [
+            "legacy_authoritative_fields_ignored"
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -433,6 +433,40 @@ async def test_build_reservations_does_not_copy_active_pin_to_future_same_name(
     assert reservations[1].slot_code == "1111"
 
 
+async def test_missing_date_same_name_slot_preserves_observed_pin(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Existing coded slots with missing dates preserve observed PINs."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    coordinator.should_update_code = True
+    start = dt_util.as_utc(datetime(2026, 9, 1, 14))
+    end = start + timedelta(days=7)
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="8642",
+            actual_code_present=True,
+            actual_start=None,
+            actual_end=None,
+        )
+    ]
+
+    reservations = coordinator._build_reservations(
+        [CalendarEvent(start=start, end=end, summary="Bob")],
+        observed_slots,
+    )
+
+    assert reservations[0].slot_code == "8642"
+    assert reservations[0].code_source == "manual_observed"
+
+
 async def test_missing_checkin_restore_defers_unknown_date_same_name_apply(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -6524,6 +6558,30 @@ class TestCoordinatorRehydration:
         assert coordinator._slot_mappings["migration_notes"] == [
             "legacy_authoritative_fields_ignored"
         ]
+
+    async def test_schema_v1_cache_with_null_notes_is_normalized(
+        self, hass: "HomeAssistant"
+    ) -> None:
+        """Schema-v1 cache normalizes null diagnostic notes to an empty list."""
+        entry = self._make_rehydrate_entry()
+        entry.add_to_hass(hass)
+        coordinator = RentalControlCoordinator(hass, entry)
+        store_payload: dict[str, Any] = {
+            "schema_version": 1,
+            "mappings": {},
+            "migration_notes": None,
+        }
+
+        with patch("custom_components.rental_control.coordinator.Store") as MockStore:
+            mock_store_instance = AsyncMock()
+            mock_store_instance.async_load = AsyncMock(return_value=store_payload)
+            mock_store_instance.async_save = AsyncMock()
+            MockStore.return_value = mock_store_instance
+
+            await coordinator.async_load_slot_store()
+
+        assert coordinator._slot_mappings["mappings"] == {}
+        assert coordinator._slot_mappings["migration_notes"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1288,6 +1288,77 @@ async def test_buffer_config_updates_override_cache(
     assert override is not None
     assert override["start_time"] == utc_time(25, 15, 0)
     assert override["end_time"] == utc_time(30, 11, 15)
+    assert coordinator.event_overrides.should_suppress_state_change(
+        10,
+        "datetime.front_door_code_slot_10_date_range_start",
+        utc_time(25, 15, 0).isoformat(),
+    )
+    assert coordinator.event_overrides.should_suppress_state_change(
+        10,
+        "datetime.front_door_code_slot_10_date_range_end",
+        utc_time(30, 11, 15).isoformat(),
+    )
+
+
+async def test_buffer_config_service_failure_keeps_override_cache(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Failed buffer writes do not advance in-memory override times."""
+    from zoneinfo import ZoneInfo
+
+    from custom_components.rental_control.event_overrides import EventOverrides
+
+    def utc_time(day: int, hour: int, minute: int) -> datetime:
+        """Return an America/New_York local time converted to UTC."""
+        result: datetime = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, day).date(),
+                datetime(2024, 12, day, hour, minute).time(),
+                ZoneInfo("America/New_York"),
+            )
+        )
+        return result
+
+    async def failing_service_call() -> None:
+        """Raise like a failed Home Assistant service coroutine."""
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    def fake_add_call(
+        _hass: HomeAssistant,
+        coro: list[Any],
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> list[Any]:
+        """Collect a failing service coroutine."""
+        coro.append(failing_service_call())
+        return coro
+
+    old_start = utc_time(25, 15, 30)
+    old_end = utc_time(30, 11, 30)
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    coordinator.lockname = "front_door"
+    coordinator.event_overrides = EventOverrides(10, 3)
+    coordinator.event_overrides._overrides[10] = {
+        "slot_name": "Buffer Guest",
+        "slot_code": "1234",
+        "start_time": old_start,
+        "end_time": old_end,
+    }
+    coordinator.code_buffer_before = 60
+    coordinator.code_buffer_after = 15
+
+    with patch(
+        "custom_components.rental_control.coordinator.add_call",
+        side_effect=fake_add_call,
+    ):
+        await coordinator._async_update_buffer_times(old_before=30, old_after=30)
+
+    override = coordinator.event_overrides.overrides[10]
+    assert override is not None
+    assert override["start_time"] == old_start
+    assert override["end_time"] == old_end
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -163,6 +163,45 @@ async def test_duplicate_name_manual_pin_lookup_does_not_steal_later_slot(
     assert reservations[1].code_source == "manual_observed"
 
 
+async def test_partial_duplicate_shift_preserves_unreserved_manual_pin(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """A shifted same-name physical slot keeps its PIN when another Bob is absent."""
+    from custom_components.rental_control.reconciliation import ManagedSlot
+    from custom_components.rental_control.reconciliation import SlotStatus
+
+    mock_config_entry.add_to_hass(hass)
+    coordinator = RentalControlCoordinator(hass, mock_config_entry)
+    old_start = dt_util.as_utc(datetime(2026, 8, 1, 14))
+    old_end = old_start + timedelta(days=7)
+    new_start = old_start + timedelta(days=1)
+    new_end = old_end + timedelta(days=1)
+    later_start = dt_util.as_utc(datetime(2026, 8, 15, 14))
+    later_end = later_start + timedelta(days=7)
+    calendar = [
+        CalendarEvent(start=new_start, end=new_end, summary="Bob"),
+        CalendarEvent(start=later_start, end=later_end, summary="Bob"),
+    ]
+    observed_slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=old_start,
+            actual_end=old_end,
+        )
+    ]
+
+    reservations = coordinator._build_reservations(calendar, observed_slots)
+
+    assert reservations[0].slot_code == "1111"
+    assert reservations[0].code_source == "manual_observed"
+    assert reservations[1].code_source == "generated"
+
+
 async def test_duplicate_name_date_shift_preserves_ordered_manual_pins(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -25,6 +25,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.rental_control.const import CHECKIN_SENSOR
 from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_IN
+from custom_components.rental_control.const import CONF_CODE_BUFFER_AFTER
 from custom_components.rental_control.const import CONF_CODE_BUFFER_BEFORE
 from custom_components.rental_control.const import CONF_LOCK_ENTRY
 from custom_components.rental_control.const import CONF_MAX_EVENTS
@@ -9105,3 +9106,249 @@ END:VCALENDAR
         assert len(result) == 1
         assert result[0].start == self._expected_utc(25, 15)
         assert result[0].end == self._expected_utc(30, 10)
+
+
+class TestBufferAwareOverrideMatching:
+    """T132 regression tests for buffer-aware manual time matching."""
+
+    @staticmethod
+    def _expected_utc(day: int, hour: int, minute: int = 0) -> datetime:
+        """Return an America/New_York local time converted to UTC."""
+        from datetime import time as time_cls
+        from zoneinfo import ZoneInfo
+
+        result: datetime = dt.as_utc(
+            datetime.combine(
+                datetime(2024, 12, day).date(),
+                time_cls(hour, minute),
+                ZoneInfo("America/New_York"),
+            )
+        )
+        return result
+
+    @staticmethod
+    def _entry(
+        entry_id: str,
+        *,
+        before: int = 30,
+        after: int = 30,
+    ) -> MockConfigEntry:
+        """Build a config entry with Honor Event Times and buffers enabled."""
+        return MockConfigEntry(
+            domain="rental_control",
+            title="Buffer Aware",
+            version=8,
+            unique_id=entry_id,
+            data={
+                "name": "Buffer Aware",
+                "url": "https://example.com/calendar.ics",
+                "timezone": "America/New_York",
+                "checkin": "16:00",
+                "checkout": "11:00",
+                "start_slot": 10,
+                "max_events": 3,
+                "days": 90,
+                "verify_ssl": True,
+                "ignore_non_reserved": False,
+                "honor_event_times": True,
+                CONF_CODE_BUFFER_BEFORE: before,
+                CONF_CODE_BUFFER_AFTER: after,
+                CONF_LOCK_ENTRY: "front_door",
+            },
+            entry_id=entry_id,
+        )
+
+    @staticmethod
+    def _ics(description: str) -> str:
+        """Return a single all-day reservation iCalendar body."""
+        return f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20241225
+DTEND;VALUE=DATE:20241230
+UID:t132-buffer@example.com
+SUMMARY:Reserved - Buffer Guest
+DESCRIPTION:{description}
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+"""
+
+    async def _parse_with_physical_times(
+        self,
+        hass: HomeAssistant,
+        *,
+        entry_id: str,
+        description: str,
+        physical_start: datetime,
+        physical_end: datetime,
+        before: int = 30,
+        after: int = 30,
+    ) -> tuple[RentalControlCoordinator, list[CalendarEvent]]:
+        """Parse an event while a physical Keymaster slot is observed."""
+        from custom_components.rental_control.event_overrides import EventOverrides
+
+        frozen_time = datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC)
+        entry = self._entry(entry_id, before=before, after=after)
+        entry.add_to_hass(hass)
+        MockConfigEntry(
+            domain="keymaster",
+            data={"lockname": "front_door"},
+            entry_id=f"km_{entry_id}",
+        ).add_to_hass(hass)
+
+        with (
+            aioresponses() as mock_session,
+            patch.object(dt_util, "now", return_value=frozen_time),
+            patch.object(dt_util, "start_of_local_day", return_value=frozen_time),
+        ):
+            mock_session.get(
+                "https://example.com/calendar.ics",
+                status=200,
+                body=self._ics(description),
+            )
+            coordinator = RentalControlCoordinator(hass, entry)
+            coordinator.event_overrides = EventOverrides(10, 3)
+            coordinator.event_overrides._overrides[10] = {
+                "slot_name": "Buffer Guest",
+                "slot_code": "1234",
+                "start_time": physical_start,
+                "end_time": physical_end,
+            }
+            events = await coordinator._async_update_data()
+
+        return coordinator, events
+
+    async def test_buffered_default_slot_is_system_managed(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Physical calendar±buffer times are not manual overrides."""
+        physical_start = self._expected_utc(25, 15, 30)
+        physical_end = self._expected_utc(30, 11, 30)
+
+        coordinator, events = await self._parse_with_physical_times(
+            hass,
+            entry_id="t132_system_managed",
+            description="Email: buffer@example.com",
+            physical_start=physical_start,
+            physical_end=physical_end,
+        )
+
+        assert events[0].start == self._expected_utc(25, 16)
+        assert events[0].end == self._expected_utc(30, 11)
+        reservation = coordinator._build_reservations(events)[0]
+        assert reservation.buffered_start == physical_start
+        assert reservation.buffered_end == physical_end
+
+    async def test_honor_times_update_to_new_buffered_window(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Honor Event Times follows check-in and checkout changes with buffers."""
+        from custom_components.rental_control.reconciliation import ActionKind
+        from custom_components.rental_control.reconciliation import ManagedSlot
+        from custom_components.rental_control.reconciliation import SlotStatus
+        from custom_components.rental_control.reconciliation import compute_desired_plan
+
+        old_start = self._expected_utc(25, 15, 30)
+        old_end = self._expected_utc(30, 11, 30)
+
+        coordinator, events = await self._parse_with_physical_times(
+            hass,
+            entry_id="t132_honor_update",
+            description="Check-in: 12:00\\nCheck-out: 09:00",
+            physical_start=old_start,
+            physical_end=old_end,
+        )
+        reservation = coordinator._build_reservations(events)[0]
+
+        assert reservation.buffered_start == self._expected_utc(25, 11, 30)
+        assert reservation.buffered_end == self._expected_utc(30, 9, 30)
+
+        observed_slot = ManagedSlot(
+            slot=10,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name=reservation.display_slot_name,
+            actual_code=reservation.slot_code,
+            actual_code_present=True,
+            actual_start=old_start,
+            actual_end=old_end,
+        )
+        plan = compute_desired_plan(
+            reservations=[reservation],
+            managed_slots=[observed_slot],
+            max_events=3,
+            plan_id="t132-buffer-update",
+            generated_at=datetime(2024, 12, 20, 12, 0, 0, tzinfo=dt_util.UTC),
+            entry_id=coordinator._entry_id,
+            lockname="front_door",
+            start_slot=10,
+        )
+
+        assert [action.kind for action in plan.actions] == [ActionKind.UPDATE_TIMES]
+
+    async def test_zero_buffer_still_follows_honor_times(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A zero-buffer slot continues to follow calendar time changes."""
+        coordinator, events = await self._parse_with_physical_times(
+            hass,
+            entry_id="t132_zero_buffer",
+            description="Check-in: 12:00\\nCheck-out: 09:00",
+            physical_start=self._expected_utc(25, 16),
+            physical_end=self._expected_utc(30, 11),
+            before=0,
+            after=0,
+        )
+        reservation = coordinator._build_reservations(events)[0]
+
+        assert reservation.buffered_start == self._expected_utc(25, 12)
+        assert reservation.buffered_end == self._expected_utc(30, 9)
+
+    async def test_true_manual_deviation_is_preserved(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Physical times that deviate from buffered expected stay manual."""
+        manual_start = self._expected_utc(25, 14)
+        manual_end = self._expected_utc(30, 12, 15)
+
+        coordinator, events = await self._parse_with_physical_times(
+            hass,
+            entry_id="t132_manual_deviation",
+            description="Email: manual@example.com",
+            physical_start=manual_start,
+            physical_end=manual_end,
+        )
+        reservation = coordinator._build_reservations(events)[0]
+
+        assert events[0].start == self._expected_utc(25, 14, 30)
+        assert events[0].end == self._expected_utc(30, 11, 45)
+        assert reservation.buffered_start == manual_start
+        assert reservation.buffered_end == manual_end
+
+    async def test_mixed_system_and_manual_fields_are_independent(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A manual checkout does not make system-managed check-in manual."""
+        system_start = self._expected_utc(25, 15, 30)
+        manual_end = self._expected_utc(30, 12, 15)
+
+        coordinator, events = await self._parse_with_physical_times(
+            hass,
+            entry_id="t132_mixed_manual",
+            description="Email: mixed@example.com",
+            physical_start=system_start,
+            physical_end=manual_end,
+        )
+        reservation = coordinator._build_reservations(events)[0]
+
+        assert events[0].start == self._expected_utc(25, 16)
+        assert events[0].end == self._expected_utc(30, 11, 45)
+        assert reservation.buffered_start == system_start
+        assert reservation.buffered_end == manual_end

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -3907,6 +3907,43 @@ class TestApplyPlanActions:
         assert results[0].confirmed is True
         mock_clear.assert_called_once()
 
+    async def test_preflight_clear_skips_non_string_text_state(self) -> None:
+        """Preflight aborts when fresh text states are not concrete strings."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 8, 1)
+        eo.update(1, "1234", "Guest", now, now)
+        coordinator = self._make_coordinator(eo)
+
+        def _state(value: object) -> MagicMock:
+            """Return a fake Home Assistant state object with *value*."""
+            state = MagicMock()
+            state.state = value
+            return state
+
+        coordinator.hass.states.get.side_effect = lambda entity_id: (
+            _state(object()) if entity_id.endswith("_name") else _state("1234")
+        )
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            new_callable=AsyncMock,
+        ) as mock_clear:
+            results = await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(
+                    SlotAction(
+                        kind=ActionKind.RESET,
+                        slot=1,
+                        reason="stale",
+                        preflight_read=True,
+                    )
+                ),
+                {},
+            )
+
+        assert results[0].unconfirmed is True
+        mock_clear.assert_not_called()
+
     async def test_preflight_clear_allows_pin_only_physical_slot(self) -> None:
         """A blank-name slot with a lingering PIN is allowed to reset."""
         eo = EventOverrides(start_slot=1, max_slots=1)

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -77,6 +77,9 @@ def _make_coordinator(
     coordinator.hass = MagicMock()
     coordinator.hass.services = MagicMock()
     coordinator.hass.services.async_call = AsyncMock()
+    empty_state = MagicMock()
+    empty_state.state = ""
+    coordinator.hass.states.get = MagicMock(return_value=empty_state)
     coordinator.max_events = max_events
     coordinator.event_prefix = ""
     coordinator.data = calendar_events
@@ -3349,8 +3352,8 @@ class TestStoreSchemaV1:
             identity_key="key-b", slot=10, status=SLOT_STATUS_OCCUPIED
         )
 
-        with pytest.raises(ValueError, match="Duplicate occupied slot 10"):
-            eo.load_persisted_mappings({"key-a": m1, "key-b": m2})
+        eo.load_persisted_mappings({"key-a": m1, "key-b": m2})
+        assert set(eo.persisted_mappings) == {"key-a", "key-b"}
 
     # ------------------------------------------------------------------
     # T009-5: pending_clear fence rebuilt on load
@@ -3370,7 +3373,7 @@ class TestStoreSchemaV1:
         m["pending_clear_since"] = "2025-01-01T00:00:00+00:00"
         eo.load_persisted_mappings({"phantom-key": m})
 
-        assert 10 in eo.pending_clear_slots
+        assert eo.pending_clear_slots == {}
 
 
 # ---------------------------------------------------------------------------
@@ -3579,7 +3582,9 @@ class TestApplyPlanActions:
         coordinator.code_buffer_after = 0
         coordinator.event_overrides = eo
         coordinator.hass.services.async_call = AsyncMock()
-        coordinator.hass.states.get.return_value = None
+        empty_state = MagicMock()
+        empty_state.state = ""
+        coordinator.hass.states.get.return_value = empty_state
         return coordinator
 
     async def test_set_action_pre_assigns_and_confirms(self) -> None:
@@ -3807,6 +3812,146 @@ class TestApplyPlanActions:
         assert results[0].confirmed is True
         assert eo.overrides[1] is None
         assert 1 not in eo.pending_fences
+
+    async def test_preflight_clear_skips_when_physical_name_changed(self) -> None:
+        """Preflight RESET/CLEAR actions do not clear a slot changed after planning."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 8, 1)
+        eo.update(1, "1234", "Guest", now, now)
+        eo.update_actual_state(
+            1,
+            {
+                "slot": 1,
+                "classification": "occupied",
+                "name_state": "Guest",
+                "has_code": True,
+            },
+        )
+        coordinator = self._make_coordinator(eo)
+
+        def _state(value: str) -> MagicMock:
+            """Return a fake Home Assistant state object with *value*."""
+            state = MagicMock()
+            state.state = value
+            return state
+
+        coordinator.hass.states.get.side_effect = lambda entity_id: (
+            _state("Different Guest") if entity_id.endswith("_name") else _state("9999")
+        )
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            new_callable=AsyncMock,
+        ) as mock_clear:
+            results = await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(
+                    SlotAction(
+                        kind=ActionKind.RESET,
+                        slot=1,
+                        reason="stale",
+                        preflight_read=True,
+                    )
+                ),
+                {},
+            )
+
+        assert results[0].unconfirmed is True
+        assert eo.overrides[1] is not None
+        assert eo.overrides[1]["slot_name"] == "Guest"
+        mock_clear.assert_not_called()
+
+    async def test_preflight_clear_accepts_prefixed_physical_name(self) -> None:
+        """Preflight compares fresh reads against observed physical display names."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 8, 1)
+        eo.update(1, "1234", "Guest", now, now)
+        eo.update_actual_state(
+            1,
+            {
+                "slot": 1,
+                "classification": "occupied",
+                "name_state": "RC Guest",
+                "has_code": True,
+            },
+        )
+        coordinator = self._make_coordinator(eo)
+
+        def _state(value: str) -> MagicMock:
+            """Return a fake Home Assistant state object with *value*."""
+            state = MagicMock()
+            state.state = value
+            return state
+
+        coordinator.hass.states.get.side_effect = lambda entity_id: (
+            _state("RC Guest") if entity_id.endswith("_name") else _state("1234")
+        )
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=OperationResult(kind="clear", slot=1, confirmed=True),
+        ) as mock_clear:
+            results = await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(
+                    SlotAction(
+                        kind=ActionKind.RESET,
+                        slot=1,
+                        reason="stale",
+                        preflight_read=True,
+                    )
+                ),
+                {},
+            )
+
+        assert results[0].confirmed is True
+        mock_clear.assert_called_once()
+
+    async def test_preflight_clear_allows_pin_only_physical_slot(self) -> None:
+        """A blank-name slot with a lingering PIN is allowed to reset."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _make_dt(2026, 8, 1)
+        eo.update(1, "9999", "Bob", now, now)
+        eo.update_actual_state(
+            1,
+            {
+                "slot": 1,
+                "classification": "phantom",
+                "name_state": None,
+                "has_code": True,
+            },
+        )
+        coordinator = self._make_coordinator(eo)
+
+        def _state(value: str) -> MagicMock:
+            """Return a fake Home Assistant state object with *value*."""
+            state = MagicMock()
+            state.state = value
+            return state
+
+        coordinator.hass.states.get.side_effect = lambda entity_id: (
+            _state("") if entity_id.endswith("_name") else _state("9999")
+        )
+
+        with patch(
+            "custom_components.rental_control.event_overrides.async_fire_clear_code",
+            return_value=OperationResult(kind="clear", slot=1, confirmed=True),
+        ) as mock_clear:
+            results = await eo.async_apply_plan(
+                coordinator,
+                self._make_plan(
+                    SlotAction(
+                        kind=ActionKind.RESET,
+                        slot=1,
+                        reason="phantom",
+                        preflight_read=True,
+                    )
+                ),
+                {},
+            )
+
+        assert results[0].confirmed is True
+        mock_clear.assert_called_once()
 
     async def test_overflow_action_not_executed(self) -> None:
         """Overflow reservations do not become physical slot actions."""
@@ -4842,6 +4987,9 @@ class TestManualDriftLogging:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        empty_state = MagicMock()
+        empty_state.state = ""
+        coordinator.hass.states.get.return_value = empty_state
         observed: list[tuple[datetime, datetime]] = []
 
         async def mock_set_code(_coordinator, event, _slot) -> OperationResult:
@@ -4854,9 +5002,17 @@ class TestManualDriftLogging:
             )
             return OperationResult(kind="set", slot=5, confirmed=True)
 
-        with patch(
-            "custom_components.rental_control.event_overrides.async_fire_set_code",
-            side_effect=mock_set_code,
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(
+                    return_value=OperationResult(kind="clear", slot=5, confirmed=True)
+                ),
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                side_effect=mock_set_code,
+            ),
         ):
             await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
 
@@ -5031,12 +5187,23 @@ class TestManualDriftLogging:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        empty_state = MagicMock()
+        empty_state.state = ""
+        coordinator.hass.states.get.return_value = empty_state
 
         confirmed = OperationResult(kind="set", slot=5, confirmed=True)
-        with patch(
-            "custom_components.rental_control.event_overrides.async_fire_set_code",
-            return_value=confirmed,
-        ) as mock_set:
+        with (
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_clear_code",
+                new=AsyncMock(
+                    return_value=OperationResult(kind="clear", slot=5, confirmed=True)
+                ),
+            ),
+            patch(
+                "custom_components.rental_control.event_overrides.async_fire_set_code",
+                return_value=confirmed,
+            ) as mock_set,
+        ):
             results = await eo.async_apply_plan(
                 coordinator, plan, {res.identity_key: res}
             )
@@ -5358,6 +5525,13 @@ class TestDuplicateActualAssignment:
         coordinator = MagicMock()
         coordinator.lockname = "test_lock"
         coordinator.hass.services.async_call = AsyncMock()
+        name_state = MagicMock()
+        name_state.state = "Guest r-dup"
+        pin_state = MagicMock()
+        pin_state.state = "DUPPIN"
+        coordinator.hass.states.get.side_effect = lambda entity_id: (
+            name_state if entity_id.endswith("_name") else pin_state
+        )
 
         confirmed = OperationResult(kind="clear", slot=5, confirmed=True)
         with patch(

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -436,6 +436,47 @@ def test_stateless_duplicate_name_same_start_orders_by_end() -> None:
     assert plan.selected == {"bob-short": 2, "bob-long": 1}
 
 
+def test_stateless_extra_stale_same_name_does_not_steal_shifted_slot() -> None:
+    """Overfull same-name groups keep the closest physical continuity slot."""
+    desired = _make_desired_reservation(
+        desired_id="bob-new",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        slot_code="2222",
+    )
+    stale_slot = ObservedSlot(
+        slot=1,
+        managed=True,
+        raw_name="Bob",
+        raw_pin="1111",
+        actual_start=_dt(2026, 8, 1),
+        actual_end=_dt(2026, 8, 8),
+    )
+    continuity_slot = ObservedSlot(
+        slot=2,
+        managed=True,
+        raw_name="Bob",
+        raw_pin="2222",
+        actual_start=_dt(2026, 8, 8),
+        actual_end=_dt(2026, 8, 15),
+    )
+
+    plan = compute_stateless_plan(
+        [stale_slot, continuity_slot],
+        [desired],
+        max_events=1,
+        plan_id="stateless-extra-stale-same-name",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-new": 2}
+    assert any(
+        action.kind is ActionKind.RESET and action.slot == 1 for action in plan.actions
+    )
+
+
 def test_stateless_prefix_equivalent_names_do_not_share_slot() -> None:
     """A physical slot already matched by one name group cannot be reused."""
     prefixed = _make_desired_reservation(
@@ -632,6 +673,52 @@ def test_duplicate_name_same_start_orders_by_end() -> None:
     )
 
     assert plan.selected == {"bob-short": 2, "bob-long": 1}
+
+
+def test_extra_stale_same_name_does_not_steal_shifted_slot() -> None:
+    """Legacy overfull same-name groups keep closest physical continuity."""
+    desired = Reservation(
+        identity_key="bob-new",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        buffered_start=_dt(2026, 8, 15),
+        buffered_end=_dt(2026, 8, 22),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="2222",
+    )
+    stale_slot = ManagedSlot(
+        slot=1,
+        managed=True,
+        status=SlotStatus.OCCUPIED,
+        actual_name="Bob",
+        actual_code="1111",
+        actual_code_present=True,
+        actual_start=_dt(2026, 8, 1),
+        actual_end=_dt(2026, 8, 8),
+    )
+    continuity_slot = ManagedSlot(
+        slot=2,
+        managed=True,
+        status=SlotStatus.OCCUPIED,
+        actual_name="Bob",
+        actual_code="2222",
+        actual_code_present=True,
+        actual_start=_dt(2026, 8, 8),
+        actual_end=_dt(2026, 8, 15),
+    )
+
+    plan = compute_desired_plan(
+        [desired],
+        [stale_slot, continuity_slot],
+        max_events=1,
+        plan_id="legacy-extra-stale-same-name",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-new": 2}
+    assert plan.slots[1].action is ActionKind.CLEAR
 
 
 def _make_desired_plan(

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -165,6 +165,14 @@ def test_observed_slot_blank_name_and_pin_is_confirmed_empty() -> None:
     assert slot.empty_confirmed is True
 
 
+def test_observed_slot_none_text_token_is_confirmed_empty() -> None:
+    """The literal None text token is accepted as a cleared Keymaster value."""
+    slot = ObservedSlot(slot=1, managed=True, raw_name="None", raw_pin="none")
+
+    assert slot.classification is ObservedSlotStatus.EMPTY
+    assert slot.empty_confirmed is True
+
+
 def test_observed_slot_derives_pin_presence_from_raw_pin() -> None:
     """A raw physical PIN prevents confirmed-empty classification."""
     slot = ObservedSlot(slot=1, managed=True, raw_name="", raw_pin="9999")

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -477,6 +477,62 @@ def test_stateless_extra_stale_same_name_does_not_steal_shifted_slot() -> None:
     )
 
 
+def test_stateless_extra_stale_same_name_keeps_ordered_subset() -> None:
+    """Overfull duplicate groups choose the best ordered physical subset."""
+    first = _make_desired_reservation(
+        desired_id="bob-one",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        slot_code="1111",
+    )
+    second = _make_desired_reservation(
+        desired_id="bob-two",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 22),
+        end=_dt(2026, 8, 29),
+        slot_code="2222",
+    )
+    slots = [
+        ObservedSlot(
+            slot=1,
+            managed=True,
+            raw_name="Bob",
+            raw_pin="9999",
+            actual_start=_dt(2026, 8, 1),
+            actual_end=_dt(2026, 8, 8),
+        ),
+        ObservedSlot(
+            slot=2,
+            managed=True,
+            raw_name="Bob",
+            raw_pin="1111",
+            actual_start=_dt(2026, 8, 8),
+            actual_end=_dt(2026, 8, 15),
+        ),
+        ObservedSlot(
+            slot=3,
+            managed=True,
+            raw_name="Bob",
+            raw_pin="2222",
+            actual_start=_dt(2026, 8, 15),
+            actual_end=_dt(2026, 8, 22),
+        ),
+    ]
+
+    plan = compute_stateless_plan(
+        slots,
+        [first, second],
+        max_events=2,
+        plan_id="stateless-extra-stale-ordered",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-one": 2, "bob-two": 3}
+
+
 def test_stateless_prefix_equivalent_names_do_not_share_slot() -> None:
     """A physical slot already matched by one name group cannot be reused."""
     prefixed = _make_desired_reservation(
@@ -718,6 +774,75 @@ def test_extra_stale_same_name_does_not_steal_shifted_slot() -> None:
     )
 
     assert plan.selected == {"bob-new": 2}
+    assert plan.slots[1].action is ActionKind.CLEAR
+
+
+def test_extra_stale_same_name_keeps_ordered_subset() -> None:
+    """Legacy overfull duplicate groups choose the best ordered subset."""
+    first = Reservation(
+        identity_key="bob-one",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        buffered_start=_dt(2026, 8, 15),
+        buffered_end=_dt(2026, 8, 22),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="1111",
+    )
+    second = Reservation(
+        identity_key="bob-two",
+        start=_dt(2026, 8, 22),
+        end=_dt(2026, 8, 29),
+        buffered_start=_dt(2026, 8, 22),
+        buffered_end=_dt(2026, 8, 29),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="2222",
+    )
+    slots = [
+        ManagedSlot(
+            slot=1,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="9999",
+            actual_code_present=True,
+            actual_start=_dt(2026, 8, 1),
+            actual_end=_dt(2026, 8, 8),
+        ),
+        ManagedSlot(
+            slot=2,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="1111",
+            actual_code_present=True,
+            actual_start=_dt(2026, 8, 8),
+            actual_end=_dt(2026, 8, 15),
+        ),
+        ManagedSlot(
+            slot=3,
+            managed=True,
+            status=SlotStatus.OCCUPIED,
+            actual_name="Bob",
+            actual_code="2222",
+            actual_code_present=True,
+            actual_start=_dt(2026, 8, 15),
+            actual_end=_dt(2026, 8, 22),
+        ),
+    ]
+
+    plan = compute_desired_plan(
+        [first, second],
+        slots,
+        max_events=2,
+        plan_id="legacy-extra-stale-ordered",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-one": 2, "bob-two": 3}
     assert plan.slots[1].action is ActionKind.CLEAR
 
 

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -39,7 +39,10 @@ import pytest
 from custom_components.rental_control.reconciliation import FINGERPRINT_VERSION
 from custom_components.rental_control.reconciliation import ActionKind
 from custom_components.rental_control.reconciliation import DesiredPlan
+from custom_components.rental_control.reconciliation import DesiredReservation
 from custom_components.rental_control.reconciliation import ManagedSlot
+from custom_components.rental_control.reconciliation import ObservedSlot
+from custom_components.rental_control.reconciliation import ObservedSlotStatus
 from custom_components.rental_control.reconciliation import PlannedSlot
 from custom_components.rental_control.reconciliation import RematchKind
 from custom_components.rental_control.reconciliation import RematchResult
@@ -50,6 +53,7 @@ from custom_components.rental_control.reconciliation import SlotStatus
 from custom_components.rental_control.reconciliation import StoredActual
 from custom_components.rental_control.reconciliation import StoredIdentity
 from custom_components.rental_control.reconciliation import compute_desired_plan
+from custom_components.rental_control.reconciliation import compute_stateless_plan
 from custom_components.rental_control.reconciliation import extract_booking_aliases
 from custom_components.rental_control.reconciliation import find_reservation_rematch
 from custom_components.rental_control.reconciliation import make_reservation_fingerprint
@@ -67,6 +71,30 @@ _TZ = timezone.utc
 def _dt(year: int, month: int, day: int, hour: int = 0) -> datetime:
     """Return a UTC-aware datetime for test convenience."""
     return datetime(year, month, day, hour, tzinfo=_TZ)
+
+
+def _make_desired_reservation(
+    *,
+    desired_id: str = "desired-abc",
+    stable_slot_name: str = "Test Guest",
+    display_slot_name: str = "RC Test Guest",
+    start: datetime | None = None,
+    end: datetime | None = None,
+    slot_code: str = "1234",
+) -> DesiredReservation:
+    """Return a minimal stateless DesiredReservation for tests."""
+    start_dt = start or _dt(2026, 7, 1)
+    end_dt = end or _dt(2026, 7, 8)
+    return DesiredReservation(
+        desired_id=desired_id,
+        stable_slot_name=stable_slot_name,
+        display_slot_name=display_slot_name,
+        start=start_dt,
+        end=end_dt,
+        buffered_start=start_dt,
+        buffered_end=end_dt,
+        slot_code=slot_code,
+    )
 
 
 def _make_reservation(
@@ -126,6 +154,132 @@ def _make_slot_mapping(
         last_observed_actual=_make_stored_actual(slot=slot),
         updated_at=_dt(2026, 6, 19),
         missing_count=missing_count,
+    )
+
+
+def test_observed_slot_blank_name_and_pin_is_confirmed_empty() -> None:
+    """Blank readable Keymaster slot is classified as confirmed empty."""
+    slot = ObservedSlot(slot=1, managed=True, raw_name="", has_pin=False)
+
+    assert slot.classification is ObservedSlotStatus.EMPTY
+    assert slot.empty_confirmed is True
+
+
+def test_observed_slot_derives_pin_presence_from_raw_pin() -> None:
+    """A raw physical PIN prevents confirmed-empty classification."""
+    slot = ObservedSlot(slot=1, managed=True, raw_name="", raw_pin="9999")
+
+    assert slot.has_pin is True
+    assert slot.classification is ObservedSlotStatus.PHANTOM
+    assert slot.empty_confirmed is False
+
+
+def test_stateless_plan_assigns_selected_reservation_to_confirmed_empty_slot() -> None:
+    """The pure stateless planner can consume a blank physical slot for assignment."""
+    desired = _make_desired_reservation(desired_id="reservation-a")
+    empty_slot = ObservedSlot(slot=2, managed=True, raw_name="", has_pin=False)
+
+    plan = compute_stateless_plan(
+        [empty_slot],
+        [desired],
+        max_events=1,
+        plan_id="stateless-empty-assignment",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"reservation-a": 2}
+    assert plan.overflow == {}
+    assert any(
+        action.kind is ActionKind.ASSIGN
+        and action.slot == 2
+        and action.desired_id == "reservation-a"
+        and action.identity_key == "reservation-a"
+        for action in plan.actions
+    )
+
+
+def test_stateless_plan_does_not_assign_into_pin_only_slot() -> None:
+    """A PIN-only physical slot must reset before any new assignment."""
+    desired = _make_desired_reservation(desired_id="reservation-pin-only")
+    pin_only_slot = ObservedSlot(slot=2, managed=True, raw_name="", raw_pin="9999")
+
+    plan = compute_stateless_plan(
+        [pin_only_slot],
+        [desired],
+        max_events=1,
+        plan_id="stateless-pin-only-blocks-assignment",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {}
+    assert plan.overflow == {"reservation-pin-only": "no_empty_slot"}
+    assert any(
+        action.kind is ActionKind.RESET and action.slot == 2 for action in plan.actions
+    )
+
+
+def test_stateless_name_matching_does_not_use_arbitrary_prefixes() -> None:
+    """Distinct stable names are not matched only because one prefixes the other."""
+    desired = _make_desired_reservation(
+        desired_id="anna-reservation",
+        stable_slot_name="Anna",
+        display_slot_name="Anna",
+    )
+    ann_slot = ObservedSlot(slot=1, managed=True, raw_name="Ann", raw_pin="1111")
+    empty_slot = ObservedSlot(slot=2, managed=True, raw_name="", has_pin=False)
+
+    plan = compute_stateless_plan(
+        [ann_slot, empty_slot],
+        [desired],
+        max_events=2,
+        plan_id="stateless-no-arbitrary-prefix-match",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"anna-reservation": 2}
+    assert any(
+        action.kind is ActionKind.RESET and action.slot == 1 for action in plan.actions
+    )
+    assert any(
+        action.kind is ActionKind.ASSIGN
+        and action.slot == 2
+        and action.identity_key == "anna-reservation"
+        for action in plan.actions
+    )
+
+
+def test_stateless_date_drift_uses_update_times_action() -> None:
+    """Pure stateless date drift updates Keymaster times without clear-and-set."""
+    start = _dt(2026, 7, 2)
+    end = _dt(2026, 7, 9)
+    desired = _make_desired_reservation(
+        desired_id="date-drift-reservation",
+        start=start,
+        end=end,
+        slot_code="1234",
+    )
+    occupied_slot = ObservedSlot(
+        slot=1,
+        managed=True,
+        raw_name="RC Test Guest",
+        raw_pin="1234",
+        actual_start=_dt(2026, 7, 1),
+        actual_end=_dt(2026, 7, 8),
+    )
+
+    plan = compute_stateless_plan(
+        [occupied_slot],
+        [desired],
+        max_events=1,
+        plan_id="stateless-date-drift-update-times",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert any(
+        action.kind is ActionKind.UPDATE_TIMES
+        and action.identity_key == "date-drift-reservation"
+        and action.reason == "date_drift"
+        for action in plan.actions
     )
 
 
@@ -232,9 +386,12 @@ class TestActionKind:
     """Tests for the ActionKind enumeration."""
 
     def test_all_expected_values_exist(self) -> None:
-        """All seven action-kind values defined in the data model are present."""
+        """All legacy and stateless action-kind values are present."""
         expected = {
             "noop",
+            "assign",
+            "update_in_place",
+            "reset",
             "set",
             "update_times",
             "clear",
@@ -283,8 +440,8 @@ class TestActionKind:
         assert ActionKind("clear") is ActionKind.CLEAR
 
     def test_member_count(self) -> None:
-        """ActionKind contains exactly seven members."""
-        assert len(ActionKind) == 7
+        """ActionKind contains legacy and stateless members."""
+        assert len(ActionKind) == 10
 
 
 # ---------------------------------------------------------------------------
@@ -3742,9 +3899,9 @@ class TestManualDriftOverwriteAction:
         )
 
         clear_actions = [a for a in plan.actions if a.kind is ActionKind.CLEAR]
-        assert len(clear_actions) == 1
-        assert clear_actions[0].slot == 6
-        assert clear_actions[0].reason == "duplicate_non_canonical"
+        assert len(clear_actions) == 2
+        assert {action.slot for action in clear_actions} == {5, 6}
+        assert {action.reason for action in clear_actions} == {"stale"}
 
     def test_overwrite_action_preserves_desired_identity_key(self) -> None:
         """OVERWRITE_MANUAL_CHANGE action carries the desired reservation's identity."""

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -283,39 +283,90 @@ def test_stateless_date_drift_uses_update_times_action() -> None:
     )
 
 
-def test_stateless_date_drift_uses_update_times_action() -> None:
-    """Pure stateless date drift updates Keymaster times without clear-and-set."""
-    start = _dt(2026, 7, 2)
-    end = _dt(2026, 7, 9)
-    desired = _make_desired_reservation(
-        desired_id="date-drift-reservation",
-        start=start,
-        end=end,
-        slot_code="1234",
+def test_stateless_duplicate_name_partial_physical_match_uses_observed_dates() -> None:
+    """A later same-name physical slot stays paired with its matching dates."""
+    early = _make_desired_reservation(
+        desired_id="bob-early",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 1),
+        end=_dt(2026, 8, 8),
+        slot_code="1111",
     )
-    occupied_slot = ObservedSlot(
-        slot=1,
+    late = _make_desired_reservation(
+        desired_id="bob-late",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        slot_code="2222",
+    )
+    empty_slot = ObservedSlot(slot=1, managed=True, raw_name="", has_pin=False)
+    late_slot = ObservedSlot(
+        slot=2,
         managed=True,
-        raw_name="RC Test Guest",
-        raw_pin="1234",
-        actual_start=_dt(2026, 7, 1),
-        actual_end=_dt(2026, 7, 8),
+        raw_name="Bob",
+        raw_pin="2222",
+        actual_start=late.buffered_start,
+        actual_end=late.buffered_end,
     )
 
     plan = compute_stateless_plan(
-        [occupied_slot],
-        [desired],
-        max_events=1,
-        plan_id="stateless-date-drift-update-times",
+        [empty_slot, late_slot],
+        [early, late],
+        max_events=2,
+        plan_id="stateless-duplicate-partial-match",
         generated_at=_dt(2026, 6, 1),
     )
 
-    assert any(
-        action.kind is ActionKind.UPDATE_TIMES
-        and action.identity_key == "date-drift-reservation"
-        and action.reason == "date_drift"
-        for action in plan.actions
+    assert plan.selected == {"bob-late": 2, "bob-early": 1}
+
+
+def test_duplicate_name_partial_physical_match_uses_observed_dates() -> None:
+    """Legacy desired plan also keeps a same-name slot paired by exact dates."""
+    early = Reservation(
+        identity_key="bob-early",
+        start=_dt(2026, 8, 1),
+        end=_dt(2026, 8, 8),
+        buffered_start=_dt(2026, 8, 1),
+        buffered_end=_dt(2026, 8, 8),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="1111",
     )
+    late = Reservation(
+        identity_key="bob-late",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        buffered_start=_dt(2026, 8, 15),
+        buffered_end=_dt(2026, 8, 22),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="2222",
+    )
+    empty_slot = ManagedSlot(slot=1, managed=True, status=SlotStatus.FREE)
+    late_slot = ManagedSlot(
+        slot=2,
+        managed=True,
+        status=SlotStatus.OCCUPIED,
+        actual_name="Bob",
+        actual_code="2222",
+        actual_code_present=True,
+        actual_start=late.buffered_start,
+        actual_end=late.buffered_end,
+    )
+
+    plan = compute_desired_plan(
+        [early, late],
+        [empty_slot, late_slot],
+        max_events=2,
+        plan_id="legacy-duplicate-partial-match",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-late": 2, "bob-early": 1}
 
 
 def _make_desired_plan(

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -344,6 +344,91 @@ def test_stateless_duplicate_name_partial_physical_match_uses_observed_dates() -
     assert plan.selected == {"bob-late": 2, "bob-early": 1}
 
 
+def test_stateless_duplicate_name_date_shift_preserves_physical_order() -> None:
+    """Complete same-name groups pair by order when dates shift onto old dates."""
+    bob_one = _make_desired_reservation(
+        desired_id="bob-one",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 8),
+        end=_dt(2026, 8, 15),
+        slot_code="1111",
+    )
+    bob_two = _make_desired_reservation(
+        desired_id="bob-two",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        slot_code="2222",
+    )
+    slot_one = ObservedSlot(
+        slot=1,
+        managed=True,
+        raw_name="Bob",
+        raw_pin="1111",
+        actual_start=_dt(2026, 8, 1),
+        actual_end=_dt(2026, 8, 8),
+    )
+    slot_two = ObservedSlot(
+        slot=2,
+        managed=True,
+        raw_name="Bob",
+        raw_pin="2222",
+        actual_start=_dt(2026, 8, 8),
+        actual_end=_dt(2026, 8, 15),
+    )
+
+    plan = compute_stateless_plan(
+        [slot_one, slot_two],
+        [bob_one, bob_two],
+        max_events=2,
+        plan_id="stateless-duplicate-order",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-one": 1, "bob-two": 2}
+
+
+def test_stateless_prefix_equivalent_names_do_not_share_slot() -> None:
+    """A physical slot already matched by one name group cannot be reused."""
+    prefixed = _make_desired_reservation(
+        desired_id="prefixed",
+        stable_slot_name="RC Bob",
+        display_slot_name="RC Bob",
+        slot_code="1111",
+    )
+    plain = _make_desired_reservation(
+        desired_id="plain",
+        stable_slot_name="Bob",
+        display_slot_name="RC Bob",
+        start=_dt(2026, 7, 8),
+        end=_dt(2026, 7, 15),
+        slot_code="2222",
+    )
+    occupied_slot = ObservedSlot(
+        slot=1,
+        managed=True,
+        raw_name="RC Bob",
+        raw_pin="1111",
+        actual_start=prefixed.buffered_start,
+        actual_end=prefixed.buffered_end,
+    )
+    empty_slot = ObservedSlot(slot=2, managed=True, raw_name="", has_pin=False)
+
+    plan = compute_stateless_plan(
+        [occupied_slot, empty_slot],
+        [prefixed, plain],
+        max_events=2,
+        plan_id="stateless-prefix-unique",
+        generated_at=_dt(2026, 6, 1),
+        prefix="RC ",
+    )
+
+    assert len(set(plan.selected.values())) == len(plan.selected)
+    assert plan.selected == {"prefixed": 1, "plain": 2}
+
+
 def test_duplicate_name_partial_physical_match_uses_observed_dates() -> None:
     """Legacy desired plan also keeps a same-name slot paired by exact dates."""
     early = Reservation(
@@ -389,6 +474,62 @@ def test_duplicate_name_partial_physical_match_uses_observed_dates() -> None:
     )
 
     assert plan.selected == {"bob-late": 2, "bob-early": 1}
+
+
+def test_duplicate_name_date_shift_preserves_physical_order() -> None:
+    """Legacy plan pairs complete same-name groups by physical order."""
+    bob_one = Reservation(
+        identity_key="bob-one",
+        start=_dt(2026, 8, 8),
+        end=_dt(2026, 8, 15),
+        buffered_start=_dt(2026, 8, 8),
+        buffered_end=_dt(2026, 8, 15),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="1111",
+    )
+    bob_two = Reservation(
+        identity_key="bob-two",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        buffered_start=_dt(2026, 8, 15),
+        buffered_end=_dt(2026, 8, 22),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="2222",
+    )
+    slot_one = ManagedSlot(
+        slot=1,
+        managed=True,
+        status=SlotStatus.OCCUPIED,
+        actual_name="Bob",
+        actual_code="1111",
+        actual_code_present=True,
+        actual_start=_dt(2026, 8, 1),
+        actual_end=_dt(2026, 8, 8),
+    )
+    slot_two = ManagedSlot(
+        slot=2,
+        managed=True,
+        status=SlotStatus.OCCUPIED,
+        actual_name="Bob",
+        actual_code="2222",
+        actual_code_present=True,
+        actual_start=_dt(2026, 8, 8),
+        actual_end=_dt(2026, 8, 15),
+    )
+
+    plan = compute_desired_plan(
+        [bob_one, bob_two],
+        [slot_one, slot_two],
+        max_events=2,
+        plan_id="legacy-duplicate-order",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-one": 1, "bob-two": 2}
 
 
 def _make_desired_plan(

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -541,6 +541,45 @@ def test_stateless_extra_stale_same_name_keeps_ordered_subset() -> None:
     assert plan.selected == {"bob-one": 2, "bob-two": 3}
 
 
+def test_stateless_partial_duplicate_pairs_closest_reservation() -> None:
+    """A lone shifted duplicate slot pairs with the closest desired stay."""
+    early = _make_desired_reservation(
+        desired_id="bob-early",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 1),
+        end=_dt(2026, 8, 8),
+        slot_code="1111",
+    )
+    late = _make_desired_reservation(
+        desired_id="bob-late",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        slot_code="2222",
+    )
+    shifted_late_slot = ObservedSlot(
+        slot=2,
+        managed=True,
+        raw_name="Bob",
+        raw_pin="2222",
+        actual_start=_dt(2026, 8, 14),
+        actual_end=_dt(2026, 8, 21),
+    )
+    empty_slot = ObservedSlot(slot=1, managed=True, raw_name="", has_pin=False)
+
+    plan = compute_stateless_plan(
+        [empty_slot, shifted_late_slot],
+        [early, late],
+        max_events=2,
+        plan_id="stateless-partial-closest",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-late": 2, "bob-early": 1}
+
+
 def test_stateless_prefix_equivalent_names_do_not_share_slot() -> None:
     """A physical slot already matched by one name group cannot be reused."""
     prefixed = _make_desired_reservation(
@@ -852,6 +891,53 @@ def test_extra_stale_same_name_keeps_ordered_subset() -> None:
 
     assert plan.selected == {"bob-one": 2, "bob-two": 3}
     assert plan.slots[1].action is ActionKind.CLEAR
+
+
+def test_partial_duplicate_pairs_closest_reservation() -> None:
+    """Legacy partial duplicate pairing uses closest desired stay."""
+    early = Reservation(
+        identity_key="bob-early",
+        start=_dt(2026, 8, 1),
+        end=_dt(2026, 8, 8),
+        buffered_start=_dt(2026, 8, 1),
+        buffered_end=_dt(2026, 8, 8),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="1111",
+    )
+    late = Reservation(
+        identity_key="bob-late",
+        start=_dt(2026, 8, 15),
+        end=_dt(2026, 8, 22),
+        buffered_start=_dt(2026, 8, 15),
+        buffered_end=_dt(2026, 8, 22),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="2222",
+    )
+    empty_slot = ManagedSlot(slot=1, managed=True, status=SlotStatus.FREE)
+    shifted_late_slot = ManagedSlot(
+        slot=2,
+        managed=True,
+        status=SlotStatus.OCCUPIED,
+        actual_name="Bob",
+        actual_code="2222",
+        actual_code_present=True,
+        actual_start=_dt(2026, 8, 14),
+        actual_end=_dt(2026, 8, 21),
+    )
+
+    plan = compute_desired_plan(
+        [early, late],
+        [empty_slot, shifted_late_slot],
+        max_events=2,
+        plan_id="legacy-partial-closest",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-late": 2, "bob-early": 1}
 
 
 def _make_desired_plan(

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -173,6 +173,20 @@ def test_observed_slot_none_text_token_is_confirmed_empty() -> None:
     assert slot.empty_confirmed is True
 
 
+def test_observed_slot_empty_confirmation_cannot_override_present_pin() -> None:
+    """Present physical state wins over an inconsistent empty-confirmed hint."""
+    slot = ObservedSlot(
+        slot=1,
+        managed=True,
+        raw_name="Guest",
+        raw_pin="1234",
+        empty_confirmed=True,
+    )
+
+    assert slot.classification is ObservedSlotStatus.OCCUPIED
+    assert slot.empty_confirmed is False
+
+
 def test_observed_slot_derives_pin_presence_from_raw_pin() -> None:
     """A raw physical PIN prevents confirmed-empty classification."""
     slot = ObservedSlot(slot=1, managed=True, raw_name="", raw_pin="9999")

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -390,6 +390,52 @@ def test_stateless_duplicate_name_date_shift_preserves_physical_order() -> None:
     assert plan.selected == {"bob-one": 1, "bob-two": 2}
 
 
+def test_stateless_duplicate_name_same_start_orders_by_end() -> None:
+    """Same-start duplicates use end dates before slot numbers for order."""
+    short = _make_desired_reservation(
+        desired_id="bob-short",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 1),
+        end=_dt(2026, 8, 8),
+        slot_code="1111",
+    )
+    long = _make_desired_reservation(
+        desired_id="bob-long",
+        stable_slot_name="Bob",
+        display_slot_name="Bob",
+        start=_dt(2026, 8, 1),
+        end=_dt(2026, 8, 15),
+        slot_code="2222",
+    )
+    long_slot = ObservedSlot(
+        slot=1,
+        managed=True,
+        raw_name="Bob",
+        raw_pin="2222",
+        actual_start=long.buffered_start,
+        actual_end=long.buffered_end,
+    )
+    short_slot = ObservedSlot(
+        slot=2,
+        managed=True,
+        raw_name="Bob",
+        raw_pin="1111",
+        actual_start=short.buffered_start,
+        actual_end=short.buffered_end,
+    )
+
+    plan = compute_stateless_plan(
+        [long_slot, short_slot],
+        [short, long],
+        max_events=2,
+        plan_id="stateless-same-start-order",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-short": 2, "bob-long": 1}
+
+
 def test_stateless_prefix_equivalent_names_do_not_share_slot() -> None:
     """A physical slot already matched by one name group cannot be reused."""
     prefixed = _make_desired_reservation(
@@ -530,6 +576,62 @@ def test_duplicate_name_date_shift_preserves_physical_order() -> None:
     )
 
     assert plan.selected == {"bob-one": 1, "bob-two": 2}
+
+
+def test_duplicate_name_same_start_orders_by_end() -> None:
+    """Legacy duplicate ordering compares end dates before slots."""
+    short = Reservation(
+        identity_key="bob-short",
+        start=_dt(2026, 8, 1),
+        end=_dt(2026, 8, 8),
+        buffered_start=_dt(2026, 8, 1),
+        buffered_end=_dt(2026, 8, 8),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="1111",
+    )
+    long = Reservation(
+        identity_key="bob-long",
+        start=_dt(2026, 8, 1),
+        end=_dt(2026, 8, 15),
+        buffered_start=_dt(2026, 8, 1),
+        buffered_end=_dt(2026, 8, 15),
+        summary="Bob",
+        slot_name="Bob",
+        display_slot_name="Bob",
+        slot_code="2222",
+    )
+    long_slot = ManagedSlot(
+        slot=1,
+        managed=True,
+        status=SlotStatus.OCCUPIED,
+        actual_name="Bob",
+        actual_code="2222",
+        actual_code_present=True,
+        actual_start=long.buffered_start,
+        actual_end=long.buffered_end,
+    )
+    short_slot = ManagedSlot(
+        slot=2,
+        managed=True,
+        status=SlotStatus.OCCUPIED,
+        actual_name="Bob",
+        actual_code="1111",
+        actual_code_present=True,
+        actual_start=short.buffered_start,
+        actual_end=short.buffered_end,
+    )
+
+    plan = compute_desired_plan(
+        [short, long],
+        [long_slot, short_slot],
+        max_events=2,
+        plan_id="legacy-same-start-order",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert plan.selected == {"bob-short": 2, "bob-long": 1}
 
 
 def _make_desired_plan(

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -173,6 +173,14 @@ def test_observed_slot_none_text_token_is_confirmed_empty() -> None:
     assert slot.empty_confirmed is True
 
 
+def test_observed_slot_missing_pin_state_is_unknown_not_empty() -> None:
+    """Missing PIN state cannot prove a physical slot is empty."""
+    slot = ObservedSlot(slot=1, managed=True, raw_name="")
+
+    assert slot.classification is ObservedSlotStatus.UNKNOWN
+    assert slot.empty_confirmed is False
+
+
 def test_observed_slot_empty_confirmation_cannot_override_present_pin() -> None:
     """Present physical state wins over an inconsistent empty-confirmed hint."""
     slot = ObservedSlot(

--- a/tests/unit/test_slot_reconciliation.py
+++ b/tests/unit/test_slot_reconciliation.py
@@ -283,6 +283,41 @@ def test_stateless_date_drift_uses_update_times_action() -> None:
     )
 
 
+def test_stateless_date_drift_uses_update_times_action() -> None:
+    """Pure stateless date drift updates Keymaster times without clear-and-set."""
+    start = _dt(2026, 7, 2)
+    end = _dt(2026, 7, 9)
+    desired = _make_desired_reservation(
+        desired_id="date-drift-reservation",
+        start=start,
+        end=end,
+        slot_code="1234",
+    )
+    occupied_slot = ObservedSlot(
+        slot=1,
+        managed=True,
+        raw_name="RC Test Guest",
+        raw_pin="1234",
+        actual_start=_dt(2026, 7, 1),
+        actual_end=_dt(2026, 7, 8),
+    )
+
+    plan = compute_stateless_plan(
+        [occupied_slot],
+        [desired],
+        max_events=1,
+        plan_id="stateless-date-drift-update-times",
+        generated_at=_dt(2026, 6, 1),
+    )
+
+    assert any(
+        action.kind is ActionKind.UPDATE_TIMES
+        and action.identity_key == "date-drift-reservation"
+        and action.reason == "date_drift"
+        for action in plan.actions
+    )
+
+
 def _make_desired_plan(
     *,
     plan_id: str = "plan-001",

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -3047,6 +3047,17 @@ class TestAsyncFireSetCodeOperationResult:
         assert result.failed is True
         assert result.error == "service unavailable"
 
+    async def test_invalid_datetime_payload_returns_failed_set(self) -> None:
+        """Invalid set-code dates fail as set operations."""
+        coordinator = self._make_coordinator()
+        event = self._make_event()
+        event.extra_state_attributes["start"] = object()
+
+        result = await async_fire_set_code(coordinator, event, 10)
+
+        assert result.failed is True
+        assert result.kind == "set"
+
     async def test_no_lockname_returns_unconfirmed(self) -> None:
         """Missing lockname returns an unconfirmed result."""
         coordinator = self._make_coordinator()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -45,6 +45,7 @@ from custom_components.rental_control.util import get_event_identities
 from custom_components.rental_control.util import get_event_names
 from custom_components.rental_control.util import get_slot_name
 from custom_components.rental_control.util import handle_state_change
+from custom_components.rental_control.util import is_cleared_keymaster_text_state
 from custom_components.rental_control.util import normalize_uid
 from custom_components.rental_control.util import trim_name
 
@@ -52,6 +53,12 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from homeassistant.core import HomeAssistant
+
+
+def test_keymaster_none_text_token_is_cleared() -> None:
+    """The literal None text token is treated as a cleared slot state."""
+    assert is_cleared_keymaster_text_state("None")
+    assert is_cleared_keymaster_text_state(" none ")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -3066,8 +3066,8 @@ class TestAsyncFireUpdateTimesOperationResult:
         event = MagicMock()
         event.extra_state_attributes = {
             "slot_name": "Guest",
-            "start": "2025-01-15T16:00:00",
-            "end": "2025-01-17T11:00:00",
+            "start": datetime(2025, 1, 15, 16, tzinfo=dt_util.UTC),
+            "end": datetime(2025, 1, 17, 11, tzinfo=dt_util.UTC),
         }
         return event
 
@@ -3081,9 +3081,31 @@ class TestAsyncFireUpdateTimesOperationResult:
         coordinator.event_overrides.verify_slot_ownership.return_value = True
         return coordinator
 
+    @staticmethod
+    def _confirm_datetime_states(coordinator: MagicMock) -> None:
+        """Configure coordinator state reads to confirm updated datetimes."""
+        expected = {
+            "datetime.front_door_code_slot_10_date_range_start": (
+                "2025-01-15T16:00:00+00:00"
+            ),
+            "datetime.front_door_code_slot_10_date_range_end": (
+                "2025-01-17T11:00:00+00:00"
+            ),
+        }
+
+        def _get_state(entity_id: str) -> MagicMock | None:
+            """Return a matching state object for datetime confirmation."""
+            value = expected.get(entity_id)
+            if value is None:
+                return None
+            return MagicMock(state=value)
+
+        coordinator.hass.states.get.side_effect = _get_state
+
     async def test_confirmed_on_success(self) -> None:
         """Successful service calls return confirmed."""
         coordinator = self._make_coordinator()
+        self._confirm_datetime_states(coordinator)
 
         result = await async_fire_update_times(coordinator, self._make_event(), 10)
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -3057,6 +3057,7 @@ class TestAsyncFireSetCodeOperationResult:
 
         assert result.failed is True
         assert result.kind == "set"
+        coordinator.hass.services.async_call.assert_not_awaited()
 
     async def test_no_lockname_returns_unconfirmed(self) -> None:
         """Missing lockname returns an unconfirmed result."""

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -3115,6 +3115,35 @@ class TestAsyncFireUpdateTimesOperationResult:
             confirmed=True,
         )
 
+    async def test_all_day_dates_are_confirmed_as_datetimes(self) -> None:
+        """All-day date values are coerced before update confirmation."""
+        coordinator = self._make_coordinator()
+        coordinator.timezone = dt_util.UTC
+        expected = {
+            "datetime.front_door_code_slot_10_date_range_start": (
+                "2025-01-15T00:00:00+00:00"
+            ),
+            "datetime.front_door_code_slot_10_date_range_end": (
+                "2025-01-17T00:00:00+00:00"
+            ),
+        }
+        coordinator.hass.states.get.side_effect = lambda entity_id: MagicMock(
+            state=expected[entity_id]
+        )
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": "Guest",
+            "start": date(2025, 1, 15),
+            "end": date(2025, 1, 17),
+        }
+
+        result = await async_fire_update_times(coordinator, event, 10)
+
+        assert result.confirmed is True
+        calls = coordinator.hass.services.async_call.await_args_list
+        payloads = [call.kwargs["service_data"] for call in calls]
+        assert all(isinstance(payload["datetime"], datetime) for payload in payloads)
+
     async def test_failed_on_service_exception(self) -> None:
         """Gather failures are returned as failed."""
         coordinator = self._make_coordinator()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -3144,6 +3144,21 @@ class TestAsyncFireUpdateTimesOperationResult:
         payloads = [call.kwargs["service_data"] for call in calls]
         assert all(isinstance(payload["datetime"], datetime) for payload in payloads)
 
+    async def test_invalid_datetime_payload_fails_safely(self) -> None:
+        """Invalid update dates fail instead of using nondeterministic times."""
+        coordinator = self._make_coordinator()
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": "Guest",
+            "start": object(),
+            "end": date(2025, 1, 17),
+        }
+
+        result = await async_fire_update_times(coordinator, event, 10)
+
+        assert result.failed is True
+        coordinator.hass.services.async_call.assert_not_awaited()
+
     async def test_failed_on_service_exception(self) -> None:
         """Gather failures are returned as failed."""
         coordinator = self._make_coordinator()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -2647,7 +2647,7 @@ class TestBufferInSetCode:
         ]
         assert len(start_calls) == 1
         sent = start_calls[0].kwargs["service_data"]["datetime"]
-        assert sent == datetime(2025, 1, 15, 15, 30, 0)
+        assert sent == datetime(2025, 1, 15, 15, 30, 0, tzinfo=dt_util.UTC)
 
     async def test_after_buffer_extends_end(self) -> None:
         """Verify date_range_end is 15 minutes later."""
@@ -2671,7 +2671,7 @@ class TestBufferInSetCode:
         ]
         assert len(end_calls) == 1
         sent = end_calls[0].kwargs["service_data"]["datetime"]
-        assert sent == datetime(2025, 1, 17, 11, 15, 0)
+        assert sent == datetime(2025, 1, 17, 11, 15, 0, tzinfo=dt_util.UTC)
 
     async def test_both_buffers_applied(self) -> None:
         """Verify both offsets applied simultaneously."""
@@ -2699,10 +2699,10 @@ class TestBufferInSetCode:
             if "date_range_end" in c.kwargs.get("target", {}).get("entity_id", "")
         ]
         assert start_calls[0].kwargs["service_data"]["datetime"] == (
-            datetime(2025, 1, 15, 15, 0, 0)
+            datetime(2025, 1, 15, 15, 0, 0, tzinfo=dt_util.UTC)
         )
         assert end_calls[0].kwargs["service_data"]["datetime"] == (
-            datetime(2025, 1, 17, 11, 30, 0)
+            datetime(2025, 1, 17, 11, 30, 0, tzinfo=dt_util.UTC)
         )
 
     async def test_zero_buffer_unchanged(self) -> None:
@@ -2716,8 +2716,8 @@ class TestBufferInSetCode:
         coordinator.hass.services.async_call = AsyncMock()
         coordinator.event_overrides.verify_slot_ownership.return_value = True
 
-        start = datetime(2025, 1, 15, 16, 0, 0)
-        end = datetime(2025, 1, 17, 11, 0, 0)
+        start = datetime(2025, 1, 15, 16, 0, 0, tzinfo=dt_util.UTC)
+        end = datetime(2025, 1, 17, 11, 0, 0, tzinfo=dt_util.UTC)
         event = self._make_event(start=start, end=end)
         await async_fire_set_code(coordinator, event, 10)
 
@@ -2777,7 +2777,7 @@ class TestBufferInUpdateTimes:
             if "date_range_start" in c.kwargs.get("target", {}).get("entity_id", "")
         ]
         assert start_calls[0].kwargs["service_data"]["datetime"] == (
-            datetime(2025, 1, 15, 15, 30, 0)
+            datetime(2025, 1, 15, 15, 30, 0, tzinfo=dt_util.UTC)
         )
 
     async def test_after_buffer_extends_end(self) -> None:
@@ -2799,7 +2799,7 @@ class TestBufferInUpdateTimes:
             if "date_range_end" in c.kwargs.get("target", {}).get("entity_id", "")
         ]
         assert end_calls[0].kwargs["service_data"]["datetime"] == (
-            datetime(2025, 1, 17, 11, 15, 0)
+            datetime(2025, 1, 17, 11, 15, 0, tzinfo=dt_util.UTC)
         )
 
     async def test_zero_buffer_unchanged(self) -> None:
@@ -2811,8 +2811,8 @@ class TestBufferInUpdateTimes:
         coordinator.hass.services.async_call = AsyncMock()
         coordinator.event_overrides.verify_slot_ownership.return_value = True
 
-        start = datetime(2025, 1, 15, 16, 0, 0)
-        end = datetime(2025, 1, 17, 11, 0, 0)
+        start = datetime(2025, 1, 15, 16, 0, 0, tzinfo=dt_util.UTC)
+        end = datetime(2025, 1, 17, 11, 0, 0, tzinfo=dt_util.UTC)
         event = self._make_event(start=start, end=end)
         await async_fire_update_times(coordinator, event, 10)
 


### PR DESCRIPTION
Closes #607
Closes #614

Summary:
- Adds stateless slot reconciliation models/planning and stable slot-name identity matching.
- Demotes the persisted slot Store to cache-only diagnostics/aliases.
- Switches refresh/apply behavior to physical Keymaster truth plus current calendar, with confirmed-empty gates before assignment/replacement.
- Preserves manual overrides, buffers, Honor PMS times, deterministic codes, check-in tracking, and event sensor compatibility.
- Fixes buffer-aware manual time detection so physical calendar±buffer slot times are system-managed, while true deviations remain manual overrides.

Validation:
- uv run pytest tests/ -q: 1433 passed, 4 skipped
- uv run pytest tests/ --cov=custom_components.rental_control --cov-report=term-missing -q: 1433 passed, 4 skipped, 92.25% coverage
- uv run pytest tests/unit/test_slot_reconciliation.py tests/unit/test_coordinator.py tests/unit/test_event_overrides.py tests/integration/test_refresh_cycle.py tests/integration/test_slot_concurrency.py tests/unit/test_util.py -q: 892 passed, 4 skipped
- uv run ruff check custom_components/ tests/: passed
- Pre-commit hooks on new commits: passed
- Code review agent: completed; issue #614 review findings fixed; final verification reported no significant issues
- Rubber-duck review: issue #614 buffer-aware path clean; broader pre-existing observations recorded for maintainer awareness

New #614 coverage:
- Honor Event Times with 30-minute pre/post buffers updates check-in and checkout to the newly buffered PMS window.
- Zero-buffer calendar time changes still update normally.
- Physical times equal to calendar±buffer are system-managed, not manual overrides.
- Genuine manual deviations and mixed system/manual fields are preserved.
- Buffer config rewrites update/suppress in-memory override feedback and avoid stale refreshes, including service-failure paths.

Migrated/removed tests justification:
- Store-authoritative tests for pending fences, miss counts, adoption, and occupied status were migrated or skipped where the Store is now explicitly cache-only and non-authoritative.
- Integration expectations now assert cache-only metadata and confirmed physical reset semantics instead of legacy Store ownership.