### PR TITLE
Fix(slots): Trim-aware slot ownership check

### DIFF
--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -204,8 +204,7 @@ class RentalControlCoordinator(DataUpdateCoordinator[list[CalendarEvent]]):
         if self.event_overrides is not None:
             self.event_overrides.trim_names = self.trim_names
             self.event_overrides.max_name_length = self.max_name_length
-            prefix = f"{self.event_prefix} " if self.event_prefix else ""
-            self.event_overrides.prefix_length = len(prefix)
+            self.event_overrides.event_prefix = self.event_prefix
         self.code_length: int = config.get(CONF_CODE_LENGTH, DEFAULT_CODE_LENGTH)
         self.event: CalendarEvent | None = None
         self.created: str = config.get(CONF_CREATION_DATETIME, str(dt.now()))
@@ -2628,8 +2627,7 @@ Please update Keymaster to at least v0.1.0-b0
         if self.event_overrides is not None:
             self.event_overrides.trim_names = self.trim_names
             self.event_overrides.max_name_length = self.max_name_length
-            prefix = f"{self.event_prefix} " if self.event_prefix else ""
-            self.event_overrides.prefix_length = len(prefix)
+            self.event_overrides.event_prefix = self.event_prefix
         self.code_length = config.get(CONF_CODE_LENGTH, DEFAULT_CODE_LENGTH)
         self.ignore_non_reserved = bool(config.get(CONF_IGNORE_NON_RESERVED))
         self.verify_ssl = bool(config.get(CONF_VERIFY_SSL))

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -168,6 +168,7 @@ class EventOverrides:
         self._start_slot: int = start_slot
         self._trim_names: bool = False
         self._max_name_length: int = 0
+        self._event_prefix: str = ""
         self._prefix_length: int = 0
 
         # Store-backed fields (T018)
@@ -237,6 +238,18 @@ class EventOverrides:
     def max_name_length(self, value: int) -> None:
         """Set the configured max name length."""
         self._max_name_length = value
+
+    @property
+    def event_prefix(self) -> str:
+        """Return the configured event prefix."""
+        return self._event_prefix
+
+    @event_prefix.setter
+    def event_prefix(self, value: str | None) -> None:
+        """Set the configured event prefix."""
+        self._event_prefix = value or ""
+        prefix = f"{self._event_prefix} " if self._event_prefix else ""
+        self._prefix_length = len(prefix)
 
     @property
     def prefix_length(self) -> int:
@@ -915,7 +928,28 @@ class EventOverrides:
         Read-only check — does not acquire the lock.
         """
         override = self._overrides.get(slot)
-        return override is not None and override["slot_name"] == expected_name
+        if override is None:
+            return False
+
+        stored_name = override["slot_name"]
+        if stored_name == expected_name:
+            return True
+
+        if not self._trim_names or self._max_name_length <= 0:
+            return False
+
+        if self._event_prefix:
+            stored_name = _strip_prefix(stored_name, self._event_prefix)
+
+        if stored_name == expected_name:
+            return True
+
+        guest_max = self._max_name_length - self._prefix_length
+        return len(expected_name) > len(stored_name) and _is_trimmed_match(
+            stored_name,
+            expected_name,
+            guest_max,
+        )
 
     def record_retry_failure(self, slot: int) -> bool:
         """Record failed lock command.

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -399,6 +399,85 @@ class TestSlotLookups:
         assert eo.get_slot_key_by_name("Nobody") == 0
 
 
+class TestTrimAwareSlotOwnership:
+    """Tests for EventOverrides.verify_slot_ownership."""
+
+    @staticmethod
+    def _make_trimmed_ownership_eo(stored_name: str) -> EventOverrides:
+        """Build an EventOverrides using the production trim configuration."""
+        eo = EventOverrides(start_slot=34, max_slots=1)
+        eo.trim_names = True
+        eo.max_name_length = 16
+        eo.event_prefix = "S5 -"
+        now = dt_util.now()
+        eo.update(34, "1234", stored_name, now, now + timedelta(days=3))
+        return eo
+
+    def test_verify_slot_ownership_accepts_trimmed_name(self) -> None:
+        """Verify a prefix-stripped trimmed slot still owns the full name."""
+        eo = self._make_trimmed_ownership_eo("Nicole")
+
+        assert eo.verify_slot_ownership(
+            34,
+            "Nicole Amidon (homeaway) - by Hostaway",
+        )
+
+    def test_verify_slot_ownership_accepts_full_when_stored_full(self) -> None:
+        """Verify exact full-name ownership continues to pass."""
+        full_name = "Nicole Amidon (homeaway) - by Hostaway"
+        eo = self._make_trimmed_ownership_eo(full_name)
+
+        assert eo.verify_slot_ownership(34, full_name)
+
+    def test_verify_slot_ownership_rejects_different_name(self) -> None:
+        """Verify a different reservation name is still rejected."""
+        eo = self._make_trimmed_ownership_eo("Nicole")
+
+        assert not eo.verify_slot_ownership(
+            34,
+            "Sarah Miller (homeaway) - by Hostaway",
+        )
+
+    def test_verify_slot_ownership_rejects_shorter_expected_name(self) -> None:
+        """Verify a shorter expected name cannot claim a longer stored owner."""
+        eo = self._make_trimmed_ownership_eo("Nicole Amidon")
+
+        assert not eo.verify_slot_ownership(34, "Nicole")
+
+    def test_verify_slot_ownership_rejects_expected_prefix_text(self) -> None:
+        """Verify a raw reservation name starting with the prefix is distinct."""
+        eo = self._make_trimmed_ownership_eo("Nicole")
+
+        assert not eo.verify_slot_ownership(
+            34,
+            "S5 - Nicole Amidon (homeaway) - by Hostaway",
+        )
+
+    def test_verify_slot_ownership_exact_when_trim_disabled(self) -> None:
+        """Verify trim-disabled ownership still requires exact equality."""
+        eo = EventOverrides(start_slot=34, max_slots=1)
+        eo.trim_names = False
+        eo.max_name_length = 16
+        eo.event_prefix = "S5 -"
+        now = dt_util.now()
+        eo.update(34, "1234", "Nicole", now, now + timedelta(days=3))
+
+        assert eo.verify_slot_ownership(34, "Nicole")
+        assert not eo.verify_slot_ownership(
+            34,
+            "Nicole Amidon (homeaway) - by Hostaway",
+        )
+
+    def test_verify_slot_ownership_accepts_prefixed_trimmed_name(self) -> None:
+        """Verify a stored Keymaster display name can include the prefix."""
+        eo = self._make_trimmed_ownership_eo("S5 - Nicole")
+
+        assert eo.verify_slot_ownership(
+            34,
+            "Nicole Amidon (homeaway) - by Hostaway",
+        )
+
+
 # ---------------------------------------------------------------------------
 # get_slot_start_date / get_slot_start_time / get_slot_end_date / get_slot_end_time
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -29,6 +29,7 @@ from custom_components.rental_control.const import COORDINATOR
 from custom_components.rental_control.const import DEFAULT_PATH
 from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.const import NAME
+from custom_components.rental_control.event_overrides import EventOverrides
 from custom_components.rental_control.util import EventIdentity
 from custom_components.rental_control.util import OperationResult
 from custom_components.rental_control.util import add_call
@@ -1927,6 +1928,35 @@ class TestAsyncFireUpdateTimes:
 class TestPreExecutionVerification:
     """Tests for ownership verification before lock commands."""
 
+    @staticmethod
+    def _make_trimmed_event_overrides() -> EventOverrides:
+        """Build EventOverrides with a trimmed stored owner."""
+        event_overrides = EventOverrides(start_slot=10, max_slots=1)
+        event_overrides.trim_names = True
+        event_overrides.max_name_length = 16
+        event_overrides.event_prefix = "S5 -"
+        now = dt_util.now()
+        event_overrides.update(
+            10,
+            "1234",
+            "Nicole",
+            now,
+            now + timedelta(days=3),
+        )
+        return event_overrides
+
+    @staticmethod
+    def _make_long_name_event() -> MagicMock:
+        """Build a mock event with the production long-name reproduction."""
+        event = MagicMock()
+        event.extra_state_attributes = {
+            "slot_name": "Nicole Amidon (homeaway) - by Hostaway",
+            "slot_code": "1234",
+            "start": "2025-01-15T16:00:00",
+            "end": "2025-01-17T11:00:00",
+        }
+        return event
+
     async def test_set_code_aborts_on_ownership_mismatch(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -1995,6 +2025,73 @@ class TestPreExecutionVerification:
 
         coordinator.hass.services.async_call.assert_not_awaited()
         assert "ownership" in caplog.text.lower()
+
+    async def test_update_times_proceeds_for_trimmed_owner(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Verify trimmed ownership allows update_times to execute."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides = self._make_trimmed_event_overrides()
+        event = self._make_long_name_event()
+
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.rental_control.util"
+        ):
+            await async_fire_update_times(coordinator, event, 10)
+
+        coordinator.hass.services.async_call.assert_awaited()
+        assert "ownership verification failed" not in caplog.text
+
+    async def test_set_code_proceeds_for_trimmed_owner(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Verify trimmed ownership allows set_code to execute."""
+        coordinator = MagicMock()
+        coordinator.lockname = "front_door"
+        coordinator.event_prefix = "S5 -"
+        coordinator.trim_names = True
+        coordinator.max_name_length = 16
+        coordinator.code_buffer_before = 0
+        coordinator.code_buffer_after = 0
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides = self._make_trimmed_event_overrides()
+
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.rental_control.util"
+        ):
+            await async_fire_set_code(coordinator, self._make_long_name_event(), 10)
+
+        coordinator.hass.services.async_call.assert_awaited()
+        assert "ownership verification failed" not in caplog.text
+
+    async def test_clear_code_proceeds_for_trimmed_owner(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Verify trimmed ownership allows clear_code to execute."""
+        coordinator = MagicMock()
+        coordinator.name = "Test Rental"
+        coordinator.lockname = "front_door"
+        coordinator.hass.services.async_call = AsyncMock()
+        coordinator.event_overrides = self._make_trimmed_event_overrides()
+
+        with (
+            caplog.at_level(
+                logging.WARNING, logger="custom_components.rental_control.util"
+            ),
+            patch("custom_components.rental_control.util.asyncio.sleep"),
+        ):
+            await async_fire_clear_code(
+                coordinator,
+                10,
+                expected_name="Nicole Amidon (homeaway) - by Hostaway",
+            )
+
+        coordinator.hass.services.async_call.assert_awaited()
+        assert "ownership verification failed" not in caplog.text
 
     async def test_set_code_proceeds_when_ownership_matches(self) -> None:
         """Verify async_fire_set_code executes when ownership passes."""


### PR DESCRIPTION
## Summary

Closes #624.

Fixes a confirmed lock-code stale-guard bug where long reservation names can be trimmed by Keymaster feedback before `verify_slot_ownership()` compares them with the full reservation name passed by reconciliation.

## Symptom

Production logged warnings such as:

```text
Slot 34 ownership verification failed for 'Nicole Amidon (homeaway) - by Hostaway'; aborting update_times
```

With `trim_names` enabled, `max_name_length = 16`, and `event_prefix = \"S5 -\"`, Keymaster displays the 38-character Hostaway name as a shortened `S5 - Nicole`, and the stored override can become the prefix-stripped `Nicole`. The exact ownership check then rejects the full reservation name and aborts `set_code`, `clear_code`, or `update_times`, leaving stale lock validity windows or codes.

## Root cause

`EventOverrides.verify_slot_ownership()` only accepted exact name equality even though `_overrides[slot][\"slot_name\"]` can contain either the full reservation name from reconciliation SET application or the trimmed/prefix-stripped name observed from Keymaster state changes.

## Fix

- Keep exact equality as the fast path.
- Wire the configured `event_prefix` into `EventOverrides` alongside existing trim settings.
- When trimming is enabled, strip the configured display prefix from stored Keymaster/display names, compute `guest_max` as `max_name_length - len(prefix_with_trailing_space)`, and accept the match only when the stored name is the configured trim of the longer expected reservation name.
- Preserve exact-only behavior when trimming is disabled.
- Add reproduction/regression tests for trimmed stored names, stored full names, prefix display names, genuine mismatches, prefix-text guest names, and shorter-name claim attempts.
- Add util stale-guard coverage showing `set_code`, `clear_code`, and `update_times` proceed for the confirmed Hostaway-style long name without logging an ownership failure.

This does not loosen ownership beyond configured trim/prefix equivalence: different names still reject, trim-disabled checks remain exact-only, and a shorter expected name cannot claim a longer stored owner.

## Validation

- Reproduction failed before the fix: `TestTrimAwareSlotOwnership::test_verify_slot_ownership_accepts_trimmed_name`, `...accepts_prefixed_trimmed_name`, and `TestPreExecutionVerification::test_update_times_proceeds_for_trimmed_owner`.
- `uv run pytest tests/unit/test_event_overrides.py tests/unit/test_util.py tests/integration/test_refresh_cycle.py tests/unit/test_coordinator.py -q`
- `uv run pytest tests/ --cov=custom_components.rental_control --cov-report=term-missing -q` (92.25%)
- `uv run ruff check custom_components/ tests/`
- `uv run pre-commit run --all-files`