### PR TITLE
Refactor(checkin): Decompose check-in sensor

### DIFF
--- a/custom_components/rental_control/sensors/checkin/__init__.py
+++ b/custom_components/rental_control/sensors/checkin/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal helpers for the Rental Control check-in sensor."""
+
+from .models import CheckinStateSnapshot
+from .models import CoordinatorUpdateContext
+from .models import DecisionEffect
+from .models import LogIntent
+from .models import RestoreReconciliationDecision
+from .models import ScheduledTransition
+from .models import TransitionDecision
+from .persistence import CheckinExtraStoredData
+
+__all__ = [
+    "CheckinExtraStoredData",
+    "CheckinStateSnapshot",
+    "CoordinatorUpdateContext",
+    "DecisionEffect",
+    "LogIntent",
+    "RestoreReconciliationDecision",
+    "ScheduledTransition",
+    "TransitionDecision",
+]

--- a/custom_components/rental_control/sensors/checkin/applicator.py
+++ b/custom_components/rental_control/sensors/checkin/applicator.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Apply ordered check-in decisions through the entity boundary."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .models import DecisionEffect
+from .models import LogIntent
+from .models import RestoreReconciliationDecision
+from .models import TransitionDecision
+
+_LOGGER = logging.getLogger("custom_components.rental_control.sensors.checkinsensor")
+
+
+def apply_transition_decision(entity: Any, decision: TransitionDecision) -> None:
+    """Apply coordinator-update effects to the check-in entity."""
+    _emit_logs(decision.log_records)
+    for effect in decision.effects:
+        _apply_effect(entity, effect, silent=False)
+    if decision.write_state:
+        entity.async_write_ha_state()
+
+
+def apply_restore_decision(
+    entity: Any, decision: RestoreReconciliationDecision
+) -> None:
+    """Apply restore reconciliation effects to the check-in entity."""
+    _emit_logs(decision.log_records)
+    for effect in decision.effects:
+        _apply_effect(entity, effect, silent=True)
+    if decision.write_state:
+        entity.async_write_ha_state()
+
+
+def _emit_logs(logs: tuple[LogIntent, ...]) -> None:
+    """Emit selected log records."""
+    for record in logs:
+        log = getattr(_LOGGER, record.level)
+        log(record.message, *record.args)
+
+
+def _apply_effect(entity: Any, effect: DecisionEffect, *, silent: bool) -> None:
+    """Apply one effect by calling entity-owned mutation methods."""
+    match effect.kind:
+        case "transition_awaiting":
+            entity._transition_to_awaiting(effect.event)
+        case "transition_checked_in":
+            entity._transition_to_checked_in(
+                effect.source or "automatic", effect.lock_name
+            )
+        case "transition_checked_out":
+            entity._transition_to_checked_out(
+                effect.source or "automatic", effect.linger_baseline
+            )
+        case "transition_no_reservation":
+            entity._transition_to_no_reservation()
+        case "silent_checked_in":
+            entity._apply_silent_checked_in(effect.source or "automatic")
+        case "silent_checked_out":
+            entity._apply_silent_checked_out(
+                effect.source or "automatic", effect.linger_baseline
+            )
+        case _:
+            _apply_non_transition_effect(entity, effect, silent=silent)
+
+
+def _apply_non_transition_effect(
+    entity: Any, effect: DecisionEffect, *, silent: bool
+) -> None:
+    """Apply a non-transition effect."""
+    match effect.kind:
+        case "update_tracked_event":
+            entity._update_tracked_event(effect.event)
+        case "update_slot_name":
+            entity._update_tracked_slot_name(effect.event)
+        case "cancel_timer":
+            entity._cancel_timer()
+        case "schedule_auto_checkout":
+            entity._schedule_auto_checkout(effect.end_time)
+        case "schedule_auto_checkin":
+            entity._schedule_auto_checkin(effect.target_time or effect.end_time)
+        case "schedule_no_reservation_to_awaiting":
+            entity._schedule_no_reservation_to_awaiting(
+                effect.target_time or effect.end_time
+            )
+        case "compute_linger":
+            entity._compute_linger_timing()
+        case "set_event_missing":
+            entity._event_missing_warned = bool(effect.value)
+        case "set_linger_followon_key":
+            entity._linger_followon_key = effect.value
+        case "set_transition_target":
+            entity._transition_target_time = effect.value
+        case "set_next_event_start_day":
+            entity._next_event_start_day = effect.value
+        case _:
+            raise ValueError(f"Unknown check-in decision effect: {effect.kind}")

--- a/custom_components/rental_control/sensors/checkin/event_selection.py
+++ b/custom_components/rental_control/sensors/checkin/event_selection.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure event-selection helpers for the check-in sensor."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+
+from homeassistant.components.calendar import CalendarEvent
+
+from ...util import get_slot_name
+
+
+def event_key(summary: str, start: datetime) -> str:
+    """Return the behavior-compatible identity key for an event."""
+    return f"{summary}|{start.isoformat()}"
+
+
+def get_relevant_event(
+    events: Sequence[CalendarEvent] | None,
+    now: datetime,
+) -> CalendarEvent | None:
+    """Return the first event whose end time has not passed."""
+    for event in events or []:
+        if event.end > now:
+            return event
+    return None
+
+
+def find_followon_event(
+    events: Sequence[CalendarEvent] | None,
+    checkout_time: datetime,
+    checked_out_event_key: str | None,
+) -> CalendarEvent | None:
+    """Return the first event starting after checkout, excluding checked-out."""
+    for event in events or []:
+        if checked_out_event_key is not None:
+            if event_key(event.summary, event.start) == checked_out_event_key:
+                continue
+        if event.start >= checkout_time:
+            return event
+    return None
+
+
+def find_tracked_event(
+    events: Sequence[CalendarEvent] | None,
+    tracked_summary: str | None,
+    tracked_start: datetime | None,
+) -> CalendarEvent | None:
+    """Find a tracked event by summary and start identity."""
+    if not events or tracked_summary is None or tracked_start is None:
+        return None
+    tracked_key = event_key(tracked_summary, tracked_start)
+    for event in events:
+        if event_key(event.summary, event.start) == tracked_key:
+            return event
+    return None
+
+
+def extract_slot_name(event: CalendarEvent, event_prefix: str) -> str | None:
+    """Extract the guest/slot name using existing Rental Control parsing."""
+    return get_slot_name(event.summary, event.description or "", event_prefix or "")

--- a/custom_components/rental_control/sensors/checkin/models.py
+++ b/custom_components/rental_control/sensors/checkin/models.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed models for check-in sensor decomposition."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from typing import Literal
+
+from homeassistant.components.calendar import CalendarEvent
+from homeassistant.core import CALLBACK_TYPE
+
+from ...const import CHECKIN_STATE_AWAITING
+from ...const import CHECKIN_STATE_CHECKED_IN
+from ...const import CHECKIN_STATE_CHECKED_OUT
+from ...const import CHECKIN_STATE_NO_RESERVATION
+
+CheckinState = Literal[
+    "no_reservation",
+    "awaiting_checkin",
+    "checked_in",
+    "checked_out",
+]
+TimerPurpose = Literal[
+    "auto_checkin",
+    "auto_checkout",
+    "linger_to_awaiting",
+    "linger_to_no_reservation",
+    "no_reservation_to_awaiting",
+]
+
+
+@dataclass(slots=True)
+class CheckinStateSnapshot:
+    """Snapshot of check-in sensor state and persisted fields."""
+
+    state: str = CHECKIN_STATE_NO_RESERVATION
+    tracked_event_summary: str | None = None
+    tracked_event_start: datetime | None = None
+    tracked_event_end: datetime | None = None
+    tracked_event_slot_name: str | None = None
+    checkin_source: str | None = None
+    checkout_source: str | None = None
+    checkout_time: datetime | None = None
+    transition_target_time: datetime | None = None
+    checked_out_event_key: str | None = None
+    next_event_start_day: datetime | None = None
+    checkin_lock_name: str | None = None
+    linger_followon_key: str | None = None
+    linger_baseline: datetime | None = None
+    event_missing_warned: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class CoordinatorUpdateContext:
+    """Inputs for pure coordinator-update decisions."""
+
+    snapshot: CheckinStateSnapshot
+    events: Sequence[CalendarEvent]
+    clock: Callable[[], datetime]
+    last_update_success: bool
+    monitoring_enabled: bool
+    cleaning_window_hours: float
+    event_prefix: str
+    active_timer: bool
+    coordinator_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionEffect:
+    """Ordered effect for the entity shell to apply."""
+
+    kind: str
+    event: CalendarEvent | None = None
+    source: str | None = None
+    lock_name: str = ""
+    linger_baseline: datetime | None = None
+    end_time: datetime | None = None
+    target_time: datetime | None = None
+    value: Any = None
+
+
+@dataclass(frozen=True, slots=True)
+class LogIntent:
+    """Log record selected by pure decision logic."""
+
+    level: str
+    message: str
+    args: tuple[Any, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class TransitionDecision:
+    """Decision from coordinator-update processing."""
+
+    effects: tuple[DecisionEffect, ...] = ()
+    write_state: bool = False
+    log_records: tuple[LogIntent, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreReconciliationDecision:
+    """Decision from restored-state reconciliation."""
+
+    effects: tuple[DecisionEffect, ...] = ()
+    write_state: bool = False
+    reason: str = ""
+    log_records: tuple[LogIntent, ...] = ()
+
+
+@dataclass(slots=True)
+class ScheduledTransition:
+    """Runtime metadata for a scheduled check-in transition."""
+
+    purpose: TimerPurpose
+    target_time: datetime
+    followon_start_day: datetime | None = None
+    cancel_handle: CALLBACK_TYPE | None = None
+
+
+VALID_CHECKIN_STATES = {
+    CHECKIN_STATE_NO_RESERVATION,
+    CHECKIN_STATE_AWAITING,
+    CHECKIN_STATE_CHECKED_IN,
+    CHECKIN_STATE_CHECKED_OUT,
+}

--- a/custom_components/rental_control/sensors/checkin/persistence.py
+++ b/custom_components/rental_control/sensors/checkin/persistence.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""RestoreEntity persistence helpers for the check-in sensor."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+from typing import Any
+
+from homeassistant.helpers.restore_state import ExtraStoredData
+from homeassistant.util import dt as dt_util
+
+from ...const import CHECKIN_STATE_NO_RESERVATION
+from .models import CheckinStateSnapshot
+
+_LOGGER = logging.getLogger(__name__)
+
+_STORED_DT_FIELDS = (
+    "tracked_event_start",
+    "tracked_event_end",
+    "checkout_time",
+    "transition_target_time",
+    "next_event_start_day",
+)
+_STORED_KEYS = (
+    "state",
+    "tracked_event_summary",
+    "tracked_event_start",
+    "tracked_event_end",
+    "tracked_event_slot_name",
+    "checkin_source",
+    "checkout_source",
+    "checkout_time",
+    "transition_target_time",
+    "checked_out_event_key",
+    "next_event_start_day",
+    "checkin_lock_name",
+)
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    """Parse an ISO 8601 string to datetime or return None."""
+    if value is None:
+        return None
+    try:
+        result: datetime | None = dt_util.parse_datetime(value)
+    except TypeError:
+        _LOGGER.warning("Failed to parse stored datetime: %s", value)
+        return None
+    except ValueError:
+        _LOGGER.warning("Failed to parse stored datetime: %s", value)
+        return None
+    if result is None:
+        _LOGGER.warning("Failed to parse stored datetime: %s", value)
+    return result
+
+
+class CheckinExtraStoredData(ExtraStoredData):
+    """Extra stored data for persisting CheckinTrackingSensor state."""
+
+    def __init__(
+        self,
+        snapshot: CheckinStateSnapshot | None = None,
+        **legacy_fields: Any,
+    ) -> None:
+        """Initialize from a snapshot or legacy keyword fields."""
+        if snapshot is None:
+            snapshot = CheckinStateSnapshot(**legacy_fields)
+        self.snapshot = snapshot
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate legacy field attribute access to the snapshot."""
+        return getattr(self.snapshot, name)
+
+    @classmethod
+    def from_snapshot(cls, snapshot: CheckinStateSnapshot) -> CheckinExtraStoredData:
+        """Build stored data from a check-in state snapshot."""
+        return cls(snapshot=snapshot)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the unchanged JSON-serialisable dict representation."""
+        data = {key: getattr(self.snapshot, key) for key in _STORED_KEYS}
+        for key in _STORED_DT_FIELDS:
+            value = data[key]
+            data[key] = value.isoformat() if value else None
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CheckinExtraStoredData:
+        """Reconstruct an instance from the persisted dictionary shape."""
+        fields: dict[str, Any] = {key: data.get(key) for key in _STORED_KEYS}
+        fields["state"] = data.get("state", CHECKIN_STATE_NO_RESERVATION)
+        for key in _STORED_DT_FIELDS:
+            fields[key] = _parse_dt(data.get(key))
+        return cls(snapshot=CheckinStateSnapshot(**fields))

--- a/custom_components/rental_control/sensors/checkin/restore_decisions.py
+++ b/custom_components/rental_control/sensors/checkin/restore_decisions.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure restored-state reconciliation decisions for the check-in sensor."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from ...const import CHECKIN_STATE_AWAITING
+from ...const import CHECKIN_STATE_CHECKED_IN
+from ...const import CHECKIN_STATE_CHECKED_OUT
+from ...const import CHECKIN_STATE_NO_RESERVATION
+from .event_selection import event_key
+from .event_selection import get_relevant_event
+from .models import CoordinatorUpdateContext
+from .models import DecisionEffect
+from .models import LogIntent
+from .models import RestoreReconciliationDecision
+
+_SELF_HEAL_FUTURE_THRESHOLD = timedelta(hours=24)
+
+
+def _decision(
+    *effects: DecisionEffect,
+    write: bool = False,
+    reason: str = "",
+    logs: tuple[LogIntent, ...] = (),
+) -> RestoreReconciliationDecision:
+    """Build a restore reconciliation decision."""
+    return RestoreReconciliationDecision(
+        effects=effects,
+        write_state=write,
+        reason=reason,
+        log_records=logs,
+    )
+
+
+def decide_restore_state(
+    ctx: CoordinatorUpdateContext,
+) -> RestoreReconciliationDecision:
+    """Choose silent effects for restored-state validation."""
+    state = ctx.snapshot.state
+    if state == CHECKIN_STATE_CHECKED_IN:
+        return decide_restore_checked_in(ctx)
+    if state == CHECKIN_STATE_AWAITING:
+        return decide_restore_awaiting(ctx)
+    if state == CHECKIN_STATE_CHECKED_OUT:
+        return decide_restore_checked_out(ctx)
+    if state == CHECKIN_STATE_NO_RESERVATION:
+        return decide_restore_no_reservation(ctx)
+    return decide_restore_unknown(ctx)
+
+
+def decide_restore_checked_in(
+    ctx: CoordinatorUpdateContext,
+) -> RestoreReconciliationDecision:
+    """Reconcile a restored checked-in state."""
+    snap = ctx.snapshot
+    now = ctx.clock()
+    if (
+        snap.tracked_event_start
+        and snap.tracked_event_start > now + _SELF_HEAL_FUTURE_THRESHOLD
+    ):
+        log = LogIntent(
+            "debug",
+            "Stale restore: checked_in but tracked event starts %s (>24h away), "
+            "forcing checkout (silent)",
+            (snap.tracked_event_start,),
+        )
+        return _decision(
+            DecisionEffect(
+                "silent_checked_out", source="automatic", linger_baseline=now
+            ),
+            DecisionEffect("compute_linger"),
+            write=True,
+            reason="far_future_checked_in",
+            logs=(log,),
+        )
+    if snap.tracked_event_end and snap.tracked_event_end <= now:
+        log = LogIntent(
+            "debug",
+            "Stale restore: checked_in but event ended, transitioning to checked_out (silent)",
+        )
+        return _decision(
+            DecisionEffect(
+                "silent_checked_out",
+                source="automatic",
+                linger_baseline=snap.tracked_event_end,
+            ),
+            DecisionEffect("compute_linger"),
+            write=True,
+            reason="ended_checked_in",
+            logs=(log,),
+        )
+    if snap.tracked_event_end is not None:
+        return _decision(
+            DecisionEffect("cancel_timer"),
+            DecisionEffect("schedule_auto_checkout", end_time=snap.tracked_event_end),
+            write=True,
+            reason="reschedule_auto_checkout",
+        )
+    return _decision(
+        DecisionEffect("cancel_timer"),
+        DecisionEffect("set_transition_target", value=None),
+        write=True,
+        reason="checked_in_missing_end",
+    )
+
+
+def decide_restore_awaiting(
+    ctx: CoordinatorUpdateContext,
+) -> RestoreReconciliationDecision:
+    """Reconcile a restored awaiting-check-in state."""
+    snap = ctx.snapshot
+    now = ctx.clock()
+    if snap.tracked_event_start and snap.tracked_event_start <= now:
+        if not ctx.monitoring_enabled:
+            return _restore_awaiting_past_start(ctx, now)
+        return _decision(
+            DecisionEffect("cancel_timer"),
+            DecisionEffect("set_transition_target", value=None),
+            write=True,
+            reason="awaiting_monitoring_on_past_start",
+        )
+    if snap.tracked_event_start is not None:
+        return _decision(
+            DecisionEffect("cancel_timer"),
+            DecisionEffect(
+                "schedule_auto_checkin", target_time=snap.tracked_event_start
+            ),
+            write=True,
+            reason="reschedule_auto_checkin",
+        )
+    return _decision(
+        DecisionEffect("cancel_timer"),
+        DecisionEffect("set_transition_target", value=None),
+        write=True,
+        reason="awaiting_missing_start",
+    )
+
+
+def _restore_awaiting_past_start(
+    ctx: CoordinatorUpdateContext, now
+) -> RestoreReconciliationDecision:
+    """Build silent check-in effects for a past awaiting start."""
+    snap = ctx.snapshot
+    effects = [DecisionEffect("silent_checked_in", source="automatic")]
+    log = LogIntent(
+        "debug",
+        "Stale restore: awaiting_checkin but start passed, transitioning to checked_in (silent)",
+    )
+    if snap.tracked_event_end is not None and snap.tracked_event_end <= now:
+        effects.append(
+            DecisionEffect(
+                "silent_checked_out",
+                source="automatic",
+                linger_baseline=snap.tracked_event_end,
+            )
+        )
+        effects.append(DecisionEffect("compute_linger"))
+    elif snap.tracked_event_end is not None:
+        effects.append(
+            DecisionEffect("schedule_auto_checkout", end_time=snap.tracked_event_end)
+        )
+    return _decision(
+        DecisionEffect("cancel_timer"),
+        DecisionEffect("set_transition_target", value=None),
+        *effects,
+        write=True,
+        reason="awaiting_past_start",
+        logs=(log,),
+    )
+
+
+def decide_restore_checked_out(
+    ctx: CoordinatorUpdateContext,
+) -> RestoreReconciliationDecision:
+    """Reconcile a restored checked-out state."""
+    event = get_relevant_event(ctx.events, ctx.clock())
+    snap = ctx.snapshot
+    if (
+        event is not None
+        and event_key(event.summary, event.start) != snap.checked_out_event_key
+    ):
+        log = LogIntent(
+            "debug",
+            "Stale restore: checked_out but new event available, transitioning to awaiting_checkin",
+        )
+        return _decision(
+            DecisionEffect("transition_awaiting", event=event),
+            reason="new_event_handoff",
+            logs=(log,),
+        )
+    if _checked_out_linger_expired(ctx):
+        log = LogIntent(
+            "debug",
+            "Stale restore: checked_out and linger expired, transitioning to no_reservation",
+        )
+        return _decision(
+            DecisionEffect("transition_no_reservation"),
+            reason="expired_linger",
+            logs=(log,),
+        )
+    return _decision(
+        DecisionEffect("compute_linger"), write=True, reason="recompute_linger"
+    )
+
+
+def _checked_out_linger_expired(ctx: CoordinatorUpdateContext) -> bool:
+    """Return whether restored checked-out linger has expired."""
+    snap = ctx.snapshot
+    now = ctx.clock()
+    if snap.transition_target_time is not None and snap.transition_target_time <= now:
+        return True
+    if snap.checkout_time is None:
+        return False
+    return snap.checkout_time + timedelta(hours=ctx.cleaning_window_hours) <= now
+
+
+def decide_restore_no_reservation(
+    ctx: CoordinatorUpdateContext,
+) -> RestoreReconciliationDecision:
+    """Reconcile a restored no-reservation state."""
+    snap = ctx.snapshot
+    if (
+        snap.next_event_start_day is not None
+        and snap.next_event_start_day > ctx.clock()
+    ):
+        log = LogIntent(
+            "debug",
+            "Restored FR-006c follow-up timer at %s for %s",
+            (snap.next_event_start_day.isoformat(), ctx.coordinator_name),
+        )
+        return _decision(
+            DecisionEffect("cancel_timer"),
+            DecisionEffect(
+                "schedule_no_reservation_to_awaiting",
+                target_time=snap.next_event_start_day,
+            ),
+            write=True,
+            reason="followup_timer",
+            logs=(log,),
+        )
+    if snap.next_event_start_day is not None:
+        return _decision(
+            DecisionEffect("set_next_event_start_day", value=None),
+            DecisionEffect("set_transition_target", value=None),
+            write=True,
+            reason="stale_followup_clear",
+        )
+    return _decision(write=True, reason="no_reservation")
+
+
+def decide_restore_unknown(
+    ctx: CoordinatorUpdateContext,
+) -> RestoreReconciliationDecision:
+    """Reconcile an unknown restored state."""
+    log = LogIntent(
+        "warning",
+        "Unknown restored state '%s', resetting to no_reservation",
+        (ctx.snapshot.state,),
+    )
+    return _decision(
+        DecisionEffect("transition_no_reservation"),
+        reason="unknown_state",
+        logs=(log,),
+    )

--- a/custom_components/rental_control/sensors/checkin/runtime.py
+++ b/custom_components/rental_control/sensors/checkin/runtime.py
@@ -1,0 +1,352 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Entity-owned runtime helpers for the check-in sensor shell."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from importlib import import_module
+import logging
+from typing import Any
+
+from homeassistant.components.datetime import DOMAIN as DATETIME
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.util import dt as dt_util
+
+from ...const import CHECKIN_STATE_AWAITING
+from ...const import CHECKIN_STATE_CHECKED_IN
+from ...const import CHECKIN_STATE_CHECKED_OUT
+from ...const import CHECKIN_STATE_NO_RESERVATION
+from ...const import EARLY_CHECKOUT_EXPIRY_SWITCH
+from ...const import EVENT_RENTAL_CONTROL_CHECKIN
+from ...const import EVENT_RENTAL_CONTROL_CHECKOUT
+from ...util import add_call
+from ...util import check_gather_results
+from ...util import compute_early_expiry_time
+from ...util import get_entry_data
+
+_LOGGER = logging.getLogger("custom_components.rental_control.sensors.checkinsensor")
+
+
+async def async_checkout(entity: Any, force: bool = False) -> None:
+    """Handle manual checkout service call."""
+    _validate_checkout_allowed(entity, force)
+    now = dt_util.now()
+    end = entity._tracked_event_end
+    await _maybe_shorten_lock_expiry(entity, now)
+    baseline = min(now, end) if end else now
+    entity._transition_to_checked_out(source="manual", linger_baseline=baseline)
+
+
+def _validate_checkout_allowed(entity: Any, force: bool) -> None:
+    """Validate manual checkout guards."""
+    if entity._state != CHECKIN_STATE_CHECKED_IN:
+        raise ServiceValidationError(
+            f"Checkout is only available when the guest is checked in "
+            f"(current state: {entity._state})"
+        )
+    end = entity._tracked_event_end
+    if (entity._tracked_event_start is None or end is None) and not force:
+        raise ServiceValidationError("Checkout requires known reservation boundaries")
+    if entity._tracked_event_start is None or end is None:
+        _LOGGER.warning(
+            "Force checkout: reservation boundaries unknown for %s, proceeding anyway",
+            entity.coordinator.name,
+        )
+        return
+    _validate_checkout_day(entity, end, force)
+
+
+def _validate_checkout_day(entity: Any, end: datetime, force: bool) -> None:
+    """Validate checkout date guard."""
+    local_now = dt_util.as_local(dt_util.now())
+    local_end = dt_util.as_local(end)
+    if local_now.date() >= local_end.date():
+        return
+    if not force:
+        raise ServiceValidationError(
+            "Checkout is only available on the last day of the reservation "
+            f"or later (current: {local_now.date().isoformat()}, "
+            f"checkout day: {local_end.date().isoformat()})"
+        )
+    _LOGGER.warning(
+        "Force checkout: overriding last-day guard for %s (current: %s, checkout day: %s)",
+        entity.coordinator.name,
+        local_now.date().isoformat(),
+        local_end.date().isoformat(),
+    )
+
+
+async def _maybe_shorten_lock_expiry(entity: Any, now: datetime) -> None:
+    """Shorten lock code expiry when early checkout expiry is enabled."""
+    entry_data = get_entry_data(entity._hass, entity._config_entry.entry_id)
+    switch = entry_data.get(EARLY_CHECKOUT_EXPIRY_SWITCH) if entry_data else None
+    if switch is None or not switch.is_on or entity._tracked_event_end is None:
+        return
+    new_end = compute_early_expiry_time(now, entity._tracked_event_end)
+    if new_end >= entity._tracked_event_end:
+        return
+    _LOGGER.info(
+        "Early checkout expiry: shortening end time from %s to %s for %s",
+        entity._tracked_event_end,
+        new_end,
+        entity._tracked_event_summary,
+    )
+    entity._tracked_event_end = new_end
+    await async_update_lock_code_expiry(entity, new_end)
+
+
+async def async_set_state(entity: Any, state: str) -> None:
+    """Force-set the sensor to an arbitrary valid state."""
+    valid = entity._attr_options
+    if valid is None or state not in valid:
+        raise ServiceValidationError(
+            f"Invalid state '{state}'. Valid states: {', '.join(valid or [])}"
+        )
+    _LOGGER.warning(
+        "DEBUG override: forcing %s from '%s' to '%s'",
+        entity.entity_id,
+        entity._state,
+        state,
+    )
+    entity._state = state
+    entity._tracked_event_summary = entity._tracked_event_start = (
+        entity._tracked_event_end
+    ) = None
+    entity._tracked_event_slot_name = entity._checkin_source = (
+        entity._checkout_source
+    ) = None
+    entity._checkout_time = entity._transition_target_time = (
+        entity._checked_out_event_key
+    ) = None
+    entity._next_event_start_day = entity._checkin_lock_name = None
+    entity._linger_followon_key = entity._linger_baseline = None
+    entity._event_missing_warned = False
+    entity._cancel_timer()
+    entity.async_write_ha_state()
+
+
+def handle_keymaster_unlock(
+    entity: Any, code_slot_num: int, lock_name: str = ""
+) -> None:
+    """Handle a keymaster unlock event."""
+    if _ignore_keymaster_unlock(entity, code_slot_num):
+        return
+    if entity._state == CHECKIN_STATE_CHECKED_IN:
+        _ignore_checked_in_unlock(entity, code_slot_num)
+        return
+    if entity._state != CHECKIN_STATE_AWAITING:
+        _LOGGER.debug(
+            "Ignoring keymaster unlock: sensor state is %s, not awaiting_checkin",
+            entity._state,
+        )
+        return
+    if _unlock_slot_mismatch(entity, code_slot_num):
+        return
+    _LOGGER.info(
+        "Keymaster unlock detected for slot %d (lock=%s), transitioning to checked_in for %s",
+        code_slot_num,
+        lock_name or entity.coordinator.lockname,
+        entity._tracked_event_summary,
+    )
+    entity._transition_to_checked_in(source="keymaster", lock_name=lock_name)
+
+
+def _ignore_keymaster_unlock(entity: Any, code_slot_num: int) -> bool:
+    """Return true when an unlock event is out of scope."""
+    if code_slot_num == 0:
+        _LOGGER.debug("Ignoring keymaster unlock: code_slot_num == 0 (manual/RF)")
+        return True
+    start_slot = entity.coordinator.start_slot
+    if start_slot <= code_slot_num < start_slot + entity.coordinator.max_events:
+        return False
+    _LOGGER.debug(
+        "Ignoring keymaster unlock: code_slot_num %d outside managed range [%d, %d)",
+        code_slot_num,
+        start_slot,
+        start_slot + entity.coordinator.max_events,
+    )
+    return True
+
+
+def _ignore_checked_in_unlock(entity: Any, code_slot_num: int) -> None:
+    """Preserve checked-in unlock ignore behavior."""
+    tracked_slot = 0
+    if entity._tracked_event_slot_name and entity.coordinator.event_overrides:
+        tracked_slot = entity.coordinator.event_overrides.get_slot_key_by_name(
+            entity._tracked_event_slot_name
+        )
+    if tracked_slot != code_slot_num:
+        _LOGGER.debug(
+            "Ignoring keymaster unlock: code_slot_num %d does not match tracked event slot %d",
+            code_slot_num,
+            tracked_slot,
+        )
+
+
+def _unlock_slot_mismatch(entity: Any, code_slot_num: int) -> bool:
+    """Return true when override slot name does not match tracked guest."""
+    overrides = entity.coordinator.event_overrides
+    if not overrides or not overrides.ready:
+        return False
+    incoming_slot_name = overrides.get_slot_name(code_slot_num)
+    if not incoming_slot_name or not entity._tracked_event_slot_name:
+        return False
+    if incoming_slot_name == entity._tracked_event_slot_name:
+        return False
+    _LOGGER.debug(
+        "Ignoring keymaster unlock: slot %d belongs to '%s' but tracked event is for '%s'",
+        code_slot_num,
+        incoming_slot_name,
+        entity._tracked_event_slot_name,
+    )
+    return True
+
+
+async def async_update_lock_code_expiry(entity: Any, new_end: datetime) -> None:
+    """Update keymaster lock code expiry after early checkout."""
+    if (
+        entity._tracked_event_slot_name is None
+        or not entity.coordinator.event_overrides
+    ):
+        return
+    slot = entity.coordinator.event_overrides.get_slot_key_by_name(
+        entity._tracked_event_slot_name
+    )
+    lockname = entity.coordinator.lockname
+    if not slot or not lockname:
+        return
+    module = import_module("custom_components.rental_control.sensors.checkinsensor")
+    caller = getattr(module, "add_call", add_call)
+    coro = caller(
+        entity._hass,
+        [],
+        DATETIME,
+        "set_value",
+        f"datetime.{lockname}_code_slot_{slot}_date_range_end",
+        {"datetime": new_end.isoformat()},
+    )
+    results = await asyncio.gather(*coro, return_exceptions=True)
+    check_gather_results(results, "Early checkout lock code expiry update", _LOGGER)
+
+
+def transition_to_no_reservation(entity: Any) -> None:
+    """Transition to no_reservation state and clear tracked data."""
+    _LOGGER.debug("Transitioning to no_reservation")
+    entity._state = CHECKIN_STATE_NO_RESERVATION
+    entity._tracked_event_summary = entity._tracked_event_start = None
+    entity._tracked_event_end = entity._tracked_event_slot_name = None
+    entity._checkin_source = entity._checkout_source = entity._checkout_time = None
+    entity._transition_target_time = entity._checked_out_event_key = None
+    entity._checkin_lock_name = entity._linger_followon_key = None
+    entity._linger_baseline = None
+    entity._event_missing_warned = False
+    entity._cancel_timer()
+    entity.async_write_ha_state()
+
+
+def apply_silent_checked_in(entity: Any, source: str) -> None:
+    """Apply a restore-silent checked-in transition."""
+    entity._state = CHECKIN_STATE_CHECKED_IN
+    entity._checkin_source = source
+    entity._cancel_timer()
+    entity._transition_target_time = None
+
+
+def apply_silent_checked_out(
+    entity: Any, source: str, checkout_time: datetime | None
+) -> None:
+    """Apply a restore-silent checked-out transition."""
+    entity._state = CHECKIN_STATE_CHECKED_OUT
+    entity._checkout_source = source
+    entity._checkout_time = checkout_time or dt_util.now()
+    if entity._tracked_event_summary and entity._tracked_event_start:
+        entity._checked_out_event_key = entity._event_key(
+            entity._tracked_event_summary, entity._tracked_event_start
+        )
+
+
+def transition_to_awaiting(entity: Any, event: Any) -> None:
+    """Transition to awaiting_checkin state."""
+    _LOGGER.debug("Transitioning to awaiting_checkin for event: %s", event.summary)
+    entity._state = CHECKIN_STATE_AWAITING
+    entity._tracked_event_summary = event.summary
+    entity._tracked_event_start = event.start
+    entity._tracked_event_end = event.end
+    entity._tracked_event_slot_name = entity._extract_slot_name(event)
+    entity._checkin_source = entity._checkout_source = entity._checkout_time = None
+    entity._next_event_start_day = entity._checkin_lock_name = None
+    entity._linger_followon_key = entity._linger_baseline = None
+    entity._event_missing_warned = False
+    entity._schedule_auto_checkin(event.start)
+    if event.start <= dt_util.now() and not entity._is_keymaster_monitoring_enabled():
+        entity._transition_to_checked_in(source="automatic")
+        return
+    entity.async_write_ha_state()
+
+
+def checkin_payload(entity: Any, source: str) -> dict[str, Any]:
+    """Return a check-in or checkout event payload."""
+    return {
+        "entity_id": entity.entity_id,
+        "summary": entity._tracked_event_summary or "",
+        "start": entity._tracked_event_start.isoformat()
+        if entity._tracked_event_start
+        else "",
+        "end": entity._tracked_event_end.isoformat()
+        if entity._tracked_event_end
+        else "",
+        "guest_name": entity._tracked_event_slot_name or "",
+        "source": source,
+    }
+
+
+def transition_to_checked_in(entity: Any, source: str, lock_name: str = "") -> None:
+    """Transition to checked_in state and fire the check-in event."""
+    _LOGGER.debug(
+        "Transitioning to checked_in (source=%s, lock=%s) for event: %s",
+        source,
+        lock_name or "(none)",
+        entity._tracked_event_summary,
+    )
+    entity._state = CHECKIN_STATE_CHECKED_IN
+    entity._checkin_source = source
+    entity._checkin_lock_name = lock_name or None
+    entity._transition_target_time = None
+    entity._event_missing_warned = False
+    payload = checkin_payload(entity, source)
+    if lock_name:
+        payload["lock_name"] = lock_name
+    entity._hass.bus.async_fire(EVENT_RENTAL_CONTROL_CHECKIN, payload)
+    entity._cancel_timer()
+    if entity._tracked_event_end is not None:
+        entity._schedule_auto_checkout(entity._tracked_event_end)
+    entity.async_write_ha_state()
+
+
+def transition_to_checked_out(
+    entity: Any, source: str, linger_baseline: datetime | None = None
+) -> None:
+    """Transition to checked_out state."""
+    _LOGGER.debug(
+        "Transitioning to checked_out (source=%s) for event: %s",
+        source,
+        entity._tracked_event_summary,
+    )
+    entity._state = CHECKIN_STATE_CHECKED_OUT
+    entity._checkout_source = source
+    entity._checkout_time = dt_util.now()
+    entity._event_missing_warned = False
+    if entity._tracked_event_summary and entity._tracked_event_start:
+        entity._checked_out_event_key = entity._event_key(
+            entity._tracked_event_summary, entity._tracked_event_start
+        )
+    entity._hass.bus.async_fire(
+        EVENT_RENTAL_CONTROL_CHECKOUT, checkin_payload(entity, source)
+    )
+    entity._cancel_timer()
+    entity._linger_baseline = linger_baseline or entity._checkout_time
+    entity._compute_linger_timing(entity._linger_baseline)
+    entity.async_write_ha_state()

--- a/custom_components/rental_control/sensors/checkin/timer_runtime.py
+++ b/custom_components/rental_control/sensors/checkin/timer_runtime.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Timer runtime helpers for the check-in sensor shell."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+import logging
+from typing import Any
+
+from homeassistant.util import dt as dt_util
+
+from ...const import CHECKIN_STATE_AWAITING
+from ...const import CHECKIN_STATE_CHECKED_IN
+from ...const import CHECKIN_STATE_CHECKED_OUT
+from ...const import CHECKIN_STATE_NO_RESERVATION
+
+_LOGGER = logging.getLogger("custom_components.rental_control.sensors.checkinsensor")
+
+
+def compute_linger_timing(entity: Any, baseline: datetime | None = None) -> None:
+    """Compute and schedule post-checkout linger timing."""
+    checkout_time = (
+        baseline or entity._linger_baseline or entity._checkout_time or dt_util.now()
+    )
+    next_event = entity._find_followon_event(checkout_time)
+    if next_event is None:
+        target = checkout_time + timedelta(hours=entity._get_cleaning_window())
+        entity._schedule_linger_to_no_reservation(target, None)
+        _LOGGER.debug(
+            "FR-006b: No follow-on, transition to no_reservation at %s",
+            target.isoformat(),
+        )
+        return
+    entity._linger_followon_key = entity._event_key(
+        next_event.summary, next_event.start
+    )
+    if (
+        dt_util.as_local(next_event.start).date()
+        == dt_util.as_local(checkout_time).date()
+    ):
+        target = checkout_time + ((next_event.start - checkout_time) / 2)
+        entity._next_event_start_day = None
+        entity._schedule_linger_to_awaiting(target)
+        _LOGGER.debug(
+            "FR-006a: Same-day turnover, transition to awaiting at %s",
+            target.isoformat(),
+        )
+        return
+    midnight = dt_util.start_of_local_day(checkout_time + timedelta(days=1))
+    entity._next_event_start_day = dt_util.start_of_local_day(next_event.start)
+    entity._schedule_linger_to_no_reservation(midnight, entity._next_event_start_day)
+    _LOGGER.debug(
+        "FR-006c: Different-day follow-on, transition to no_reservation "
+        "at %s, follow-up awaiting at %s",
+        midnight.isoformat(),
+        entity._next_event_start_day.isoformat(),
+    )
+
+
+def auto_checkin_callback(entity: Any, _now: datetime) -> None:
+    """Run the automatic check-in callback."""
+    _LOGGER.debug("Auto check-in timer fired for %s", entity.coordinator.name)
+    entity._timer_manager.clear_callback_handle()
+    if entity._state != CHECKIN_STATE_AWAITING:
+        return
+    if entity._is_keymaster_monitoring_enabled():
+        _LOGGER.debug(
+            "Keymaster monitoring is on; staying in awaiting_checkin "
+            "until door code is used for %s",
+            entity.coordinator.name,
+        )
+        entity._transition_target_time = None
+        entity.async_write_ha_state()
+        return
+    entity._transition_to_checked_in(source="automatic")
+
+
+def auto_checkout_callback(entity: Any, _now: datetime) -> None:
+    """Run the automatic checkout callback."""
+    _LOGGER.debug("Auto check-out timer fired for %s", entity.coordinator.name)
+    entity._timer_manager.clear_callback_handle()
+    if entity._state == CHECKIN_STATE_CHECKED_IN:
+        entity._transition_to_checked_out(source="automatic")
+
+
+def linger_to_awaiting_callback(entity: Any, _now: datetime) -> None:
+    """Run the same-day linger callback."""
+    _LOGGER.debug("Linger-to-awaiting timer fired for %s", entity.coordinator.name)
+    entity._timer_manager.clear_callback_handle()
+    if entity._state != CHECKIN_STATE_CHECKED_OUT:
+        return
+    event = entity._find_followon_event(
+        entity._linger_baseline or entity._checkout_time or _now
+    )
+    if event is not None:
+        entity._transition_to_awaiting(event)
+    else:
+        entity._transition_to_no_reservation()
+
+
+def linger_to_no_reservation_callback(entity: Any, _now: datetime) -> None:
+    """Run the linger expiry callback."""
+    _LOGGER.debug(
+        "Linger-to-no-reservation timer fired for %s", entity.coordinator.name
+    )
+    entity._timer_manager.clear_callback_handle()
+    if entity._state != CHECKIN_STATE_CHECKED_OUT:
+        return
+    followon_start_day = entity._next_event_start_day
+    entity._transition_to_no_reservation()
+    if followon_start_day is None:
+        return
+    if followon_start_day > _now:
+        entity._schedule_no_reservation_to_awaiting(followon_start_day)
+        _LOGGER.debug(
+            "FR-006c: Scheduled follow-up awaiting transition at %s for %s",
+            followon_start_day.isoformat(),
+            entity.coordinator.name,
+        )
+        entity.async_write_ha_state()
+    else:
+        _LOGGER.debug(
+            "FR-006c: Follow-on start day %s already passed, relying on coordinator update",
+            followon_start_day.isoformat(),
+        )
+
+
+def no_reservation_to_awaiting_callback(entity: Any, _now: datetime) -> None:
+    """Run the FR-006c follow-up awaiting callback."""
+    _LOGGER.debug(
+        "FR-006c no-reservation-to-awaiting timer fired for %s", entity.coordinator.name
+    )
+    entity._timer_manager.clear_callback_handle()
+    entity._next_event_start_day = None
+    entity._transition_target_time = None
+    if entity._state != CHECKIN_STATE_NO_RESERVATION:
+        return
+    event = entity._get_relevant_event()
+    if event is not None:
+        entity._transition_to_awaiting(event)
+    else:
+        _LOGGER.debug(
+            "FR-006c: No event found in coordinator data at follow-up time, "
+            "staying in no_reservation"
+        )
+
+
+def schedule_auto_checkin(entity: Any, start_time: datetime) -> None:
+    """Schedule automatic check-in for a start time."""
+    entity._cancel_timer()
+    if start_time > dt_util.now():
+        entity._transition_target_time = start_time
+        entity._timer_manager.schedule(
+            "auto_checkin", entity._async_auto_checkin_callback, start_time
+        )
+    else:
+        entity._transition_target_time = None
+
+
+def schedule_auto_checkout(entity: Any, end_time: datetime) -> None:
+    """Schedule automatic checkout at the given end time."""
+    if end_time > dt_util.now():
+        entity._transition_target_time = end_time
+        entity._timer_manager.schedule(
+            "auto_checkout", entity._async_auto_checkout_callback, end_time
+        )
+    else:
+        entity._transition_target_time = None
+        entity._transition_to_checked_out(source="automatic", linger_baseline=end_time)
+
+
+def schedule_linger_to_awaiting(entity: Any, target: datetime) -> None:
+    """Schedule same-day linger transition."""
+    entity._transition_target_time = target
+    entity._timer_manager.schedule(
+        "linger_to_awaiting", entity._async_linger_to_awaiting_callback, target
+    )
+
+
+def schedule_linger_to_no_reservation(
+    entity: Any, target: datetime, followup: datetime | None
+) -> None:
+    """Schedule linger expiry transition."""
+    entity._transition_target_time = target
+    if followup is None:
+        entity._next_event_start_day = None
+        entity._linger_followon_key = None
+    entity._timer_manager.schedule(
+        "linger_to_no_reservation",
+        entity._async_linger_to_no_reservation_callback,
+        target,
+        followup,
+    )
+
+
+def schedule_no_reservation_to_awaiting(entity: Any, target: datetime) -> None:
+    """Schedule FR-006c follow-up awaiting transition."""
+    entity._transition_target_time = target
+    entity._next_event_start_day = target
+    entity._timer_manager.schedule(
+        "no_reservation_to_awaiting",
+        entity._async_no_reservation_to_awaiting_callback,
+        target,
+    )

--- a/custom_components/rental_control/sensors/checkin/timers.py
+++ b/custom_components/rental_control/sensors/checkin/timers.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Timer manager preserving check-in sensor single-handle semantics."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+
+from homeassistant.core import CALLBACK_TYPE
+from homeassistant.core import HomeAssistant
+
+from .models import ScheduledTransition
+from .models import TimerPurpose
+
+
+class CheckinTimerManager:
+    """Manage one active check-in scheduled transition handle."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        tracker: Callable[
+            [HomeAssistant, Callable[[datetime], None], datetime], CALLBACK_TYPE
+        ],
+    ) -> None:
+        """Initialize the timer manager."""
+        self._hass = hass
+        self._tracker = tracker
+        self.scheduled: ScheduledTransition | None = None
+
+    @property
+    def handle(self) -> CALLBACK_TYPE | None:
+        """Return the active unsubscribe handle."""
+        return self.scheduled.cancel_handle if self.scheduled else None
+
+    @handle.setter
+    def handle(self, value: CALLBACK_TYPE | None) -> None:
+        """Set the active unsubscribe handle for compatibility."""
+        if value is None:
+            self.scheduled = None
+        else:
+            self.scheduled = ScheduledTransition(
+                "auto_checkin", datetime.min, None, value
+            )
+
+    def cancel(self) -> None:
+        """Cancel any active timer exactly once."""
+        if self.scheduled and self.scheduled.cancel_handle is not None:
+            self.scheduled.cancel_handle()
+        self.scheduled = None
+
+    def clear_callback_handle(self) -> None:
+        """Clear the active handle at callback entry."""
+        self.scheduled = None
+
+    def schedule(
+        self,
+        purpose: TimerPurpose,
+        callback: Callable[[datetime], None],
+        target_time: datetime,
+        followon_start_day: datetime | None = None,
+    ) -> None:
+        """Cancel the old handle and schedule a new absolute-time callback."""
+        self.cancel()
+        handle = self._tracker(self._hass, callback, target_time)
+        self.scheduled = ScheduledTransition(
+            purpose=purpose,
+            target_time=target_time,
+            followon_start_day=followon_start_day,
+            cancel_handle=handle,
+        )

--- a/custom_components/rental_control/sensors/checkin/transition_decisions.py
+++ b/custom_components/rental_control/sensors/checkin/transition_decisions.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure coordinator-update decisions for the check-in sensor."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from ...const import CHECKIN_STATE_AWAITING
+from ...const import CHECKIN_STATE_CHECKED_IN
+from ...const import CHECKIN_STATE_CHECKED_OUT
+from ...const import CHECKIN_STATE_NO_RESERVATION
+from .event_selection import event_key
+from .event_selection import find_followon_event
+from .event_selection import find_tracked_event
+from .event_selection import get_relevant_event
+from .models import CoordinatorUpdateContext
+from .models import DecisionEffect
+from .models import LogIntent
+from .models import TransitionDecision
+
+_SELF_HEAL_FUTURE_THRESHOLD = timedelta(hours=24)
+
+
+def _decision(
+    *effects: DecisionEffect,
+    write: bool = False,
+    logs: tuple[LogIntent, ...] = (),
+) -> TransitionDecision:
+    """Build a transition decision."""
+    return TransitionDecision(effects=effects, write_state=write, log_records=logs)
+
+
+def decide_coordinator_update(ctx: CoordinatorUpdateContext) -> TransitionDecision:
+    """Choose effects for one coordinator update."""
+    if not ctx.last_update_success:
+        return _decision(write=True)
+    state = ctx.snapshot.state
+    if state == CHECKIN_STATE_NO_RESERVATION:
+        return decide_no_reservation_update(ctx)
+    if state == CHECKIN_STATE_AWAITING:
+        return decide_awaiting_update(ctx)
+    if state == CHECKIN_STATE_CHECKED_IN:
+        return decide_checked_in_update(ctx)
+    if state == CHECKIN_STATE_CHECKED_OUT:
+        return decide_checked_out_update(ctx)
+    return _decision(write=True)
+
+
+def decide_no_reservation_update(ctx: CoordinatorUpdateContext) -> TransitionDecision:
+    """Decide updates while no reservation is tracked."""
+    event = get_relevant_event(ctx.events, ctx.clock())
+    if event is None:
+        return _decision(write=True)
+    return _decision(DecisionEffect("transition_awaiting", event=event))
+
+
+def decide_awaiting_update(ctx: CoordinatorUpdateContext) -> TransitionDecision:
+    """Decide updates while awaiting check-in."""
+    snap = ctx.snapshot
+    tracked = find_tracked_event(
+        ctx.events, snap.tracked_event_summary, snap.tracked_event_start
+    )
+    if tracked is None:
+        event = get_relevant_event(ctx.events, ctx.clock())
+        if event is not None:
+            return _decision(DecisionEffect("transition_awaiting", event=event))
+        return _decision(DecisionEffect("transition_no_reservation"))
+    replacement = _awaiting_replacement(ctx)
+    if replacement is not None:
+        return replacement
+    effects = [DecisionEffect("update_tracked_event", event=tracked)]
+    if snap.tracked_event_start is not None and snap.tracked_event_start <= ctx.clock():
+        if not ctx.monitoring_enabled:
+            effects.append(DecisionEffect("transition_checked_in", source="automatic"))
+            return _decision(*effects)
+    return _decision(*effects, write=True)
+
+
+def _awaiting_replacement(ctx: CoordinatorUpdateContext) -> TransitionDecision | None:
+    """Return replacement decision for a more relevant awaiting event."""
+    snap = ctx.snapshot
+    relevant = get_relevant_event(ctx.events, ctx.clock())
+    if relevant is None or snap.tracked_event_start is None:
+        return None
+    if snap.tracked_event_summary is None:
+        return None
+    relevant_key = event_key(relevant.summary, relevant.start)
+    tracked_key = event_key(snap.tracked_event_summary, snap.tracked_event_start)
+    if relevant_key == tracked_key or relevant_key == snap.checked_out_event_key:
+        return None
+    if relevant.start >= snap.tracked_event_start:
+        return None
+    log = LogIntent(
+        "debug",
+        "More relevant event found (%s starting %s) while awaiting %s "
+        "starting %s; switching tracked event",
+        (
+            relevant.summary,
+            relevant.start,
+            snap.tracked_event_summary,
+            snap.tracked_event_start,
+        ),
+    )
+    return _decision(DecisionEffect("transition_awaiting", event=relevant), logs=(log,))
+
+
+def decide_checked_in_update(ctx: CoordinatorUpdateContext) -> TransitionDecision:
+    """Decide updates while checked in."""
+    snap = ctx.snapshot
+    tracked = find_tracked_event(
+        ctx.events, snap.tracked_event_summary, snap.tracked_event_start
+    )
+    if tracked is None:
+        return _decide_checked_in_missing(ctx)
+    now = ctx.clock()
+    if tracked.start > now + _SELF_HEAL_FUTURE_THRESHOLD:
+        return _decide_checked_in_far_future(ctx, tracked, now)
+    if tracked.end <= now:
+        log = LogIntent(
+            "debug",
+            "Event end time %s has passed, forcing automatic checkout for %s",
+            (tracked.end, ctx.coordinator_name),
+        )
+        return _decision(
+            DecisionEffect("update_tracked_event", event=tracked),
+            DecisionEffect("cancel_timer"),
+            DecisionEffect(
+                "transition_checked_out",
+                source="automatic",
+                linger_baseline=tracked.end,
+            ),
+            logs=(log,),
+        )
+    if tracked.end != snap.tracked_event_end:
+        log = LogIntent(
+            "debug",
+            "Event end time changed from %s to %s, rescheduling auto check-out",
+            (snap.tracked_event_end, tracked.end),
+        )
+        return _decision(
+            DecisionEffect("set_event_missing", value=False),
+            DecisionEffect("update_tracked_event", event=tracked),
+            DecisionEffect("cancel_timer"),
+            DecisionEffect("schedule_auto_checkout", end_time=tracked.end),
+            write=True,
+            logs=(log,),
+        )
+    return _decision(
+        DecisionEffect("set_event_missing", value=False),
+        DecisionEffect("update_slot_name", event=tracked),
+        write=True,
+    )
+
+
+def _decide_checked_in_far_future(
+    ctx: CoordinatorUpdateContext, tracked, now
+) -> TransitionDecision:
+    """Build self-healing checkout decision for far-future tracked event."""
+    effects = [
+        DecisionEffect(
+            "transition_checked_out", source="automatic", linger_baseline=now
+        )
+    ]
+    log = LogIntent(
+        "warning",
+        "Self-healing: sensor is checked_in but tracked event '%s' starts "
+        "at %s which is more than 24h in the future; forcing checkout for %s",
+        (tracked.summary, tracked.start, ctx.coordinator_name),
+    )
+    event = get_relevant_event(ctx.events, now)
+    if event is not None and event_key(event.summary, event.start) != event_key(
+        tracked.summary, tracked.start
+    ):
+        effects.append(DecisionEffect("transition_awaiting", event=event))
+    return _decision(*effects, logs=(log,))
+
+
+def _decide_checked_in_missing(ctx: CoordinatorUpdateContext) -> TransitionDecision:
+    """Decide checked-in behavior when tracked event is missing."""
+    snap = ctx.snapshot
+    if snap.tracked_event_end is not None and snap.tracked_event_end <= ctx.clock():
+        log = LogIntent(
+            "warning",
+            "Tracked event not found in coordinator data while checked_in for %s "
+            "and stored end time %s has passed; forcing checkout",
+            (ctx.coordinator_name, snap.tracked_event_end),
+        )
+        return _decision(
+            DecisionEffect("cancel_timer"),
+            DecisionEffect(
+                "transition_checked_out",
+                source="automatic",
+                linger_baseline=snap.tracked_event_end,
+            ),
+            logs=(log,),
+        )
+    if snap.tracked_event_end is None and snap.tracked_event_start is None:
+        if snap.tracked_event_summary is None:
+            log = LogIntent(
+                "warning",
+                "All tracking data lost while checked_in for %s; resetting to no_reservation",
+                (ctx.coordinator_name,),
+            )
+            return _decision(
+                DecisionEffect("cancel_timer"),
+                DecisionEffect("transition_no_reservation"),
+                logs=(log,),
+            )
+    return _missing_preserve_decision(ctx)
+
+
+def _missing_preserve_decision(ctx: CoordinatorUpdateContext) -> TransitionDecision:
+    """Return warning/debug decision for transient missing event."""
+    if not ctx.snapshot.event_missing_warned:
+        log = LogIntent(
+            "warning",
+            "Tracked event not found in coordinator data while checked_in for %s; preserving state",
+            (ctx.coordinator_name,),
+        )
+        return _decision(
+            DecisionEffect("set_event_missing", value=True), write=True, logs=(log,)
+        )
+    log = LogIntent(
+        "debug",
+        "Tracked event still missing for %s; preserving checked_in state",
+        (ctx.coordinator_name,),
+    )
+    return _decision(write=True, logs=(log,))
+
+
+def decide_checked_out_update(ctx: CoordinatorUpdateContext) -> TransitionDecision:
+    """Decide updates while checked out."""
+    snap = ctx.snapshot
+    checkout_time = snap.linger_baseline or snap.checkout_time or ctx.clock()
+    followon = find_followon_event(
+        ctx.events, checkout_time, snap.checked_out_event_key
+    )
+    if followon is not None:
+        followon_key = event_key(followon.summary, followon.start)
+        if ctx.active_timer and snap.linger_followon_key == followon_key:
+            return _decision(write=True)
+        return _decision(
+            DecisionEffect("cancel_timer"),
+            DecisionEffect("compute_linger"),
+            write=True,
+        )
+    if snap.linger_followon_key is not None:
+        return _decision(
+            DecisionEffect("cancel_timer"),
+            DecisionEffect("set_linger_followon_key", value=None),
+            DecisionEffect("compute_linger"),
+            write=True,
+        )
+    if not ctx.active_timer:
+        return _decision(DecisionEffect("compute_linger"), write=True)
+    return _decision(write=True)

--- a/custom_components/rental_control/sensors/checkinsensor.py
+++ b/custom_components/rental_control/sensors/checkinsensor.py
@@ -1,195 +1,64 @@
 # SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Check-in/check-out tracking sensor for Rental Control.
-
-Implements a four-state state machine that tracks guest occupancy:
-``no_reservation`` → ``awaiting_checkin`` → ``checked_in`` → ``checked_out``.
-Transitions are driven by coordinator data updates and timer-scheduled
-callbacks.
-"""
+"""Check-in/check-out tracking sensor for Rental Control."""
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime
-from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING
 from typing import Any
 
 from homeassistant.components.calendar import CalendarEvent
-from homeassistant.components.datetime import DOMAIN as DATETIME
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_track_point_in_time
-from homeassistant.helpers.restore_state import ExtraStoredData
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from ..const import CHECKIN_STATE_AWAITING
-from ..const import CHECKIN_STATE_CHECKED_IN
-from ..const import CHECKIN_STATE_CHECKED_OUT
-from ..const import CHECKIN_STATE_NO_RESERVATION
-from ..const import CONF_CLEANING_WINDOW
-from ..const import CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
-from ..const import DEFAULT_CLEANING_WINDOW
-from ..const import DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS
-from ..const import EARLY_CHECKOUT_EXPIRY_SWITCH
-from ..const import EVENT_RENTAL_CONTROL_CHECKIN
-from ..const import EVENT_RENTAL_CONTROL_CHECKOUT
-from ..const import KEYMASTER_MONITORING_SWITCH
-from ..util import add_call
-from ..util import check_gather_results
-from ..util import compute_early_expiry_time
+from .. import const as rc_const
+from ..util import add_call as add_call  # re-exported for tests/runtime patching
 from ..util import gen_uuid
 from ..util import get_entry_data
-from ..util import get_slot_name
+from .checkin import runtime
+from .checkin import timer_runtime
+from .checkin.applicator import apply_restore_decision
+from .checkin.applicator import apply_transition_decision
+from .checkin.event_selection import event_key
+from .checkin.event_selection import extract_slot_name
+from .checkin.event_selection import find_followon_event
+from .checkin.event_selection import find_tracked_event
+from .checkin.event_selection import get_relevant_event
+from .checkin.models import CheckinStateSnapshot
+from .checkin.models import CoordinatorUpdateContext
+from .checkin.persistence import CheckinExtraStoredData
+from .checkin.restore_decisions import decide_restore_state
+from .checkin.timers import CheckinTimerManager
+from .checkin.transition_decisions import decide_coordinator_update
 
 if TYPE_CHECKING:
     from ..coordinator import RentalControlCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-
-_CHECKIN_STATE_ICONS: dict[str, str] = {
-    CHECKIN_STATE_AWAITING: "mdi:door-open",
-    CHECKIN_STATE_CHECKED_IN: "mdi:account-check",
-    CHECKIN_STATE_CHECKED_OUT: "mdi:airplane",
-    CHECKIN_STATE_NO_RESERVATION: "mdi:bed-empty",
+_CHECKIN_STATE_ICONS = {
+    rc_const.CHECKIN_STATE_AWAITING: "mdi:door-open",
+    rc_const.CHECKIN_STATE_CHECKED_IN: "mdi:account-check",
+    rc_const.CHECKIN_STATE_CHECKED_OUT: "mdi:airplane",
+    rc_const.CHECKIN_STATE_NO_RESERVATION: "mdi:bed-empty",
 }
-_SELF_HEAL_FUTURE_THRESHOLD = timedelta(hours=24)
-
-
-class CheckinExtraStoredData(ExtraStoredData):
-    """Extra stored data for persisting CheckinTrackingSensor state.
-
-    Serialises all sensor instance variables to a dict of JSON-safe
-    values.  Datetime fields are stored as ISO 8601 strings (or
-    ``None``).  The companion ``from_dict`` class-method rebuilds an
-    instance from the dict produced by ``as_dict``.
-    """
-
-    def __init__(
-        self,
-        state: str,
-        tracked_event_summary: str | None,
-        tracked_event_start: datetime | None,
-        tracked_event_end: datetime | None,
-        tracked_event_slot_name: str | None,
-        checkin_source: str | None,
-        checkout_source: str | None,
-        checkout_time: datetime | None,
-        transition_target_time: datetime | None,
-        checked_out_event_key: str | None,
-        next_event_start_day: datetime | None = None,
-        checkin_lock_name: str | None = None,
-    ) -> None:
-        """Initialise from typed field values."""
-        self.state = state
-        self.tracked_event_summary = tracked_event_summary
-        self.tracked_event_start = tracked_event_start
-        self.tracked_event_end = tracked_event_end
-        self.tracked_event_slot_name = tracked_event_slot_name
-        self.checkin_source = checkin_source
-        self.checkout_source = checkout_source
-        self.checkout_time = checkout_time
-        self.transition_target_time = transition_target_time
-        self.checked_out_event_key = checked_out_event_key
-        self.next_event_start_day = next_event_start_day
-        self.checkin_lock_name = checkin_lock_name
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return a JSON-serialisable dict representation."""
-        return {
-            "state": self.state,
-            "tracked_event_summary": self.tracked_event_summary,
-            "tracked_event_start": (
-                self.tracked_event_start.isoformat()
-                if self.tracked_event_start
-                else None
-            ),
-            "tracked_event_end": (
-                self.tracked_event_end.isoformat() if self.tracked_event_end else None
-            ),
-            "tracked_event_slot_name": self.tracked_event_slot_name,
-            "checkin_source": self.checkin_source,
-            "checkout_source": self.checkout_source,
-            "checkout_time": (
-                self.checkout_time.isoformat() if self.checkout_time else None
-            ),
-            "transition_target_time": (
-                self.transition_target_time.isoformat()
-                if self.transition_target_time
-                else None
-            ),
-            "checked_out_event_key": self.checked_out_event_key,
-            "next_event_start_day": (
-                self.next_event_start_day.isoformat()
-                if self.next_event_start_day
-                else None
-            ),
-            "checkin_lock_name": self.checkin_lock_name,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> CheckinExtraStoredData:
-        """Reconstruct an instance from a dict (as produced by ``as_dict``).
-
-        ISO 8601 date-time strings are parsed back to ``datetime``
-        objects; ``None`` values pass through unchanged.
-        """
-
-        def _parse_dt(value: str | None) -> datetime | None:
-            """Parse an ISO 8601 string to datetime or return None."""
-            if value is None:
-                return None
-            try:
-                result: datetime | None = dt_util.parse_datetime(value)
-            except (TypeError, ValueError):  # fmt: skip
-                _LOGGER.warning("Failed to parse stored datetime: %s", value)
-                return None
-            if result is None:
-                _LOGGER.warning("Failed to parse stored datetime: %s", value)
-            return result
-
-        return cls(
-            state=data.get("state", CHECKIN_STATE_NO_RESERVATION),
-            tracked_event_summary=data.get("tracked_event_summary"),
-            tracked_event_start=_parse_dt(data.get("tracked_event_start")),
-            tracked_event_end=_parse_dt(data.get("tracked_event_end")),
-            tracked_event_slot_name=data.get("tracked_event_slot_name"),
-            checkin_source=data.get("checkin_source"),
-            checkout_source=data.get("checkout_source"),
-            checkout_time=_parse_dt(data.get("checkout_time")),
-            transition_target_time=_parse_dt(data.get("transition_target_time")),
-            checked_out_event_key=data.get("checked_out_event_key"),
-            next_event_start_day=_parse_dt(data.get("next_event_start_day")),
-            checkin_lock_name=data.get("checkin_lock_name"),
-        )
 
 
 class CheckinTrackingSensor(
-    CoordinatorEntity["RentalControlCoordinator"],
-    SensorEntity,
-    RestoreEntity,
+    CoordinatorEntity["RentalControlCoordinator"], SensorEntity, RestoreEntity
 ):
-    """Sensor that tracks guest check-in/check-out state.
-
-    Maintains a four-state state machine driven by coordinator data
-    updates and timer-scheduled callbacks:
-
-    - ``no_reservation``: No relevant calendar event
-    - ``awaiting_checkin``: Event identified, waiting for guest arrival
-    - ``checked_in``: Guest has arrived
-    - ``checked_out``: Guest has departed, post-checkout linger active
-    """
+    """Sensor that tracks guest check-in/check-out state."""
 
     def __init__(
         self,
@@ -197,13 +66,7 @@ class CheckinTrackingSensor(
         coordinator: RentalControlCoordinator,
         config_entry: ConfigEntry,
     ) -> None:
-        """Initialize the check-in tracking sensor.
-
-        Args:
-            hass: Home Assistant instance.
-            coordinator: The rental control data coordinator.
-            config_entry: The integration config entry.
-        """
+        """Initialize the check-in tracking sensor."""
         super().__init__(coordinator)
         self._hass = hass
         self._config_entry = config_entry
@@ -211,14 +74,12 @@ class CheckinTrackingSensor(
         self._attr_translation_key = "checkin"
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = [
-            CHECKIN_STATE_NO_RESERVATION,
-            CHECKIN_STATE_AWAITING,
-            CHECKIN_STATE_CHECKED_IN,
-            CHECKIN_STATE_CHECKED_OUT,
+            rc_const.CHECKIN_STATE_NO_RESERVATION,
+            rc_const.CHECKIN_STATE_AWAITING,
+            rc_const.CHECKIN_STATE_CHECKED_IN,
+            rc_const.CHECKIN_STATE_CHECKED_OUT,
         ]
-        self._state: str = CHECKIN_STATE_NO_RESERVATION
-
-        # Tracked event fields (from data-model.md)
+        self._state = rc_const.CHECKIN_STATE_NO_RESERVATION
         self._tracked_event_summary: str | None = None
         self._tracked_event_start: datetime | None = None
         self._tracked_event_end: datetime | None = None
@@ -228,29 +89,23 @@ class CheckinTrackingSensor(
         self._checkout_time: datetime | None = None
         self._transition_target_time: datetime | None = None
         self._checked_out_event_key: str | None = None
-
-        # FR-006c: Start day of the follow-on event for midnight-to-awaiting
         self._next_event_start_day: datetime | None = None
-
-        # Spec 006: Lock that triggered check-in (child lock monitoring)
         self._checkin_lock_name: str | None = None
-
-        # Follow-on event key for linger guard (not persisted)
         self._linger_followon_key: str | None = None
-
-        # Effective baseline for follow-on event lookups (not persisted).
-        # Set by _transition_to_checked_out to preserve the correct
-        # reference point across subsequent coordinator updates.
         self._linger_baseline: datetime | None = None
-
-        # Internal timer unsubscribe handle
-        self._unsub_timer: CALLBACK_TYPE | None = None
-
-        # Guard against repeated warnings when tracked event is missing
-        self._event_missing_warned: bool = False
-
-        # Unique ID
+        self._event_missing_warned = False
+        self._timer_manager = CheckinTimerManager(hass, async_track_point_in_time)
         self._unique_id = gen_uuid(f"{self.coordinator.unique_id} checkin_tracking")
+
+    @property
+    def _unsub_timer(self) -> CALLBACK_TYPE | None:
+        """Return the compatibility timer unsubscribe handle."""
+        return self._timer_manager.handle
+
+    @_unsub_timer.setter
+    def _unsub_timer(self, value: CALLBACK_TYPE | None) -> None:
+        """Set the compatibility timer unsubscribe handle."""
+        self._timer_manager.handle = value
 
     @property
     def unique_id(self) -> str:
@@ -274,10 +129,7 @@ class CheckinTrackingSensor(
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return extra state attributes for the sensor.
-
-        Returns all tracked event attributes per data-model.md.
-        """
+        """Return extra state attributes for the sensor."""
         attrs: dict[str, Any] = {
             "checkin_state": self._state,
             "summary": self._tracked_event_summary,
@@ -291,8 +143,8 @@ class CheckinTrackingSensor(
             "lock_name": self._checkin_lock_name,
         }
         if self._config_entry.data.get(
-            CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS,
-            DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS,
+            rc_const.CONF_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS,
+            rc_const.DEFAULT_ENABLE_KEYMASTER_EVENT_DIAGNOSTICS,
         ):
             attrs["keymaster_event_diagnostics"] = list(
                 self.coordinator.keymaster_event_diagnostics
@@ -301,1248 +153,234 @@ class CheckinTrackingSensor(
 
     @property
     def extra_restore_state_data(self) -> CheckinExtraStoredData:
-        """Return entity-specific state data for RestoreEntity persistence.
-
-        Returns a ``CheckinExtraStoredData`` instance containing all
-        sensor fields that must survive an HA restart.
-        """
-        return CheckinExtraStoredData(
-            state=self._state,
-            tracked_event_summary=self._tracked_event_summary,
-            tracked_event_start=self._tracked_event_start,
-            tracked_event_end=self._tracked_event_end,
-            tracked_event_slot_name=self._tracked_event_slot_name,
-            checkin_source=self._checkin_source,
-            checkout_source=self._checkout_source,
-            checkout_time=self._checkout_time,
-            transition_target_time=self._transition_target_time,
-            checked_out_event_key=self._checked_out_event_key,
-            next_event_start_day=self._next_event_start_day,
-            checkin_lock_name=self._checkin_lock_name,
-        )
+        """Return entity-specific state data for RestoreEntity persistence."""
+        return CheckinExtraStoredData.from_snapshot(self._snapshot())
 
     @staticmethod
     def _event_key(summary: str, start: datetime) -> str:
-        """Generate a unique identity key for an event.
+        """Generate the behavior-compatible event identity key."""
+        return event_key(summary, start)
 
-        Only summary and start are used for identity. The end time is
-        deliberately excluded so that post-checkout event extensions
-        (same summary + start but later end) are detected as the SAME
-        event rather than a new one, satisfying FR-007.
+    def _snapshot(self) -> CheckinStateSnapshot:
+        """Return a typed snapshot of current state."""
+        return CheckinStateSnapshot(
+            self._state,
+            self._tracked_event_summary,
+            self._tracked_event_start,
+            self._tracked_event_end,
+            self._tracked_event_slot_name,
+            self._checkin_source,
+            self._checkout_source,
+            self._checkout_time,
+            self._transition_target_time,
+            self._checked_out_event_key,
+            self._next_event_start_day,
+            self._checkin_lock_name,
+            self._linger_followon_key,
+            self._linger_baseline,
+            self._event_missing_warned,
+        )
 
-        Args:
-            summary: The event summary text.
-            start: The event start datetime.
+    def _apply_snapshot(self, snapshot: CheckinStateSnapshot) -> None:
+        """Replace mutable fields from a snapshot."""
+        for field in snapshot.__dataclass_fields__:
+            if field == "state":
+                self._state = snapshot.state
+            else:
+                setattr(self, f"_{field}", getattr(snapshot, field))
 
-        Returns:
-            A composite identity key string.
-        """
-        return f"{summary}|{start.isoformat()}"
+    def _decision_context(self) -> CoordinatorUpdateContext:
+        """Build a pure decision context from entity state."""
+        return CoordinatorUpdateContext(
+            self._snapshot(),
+            self.coordinator.data or [],
+            dt_util.now,
+            self.coordinator.last_update_success,
+            self._is_keymaster_monitoring_enabled(),
+            self._get_cleaning_window(),
+            self.coordinator.event_prefix or "",
+            self._unsub_timer is not None,
+            self.coordinator.name,
+        )
 
     def _get_cleaning_window(self) -> float:
-        """Return the configured cleaning window in hours.
-
-        Returns:
-            The cleaning window duration from config data,
-            or the default value.
-        """
+        """Return the configured cleaning window in hours."""
         return float(
-            self._config_entry.data.get(CONF_CLEANING_WINDOW, DEFAULT_CLEANING_WINDOW)
+            self._config_entry.data.get(
+                rc_const.CONF_CLEANING_WINDOW, rc_const.DEFAULT_CLEANING_WINDOW
+            )
         )
 
     def _cancel_timer(self) -> None:
         """Cancel any pending timer callback."""
-        if self._unsub_timer is not None:
-            self._unsub_timer()
-            self._unsub_timer = None
+        self._timer_manager.cancel()
 
     def _get_relevant_event(self) -> CalendarEvent | None:
-        """Get the most relevant event from coordinator data.
-
-        Returns the first event whose end time is still in the future,
-        skipping events that have already ended.  This prevents the
-        sensor from tracking stale events that remain in coordinator
-        data until the next midnight filter removes them.
-
-        Returns:
-            The first non-ended event, or None if no active events.
-        """
-        now = dt_util.now()
-        for event in self.coordinator.data or []:
-            if event.end > now:
-                return event
-        return None
-
-    def _get_next_event(self) -> CalendarEvent | None:
-        """Get the next event after the current one.
-
-        Returns:
-            The second event from coordinator data (event 1), or None
-            if not available.
-        """
-        if self.coordinator.data and len(self.coordinator.data) > 1:
-            return self.coordinator.data[1]
-        return None
+        """Get the most relevant event from coordinator data."""
+        return get_relevant_event(self.coordinator.data or [], dt_util.now())
 
     def _find_followon_event(self, checkout_time: datetime) -> CalendarEvent | None:
-        """Find the first follow-on event after checkout.
-
-        Scans coordinator data for the first event that is not the
-        checked-out event and starts at or after checkout time. This
-        avoids hardcoding an index, which would break if the
-        checked-out event has already been filtered from the data.
-
-        Args:
-            checkout_time: The checkout time to compare against.
-
-        Returns:
-            The follow-on CalendarEvent, or None if none found.
-        """
-        events = self.coordinator.data or []
-        for event in events:
-            if self._checked_out_event_key is not None:
-                event_key = self._event_key(event.summary, event.start)
-                if event_key == self._checked_out_event_key:
-                    continue
-            if event.start >= checkout_time:
-                return event
-        return None
+        """Find the first follow-on event after checkout."""
+        return find_followon_event(
+            self.coordinator.data or [], checkout_time, self._checked_out_event_key
+        )
 
     def _find_tracked_event(self) -> CalendarEvent | None:
-        """Find the currently tracked event in coordinator data by identity key.
-
-        Searches all events, not just position 0, to handle event
-        list reordering during coordinator refreshes.
-
-        Returns:
-            The tracked CalendarEvent, or None if not found.
-        """
-        if (
-            not self.coordinator.data
-            or self._tracked_event_summary is None
-            or self._tracked_event_start is None
-        ):
-            return None
-        tracked_key = self._event_key(
-            self._tracked_event_summary, self._tracked_event_start
+        """Find the currently tracked event in coordinator data."""
+        return find_tracked_event(
+            self.coordinator.data or [],
+            self._tracked_event_summary,
+            self._tracked_event_start,
         )
-        for event in self.coordinator.data:
-            if self._event_key(event.summary, event.start) == tracked_key:
-                return event
-        return None
 
     def _extract_slot_name(self, event: CalendarEvent) -> str | None:
-        """Extract guest/slot name from a calendar event.
-
-        Uses the same extraction logic as the existing cal sensor.
-
-        Args:
-            event: The calendar event to extract from.
-
-        Returns:
-            The extracted slot name, or None.
-        """
-        return get_slot_name(
-            event.summary,
-            event.description or "",
-            self.coordinator.event_prefix or "",
-        )
+        """Extract guest/slot name from a calendar event."""
+        return extract_slot_name(event, self.coordinator.event_prefix or "")
 
     def _is_keymaster_monitoring_enabled(self) -> bool:
-        """Return True when keymaster monitoring is switched on.
-
-        Looks up the :class:`KeymasterMonitoringSwitch` stored in
-        ``hass.data`` for this config entry.  When the switch entity
-        is loaded, returns its ``is_on`` state.
-
-        When the switch entity is **not yet loaded** (e.g. during
-        platform setup on restart), falls back to the coordinator
-        configuration: if a lock is configured monitoring *may* be
-        active, so ``True`` is returned to prevent premature
-        auto check-in during the setup race window.
-        """
+        """Return True when keymaster monitoring is switched on."""
         entry_data = get_entry_data(self._hass, self._config_entry.entry_id)
         if entry_data is None:
             return self.coordinator.lockname is not None
-
-        monitoring_switch = entry_data.get(KEYMASTER_MONITORING_SWITCH)
+        monitoring_switch = entry_data.get(rc_const.KEYMASTER_MONITORING_SWITCH)
         if monitoring_switch is not None:
             return bool(monitoring_switch.is_on)
-        # Switch entity not yet loaded — fall back to configuration.
-        # If a lock is configured, assume monitoring may be active to
-        # prevent premature auto check-in during platform setup race.
         return self.coordinator.lockname is not None
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator.
-
-        Evaluates the current event data and state to determine if a
-        state transition is needed.
-        """
+        """Handle updated data from the coordinator."""
         _LOGGER.debug(
             "Running CheckinTrackingSensor coordinator update for %s",
             self.coordinator.name,
         )
-
-        if not self.coordinator.last_update_success:
-            self.async_write_ha_state()
-            return
-
-        current_state = self._state
-
-        if current_state == CHECKIN_STATE_NO_RESERVATION:
-            event = self._get_relevant_event()
-            if event is not None:
-                self._transition_to_awaiting(event)
-            else:
-                self.async_write_ha_state()
-
-        elif current_state == CHECKIN_STATE_AWAITING:
-            tracked = self._find_tracked_event()
-            if tracked is not None:
-                # Check if a more relevant (earlier) event has appeared
-                # that the sensor should track instead. This handles the
-                # case where a nearer reservation is added to the calendar
-                # after the sensor already started tracking a future event.
-                relevant = self._get_relevant_event()
-                if (
-                    relevant is not None
-                    and self._tracked_event_start is not None
-                    and self._tracked_event_summary is not None
-                ):
-                    relevant_key = self._event_key(relevant.summary, relevant.start)
-                    tracked_key = self._event_key(
-                        self._tracked_event_summary,
-                        self._tracked_event_start,
-                    )
-                    if (
-                        relevant_key != tracked_key
-                        and relevant_key != self._checked_out_event_key
-                        and relevant.start < self._tracked_event_start
-                    ):
-                        _LOGGER.debug(
-                            "More relevant event found (%s starting "
-                            "%s) while awaiting %s starting %s; "
-                            "switching tracked event",
-                            relevant.summary,
-                            relevant.start,
-                            self._tracked_event_summary,
-                            self._tracked_event_start,
-                        )
-                        self._transition_to_awaiting(relevant)
-                        return
-
-                # Same event still in coordinator — update mutable fields
-                self._tracked_event_end = tracked.end
-                self._tracked_event_slot_name = self._extract_slot_name(tracked)
-                # Re-evaluate auto check-in on each coordinator update.
-                # During the startup race the monitoring switch may not
-                # have been loaded yet, so _is_keymaster_monitoring_enabled
-                # conservatively returned True.  Once all platforms are
-                # up and the switch is available, this path allows the
-                # deferred auto-checkin to proceed when monitoring is
-                # actually off and the event start has passed.
-                now = dt_util.now()
-                if (
-                    self._tracked_event_start is not None
-                    and self._tracked_event_start <= now
-                    and not self._is_keymaster_monitoring_enabled()
-                ):
-                    self._transition_to_checked_in(source="automatic")
-                else:
-                    self.async_write_ha_state()
-            else:
-                # Tracked event gone — pick up next available or clear
-                event = self._get_relevant_event()
-                if event is not None:
-                    self._transition_to_awaiting(event)
-                else:
-                    self._transition_to_no_reservation()
-
-        elif current_state == CHECKIN_STATE_CHECKED_IN:
-            tracked = self._find_tracked_event()
-            if tracked is not None:
-                self._event_missing_warned = False
-                now = dt_util.now()
-                # Self-healing: if the tracked event starts more than
-                # 24 hours from now, the sensor is tracking the wrong
-                # event regardless of how check-in was triggered.
-                # Events starting within 24 hours may be legitimate
-                # early arrivals via keymaster.
-                if tracked.start > now + _SELF_HEAL_FUTURE_THRESHOLD:
-                    _LOGGER.warning(
-                        "Self-healing: sensor is checked_in but "
-                        "tracked event '%s' starts at %s which is "
-                        "more than 24h in the future; forcing checkout for %s",
-                        tracked.summary,
-                        tracked.start,
-                        self.coordinator.name,
-                    )
-                    self._transition_to_checked_out(
-                        source="automatic",
-                        linger_baseline=now,
-                    )
-                    event = self._get_relevant_event()
-                    if event is not None and (
-                        self._event_key(event.summary, event.start)
-                        != self._checked_out_event_key
-                    ):
-                        self._transition_to_awaiting(event)
-                    return
-                if tracked.end <= now:
-                    # Event has ended — force checkout as safety net
-                    # in case the auto-checkout timer failed to fire.
-                    _LOGGER.debug(
-                        "Event end time %s has passed, forcing "
-                        "automatic checkout for %s",
-                        tracked.end,
-                        self.coordinator.name,
-                    )
-                    self._tracked_event_end = tracked.end
-                    self._tracked_event_slot_name = self._extract_slot_name(tracked)
-                    self._cancel_timer()
-                    self._transition_to_checked_out(
-                        source="automatic",
-                        linger_baseline=tracked.end,
-                    )
-                elif tracked.end != self._tracked_event_end:
-                    # FR-030: Check if event end time changed
-                    _LOGGER.debug(
-                        "Event end time changed from %s to %s, "
-                        "rescheduling auto check-out",
-                        self._tracked_event_end,
-                        tracked.end,
-                    )
-                    self._tracked_event_end = tracked.end
-                    self._cancel_timer()
-                    self._schedule_auto_checkout(tracked.end)
-                    self._tracked_event_slot_name = self._extract_slot_name(tracked)
-                    self.async_write_ha_state()
-                else:
-                    self._tracked_event_slot_name = self._extract_slot_name(tracked)
-                    self.async_write_ha_state()
-            else:
-                # Tracked event not found in coordinator data.
-                # If the stored end time has already passed, force
-                # checkout as a safety net (mirrors the tracked-event
-                # end-time check above).  Otherwise, preserve
-                # checked_in for transient data mismatches.
-                fallback_end = self._tracked_event_end
-                if fallback_end is not None and fallback_end <= dt_util.now():
-                    _LOGGER.warning(
-                        "Tracked event not found in coordinator data "
-                        "while checked_in for %s and stored end "
-                        "time %s has passed; forcing checkout",
-                        self.coordinator.name,
-                        fallback_end,
-                    )
-                    self._cancel_timer()
-                    self._transition_to_checked_out(
-                        source="automatic",
-                        linger_baseline=fallback_end,
-                    )
-                elif (
-                    fallback_end is None
-                    and self._tracked_event_start is None
-                    and self._tracked_event_summary is None
-                ):
-                    # All tracking data lost — cannot recover.
-                    # Transition to no_reservation so the next
-                    # coordinator update can pick up fresh events.
-                    _LOGGER.warning(
-                        "All tracking data lost while checked_in "
-                        "for %s; resetting to no_reservation",
-                        self.coordinator.name,
-                    )
-                    self._cancel_timer()
-                    self._transition_to_no_reservation()
-                else:
-                    if not self._event_missing_warned:
-                        _LOGGER.warning(
-                            "Tracked event not found in coordinator "
-                            "data while checked_in for %s; "
-                            "preserving state",
-                            self.coordinator.name,
-                        )
-                        self._event_missing_warned = True
-                    else:
-                        _LOGGER.debug(
-                            "Tracked event still missing for %s; "
-                            "preserving checked_in state",
-                            self.coordinator.name,
-                        )
-                    self.async_write_ha_state()
-
-        elif current_state == CHECKIN_STATE_CHECKED_OUT:
-            checkout_time = (
-                self._linger_baseline or self._checkout_time or dt_util.now()
-            )
-            followon = self._find_followon_event(checkout_time)
-            if followon is not None:
-                followon_key = self._event_key(followon.summary, followon.start)
-                if (
-                    self._unsub_timer is not None
-                    and self._linger_followon_key == followon_key
-                ):
-                    # Same follow-on, timer already scheduled
-                    self.async_write_ha_state()
-                else:
-                    # New or changed follow-on event
-                    self._cancel_timer()
-                    self._compute_linger_timing()
-                    self.async_write_ha_state()
-            else:
-                # No follow-on event
-                if self._linger_followon_key is not None:
-                    # Follow-on was removed — recompute for FR-006b
-                    self._cancel_timer()
-                    self._linger_followon_key = None
-                    self._compute_linger_timing()
-                elif self._unsub_timer is None:
-                    self._compute_linger_timing()
-                self.async_write_ha_state()
+        apply_transition_decision(
+            self, decide_coordinator_update(self._decision_context())
+        )
 
     def _transition_to_awaiting(self, event: CalendarEvent) -> None:
-        """Transition to awaiting_checkin state.
+        """Transition to awaiting_checkin state."""
+        runtime.transition_to_awaiting(self, event)
 
-        Sets state and attributes from the provided event and schedules
-        auto check-in at event start time.
-
-        Args:
-            event: The calendar event to track.
-        """
-        _LOGGER.debug(
-            "Transitioning to awaiting_checkin for event: %s",
-            event.summary,
-        )
-        self._state = CHECKIN_STATE_AWAITING
-        self._tracked_event_summary = event.summary
-        self._tracked_event_start = event.start
+    def _update_tracked_event(self, event: CalendarEvent) -> None:
+        """Update mutable tracked fields from an event."""
         self._tracked_event_end = event.end
         self._tracked_event_slot_name = self._extract_slot_name(event)
-        self._checkin_source = None
-        self._checkout_source = None
-        self._checkout_time = None
-        # Preserve _checked_out_event_key so that the awaiting
-        # re-evaluation logic can exclude the just-checked-out event
-        # and avoid same-day turnover regressions.
-        self._next_event_start_day = None
-        self._checkin_lock_name = None
-        self._linger_followon_key = None
-        self._linger_baseline = None
-        self._event_missing_warned = False
 
-        # Schedule auto check-in at event start time
-        self._cancel_timer()
-        now = dt_util.now()
-        if event.start > now:
-            self._transition_target_time = event.start
-            self._unsub_timer = async_track_point_in_time(
-                self._hass,
-                self._async_auto_checkin_callback,
-                event.start,
-            )
-        else:
-            # Event start already passed — auto check-in only if
-            # keymaster monitoring is disabled; otherwise stay in
-            # awaiting_checkin until the guest uses their code.
-            self._transition_target_time = None
-            if not self._is_keymaster_monitoring_enabled():
-                self._transition_to_checked_in(source="automatic")
-                return
-
-        self.async_write_ha_state()
+    def _update_tracked_slot_name(self, event: CalendarEvent) -> None:
+        """Update tracked slot name from an event."""
+        self._tracked_event_slot_name = self._extract_slot_name(event)
 
     def _transition_to_checked_in(self, source: str, lock_name: str = "") -> None:
-        """Transition to checked_in state.
+        """Transition to checked_in state and fire the check-in event."""
+        runtime.transition_to_checked_in(self, source, lock_name)
 
-        Fires a check-in event on the HA event bus and schedules auto
-        check-out at the event end time.
+    def _checkin_payload(self, source: str) -> dict[str, Any]:
+        """Return a check-in event payload."""
+        return runtime.checkin_payload(self, source)
 
-        Args:
-            source: How check-in occurred (``keymaster`` or ``automatic``).
-            lock_name: The lock that triggered check-in (empty if automatic).
-        """
-        _LOGGER.debug(
-            "Transitioning to checked_in (source=%s, lock=%s) for event: %s",
-            source,
-            lock_name or "(none)",
-            self._tracked_event_summary,
-        )
-        self._state = CHECKIN_STATE_CHECKED_IN
-        self._checkin_source = source
-        self._checkin_lock_name = lock_name or None
-        self._transition_target_time = None
-        self._event_missing_warned = False
-
-        # Fire check-in event (per contracts/events.md)
-        event_payload: dict[str, Any] = {
-            "entity_id": self.entity_id,
-            "summary": self._tracked_event_summary or "",
-            "start": (
-                self._tracked_event_start.isoformat()
-                if self._tracked_event_start
-                else ""
-            ),
-            "end": (
-                self._tracked_event_end.isoformat() if self._tracked_event_end else ""
-            ),
-            "guest_name": self._tracked_event_slot_name or "",
-            "source": source,
-        }
-        if lock_name:
-            event_payload["lock_name"] = lock_name
-        self._hass.bus.async_fire(
-            EVENT_RENTAL_CONTROL_CHECKIN,
-            event_payload,
-        )
-
-        # Schedule auto check-out at event end time
-        self._cancel_timer()
-        if self._tracked_event_end is not None:
-            self._schedule_auto_checkout(self._tracked_event_end)
-
-        self.async_write_ha_state()
+    def _schedule_auto_checkin(self, start_time: datetime) -> None:
+        """Schedule automatic check-in for a start time."""
+        timer_runtime.schedule_auto_checkin(self, start_time)
 
     def _schedule_auto_checkout(self, end_time: datetime) -> None:
-        """Schedule automatic checkout at the given end time.
-
-        Args:
-            end_time: When to trigger automatic checkout.
-        """
-        now = dt_util.now()
-        if end_time > now:
-            self._transition_target_time = end_time
-            self._unsub_timer = async_track_point_in_time(
-                self._hass,
-                self._async_auto_checkout_callback,
-                end_time,
-            )
-        else:
-            # End time already passed - checkout immediately
-            self._transition_target_time = None
-            self._transition_to_checked_out(
-                source="automatic",
-                linger_baseline=end_time,
-            )
+        """Schedule automatic checkout at the given end time."""
+        timer_runtime.schedule_auto_checkout(self, end_time)
 
     def _transition_to_checked_out(
-        self,
-        source: str,
-        linger_baseline: datetime | None = None,
+        self, source: str, linger_baseline: datetime | None = None
     ) -> None:
-        """Transition to checked_out state.
-
-        Records checkout details, fires checkout event, stores event
-        identity key for FR-007, and computes post-checkout linger timing.
-
-        Args:
-            source: How check-out occurred (``manual`` or ``automatic``).
-            linger_baseline: Reference time for follow-on event lookup
-                and linger scheduling.  Defaults to ``dt_util.now()``.
-                Pass the event end time when the reservation has already
-                ended so that follow-on events starting between ``end``
-                and ``now`` are not skipped.
-        """
-        _LOGGER.debug(
-            "Transitioning to checked_out (source=%s) for event: %s",
-            source,
-            self._tracked_event_summary,
-        )
-        self._state = CHECKIN_STATE_CHECKED_OUT
-        self._checkout_source = source
-        self._checkout_time = dt_util.now()
-        self._event_missing_warned = False
-
-        # Store event identity key for FR-007
-        if self._tracked_event_summary and self._tracked_event_start:
-            self._checked_out_event_key = self._event_key(
-                self._tracked_event_summary, self._tracked_event_start
-            )
-
-        # Fire check-out event (per contracts/events.md)
-        self._hass.bus.async_fire(
-            EVENT_RENTAL_CONTROL_CHECKOUT,
-            {
-                "entity_id": self.entity_id,
-                "summary": self._tracked_event_summary or "",
-                "start": (
-                    self._tracked_event_start.isoformat()
-                    if self._tracked_event_start
-                    else ""
-                ),
-                "end": (
-                    self._tracked_event_end.isoformat()
-                    if self._tracked_event_end
-                    else ""
-                ),
-                "guest_name": self._tracked_event_slot_name or "",
-                "source": source,
-            },
-        )
-
-        # Compute post-checkout linger timing
-        self._cancel_timer()
-        effective_baseline = linger_baseline or self._checkout_time
-        self._linger_baseline = effective_baseline
-        self._compute_linger_timing(baseline=effective_baseline)
-
-        self.async_write_ha_state()
+        """Transition to checked_out state."""
+        runtime.transition_to_checked_out(self, source, linger_baseline)
 
     def _compute_linger_timing(self, baseline: datetime | None = None) -> None:
-        """Compute and schedule post-checkout linger timing.
+        """Compute and schedule post-checkout linger timing."""
+        timer_runtime.compute_linger_timing(self, baseline)
 
-        Determines which FR-006 scenario applies based on the next
-        event's timing and schedules the appropriate transition.
+    def _schedule_linger_to_awaiting(self, target: datetime) -> None:
+        """Schedule same-day linger transition."""
+        timer_runtime.schedule_linger_to_awaiting(self, target)
 
-        Date comparisons use the HA-configured local timezone so that
-        "same calendar day" is evaluated from the user's perspective,
-        not raw UTC dates.
+    def _schedule_linger_to_no_reservation(
+        self, target: datetime, followup: datetime | None
+    ) -> None:
+        """Schedule linger expiry transition."""
+        timer_runtime.schedule_linger_to_no_reservation(self, target, followup)
 
-        Args:
-            baseline: Reference time for follow-on event lookup and
-                gap calculations.  Falls back to ``_linger_baseline``,
-                then ``_checkout_time``, then ``dt_util.now()``.
-        """
-        checkout_time = (
-            baseline or self._linger_baseline or self._checkout_time or dt_util.now()
-        )
-        next_event = self._find_followon_event(checkout_time)
-
-        if next_event is not None:
-            self._linger_followon_key = self._event_key(
-                next_event.summary, next_event.start
-            )
-            # Compare dates in the HA-configured local timezone (T038)
-            local_checkout = dt_util.as_local(checkout_time)
-            local_next_start = dt_util.as_local(next_event.start)
-
-            if local_next_start.date() == local_checkout.date():
-                # FR-006a: Same-day turnover
-                # Transition at half the gap between checkout and next start
-                gap = next_event.start - checkout_time
-                half_gap = checkout_time + (gap / 2)
-                self._transition_target_time = half_gap
-                self._next_event_start_day = None
-                self._unsub_timer = async_track_point_in_time(
-                    self._hass,
-                    self._async_linger_to_awaiting_callback,
-                    half_gap,
-                )
-                _LOGGER.debug(
-                    "FR-006a: Same-day turnover, transition to awaiting at %s",
-                    half_gap.isoformat(),
-                )
-            else:
-                # FR-006c: Different-day follow-on
-                # Transition at midnight boundary; store next event's start
-                # day for the follow-up timer (T039)
-                midnight = dt_util.start_of_local_day(checkout_time + timedelta(days=1))
-                self._transition_target_time = midnight
-                self._next_event_start_day = dt_util.start_of_local_day(
-                    next_event.start
-                )
-                self._unsub_timer = async_track_point_in_time(
-                    self._hass,
-                    self._async_linger_to_no_reservation_callback,
-                    midnight,
-                )
-                _LOGGER.debug(
-                    "FR-006c: Different-day follow-on, transition to "
-                    "no_reservation at %s, follow-up awaiting at %s",
-                    midnight.isoformat(),
-                    self._next_event_start_day.isoformat(),
-                )
-        else:
-            self._linger_followon_key = None
-            # FR-006b: No follow-on reservation
-            # Transition after cleaning window
-            cleaning_hours = self._get_cleaning_window()
-            linger_end = checkout_time + timedelta(hours=cleaning_hours)
-            self._transition_target_time = linger_end
-            self._next_event_start_day = None
-            self._unsub_timer = async_track_point_in_time(
-                self._hass,
-                self._async_linger_to_no_reservation_callback,
-                linger_end,
-            )
-            _LOGGER.debug(
-                "FR-006b: No follow-on, transition to no_reservation at %s",
-                linger_end.isoformat(),
-            )
+    def _schedule_no_reservation_to_awaiting(self, target: datetime) -> None:
+        """Schedule FR-006c follow-up awaiting transition."""
+        timer_runtime.schedule_no_reservation_to_awaiting(self, target)
 
     def _transition_to_no_reservation(self) -> None:
-        """Transition to no_reservation state.
-
-        Clears all tracked event data and cancels any pending timers.
-        Note: Does NOT clear ``_next_event_start_day`` — the FR-006c
-        follow-up logic in ``_async_linger_to_no_reservation_callback``
-        reads it after this method returns.
-        """
-        _LOGGER.debug("Transitioning to no_reservation")
-        self._state = CHECKIN_STATE_NO_RESERVATION
-        self._tracked_event_summary = None
-        self._tracked_event_start = None
-        self._tracked_event_end = None
-        self._tracked_event_slot_name = None
-        self._checkin_source = None
-        self._checkout_source = None
-        self._checkout_time = None
-        self._transition_target_time = None
-        self._checked_out_event_key = None
-        self._checkin_lock_name = None
-        self._linger_followon_key = None
-        self._linger_baseline = None
-        self._event_missing_warned = False
-
-        self._cancel_timer()
-        self.async_write_ha_state()
+        """Transition to no_reservation state and clear tracked data."""
+        runtime.transition_to_no_reservation(self)
 
     @callback
     def _async_auto_checkin_callback(self, _now: datetime) -> None:
-        """Timer callback for automatic check-in at event start time.
-
-        When keymaster monitoring is enabled the sensor must stay in
-        ``awaiting_checkin`` until the guest actually uses their door
-        code, so the automatic transition is skipped.
-
-        Args:
-            _now: The current time when the callback fires.
-        """
-        _LOGGER.debug("Auto check-in timer fired for %s", self.coordinator.name)
-        self._unsub_timer = None
-        if self._state != CHECKIN_STATE_AWAITING:
-            return
-        if self._is_keymaster_monitoring_enabled():
-            _LOGGER.debug(
-                "Keymaster monitoring is on; staying in awaiting_checkin "
-                "until door code is used for %s",
-                self.coordinator.name,
-            )
-            self._transition_target_time = None
-            self.async_write_ha_state()
-            return
-        self._transition_to_checked_in(source="automatic")
+        """Timer callback for automatic check-in at event start time."""
+        timer_runtime.auto_checkin_callback(self, _now)
 
     @callback
     def _async_auto_checkout_callback(self, _now: datetime) -> None:
-        """Timer callback for automatic check-out at event end time.
-
-        Args:
-            _now: The current time when the callback fires.
-        """
-        _LOGGER.debug("Auto check-out timer fired for %s", self.coordinator.name)
-        self._unsub_timer = None
-        if self._state == CHECKIN_STATE_CHECKED_IN:
-            self._transition_to_checked_out(source="automatic")
+        """Timer callback for automatic check-out at event end time."""
+        timer_runtime.auto_checkout_callback(self, _now)
 
     @callback
     def _async_linger_to_awaiting_callback(self, _now: datetime) -> None:
-        """Timer callback for same-day turnover (FR-006a).
-
-        Transitions from checked_out to awaiting_checkin for the next event.
-
-        Args:
-            _now: The current time when the callback fires.
-        """
-        _LOGGER.debug("Linger-to-awaiting timer fired for %s", self.coordinator.name)
-        self._unsub_timer = None
-        if self._state == CHECKIN_STATE_CHECKED_OUT:
-            checkout_time = self._linger_baseline or self._checkout_time or _now
-            event = self._find_followon_event(checkout_time)
-            if event is not None:
-                self._transition_to_awaiting(event)
-            else:
-                self._transition_to_no_reservation()
+        """Timer callback for same-day turnover."""
+        timer_runtime.linger_to_awaiting_callback(self, _now)
 
     @callback
     def _async_linger_to_no_reservation_callback(self, _now: datetime) -> None:
-        """Timer callback for post-checkout linger expiry (FR-006b/c).
-
-        Transitions from checked_out to no_reservation. For FR-006c,
-        schedules a follow-up timer at 00:00 on the next event's start
-        day to transition from no_reservation to awaiting_checkin (T039).
-
-        Args:
-            _now: The current time when the callback fires.
-        """
-        _LOGGER.debug(
-            "Linger-to-no-reservation timer fired for %s", self.coordinator.name
-        )
-        self._unsub_timer = None
-        if self._state == CHECKIN_STATE_CHECKED_OUT:
-            # Capture follow-on event start day before clearing state
-            followon_start_day = self._next_event_start_day
-            self._transition_to_no_reservation()
-
-            # T039: FR-006c follow-up timer for midnight-to-awaiting
-            if followon_start_day is not None:
-                if followon_start_day > _now:
-                    self._transition_target_time = followon_start_day
-                    self._next_event_start_day = followon_start_day
-                    self._unsub_timer = async_track_point_in_time(
-                        self._hass,
-                        self._async_no_reservation_to_awaiting_callback,
-                        followon_start_day,
-                    )
-                    _LOGGER.debug(
-                        "FR-006c: Scheduled follow-up awaiting transition at %s for %s",
-                        followon_start_day.isoformat(),
-                        self.coordinator.name,
-                    )
-                    self.async_write_ha_state()
-                else:
-                    # Follow-on start day already passed — trigger
-                    # coordinator-driven evaluation on next update
-                    _LOGGER.debug(
-                        "FR-006c: Follow-on start day %s already passed, "
-                        "relying on coordinator update",
-                        followon_start_day.isoformat(),
-                    )
+        """Timer callback for post-checkout linger expiry."""
+        timer_runtime.linger_to_no_reservation_callback(self, _now)
 
     @callback
     def _async_no_reservation_to_awaiting_callback(self, _now: datetime) -> None:
-        """Timer callback for FR-006c follow-up awaiting transition.
-
-        Fires at 00:00 on the next event's start day. Finds the
-        follow-on event in coordinator data and transitions to
-        awaiting_checkin. Falls back to no-op if the event has
-        disappeared.
-
-        Args:
-            _now: The current time when the callback fires.
-        """
-        _LOGGER.debug(
-            "FR-006c no-reservation-to-awaiting timer fired for %s",
-            self.coordinator.name,
-        )
-        self._unsub_timer = None
-        self._next_event_start_day = None
-        self._transition_target_time = None
-
-        if self._state != CHECKIN_STATE_NO_RESERVATION:
-            return
-
-        # Find the next event from coordinator data
-        event = self._get_relevant_event()
-        if event is not None:
-            self._transition_to_awaiting(event)
-        else:
-            _LOGGER.debug(
-                "FR-006c: No event found in coordinator data at "
-                "follow-up time, staying in no_reservation",
-            )
+        """Timer callback for FR-006c follow-up awaiting transition."""
+        timer_runtime.no_reservation_to_awaiting_callback(self, _now)
 
     async def async_checkout(self, force: bool = False) -> None:
-        """Handle manual checkout service call.
-
-        Validates guard conditions:
-        1. Sensor must be in ``checked_in`` state
-        2. Reservation boundaries must be known (skipped when
-           *force* is ``True``)
-        3. Current date must be on or after the last day of the
-           reservation (skipped when *force* is ``True``)
-
-        On success, calls ``_transition_to_checked_out(source="manual")``.
-
-        Args:
-            force: Bypass guards 2 and 3.  Use when the sensor is
-                stuck and the admin needs to override.
-
-        Raises:
-            ServiceValidationError: If guard conditions are not met.
-        """
-        # Guard 1: State must be checked_in (never bypassed)
-        if self._state != CHECKIN_STATE_CHECKED_IN:
-            raise ServiceValidationError(
-                f"Checkout is only available when the guest is "
-                f"checked in (current state: {self._state})"
-            )
-
-        now = dt_util.now()
-        end = self._tracked_event_end
-
-        # Guard 2: Reservation boundaries must be known
-        if self._tracked_event_start is None or end is None:
-            if not force:
-                raise ServiceValidationError(
-                    "Checkout requires known reservation boundaries"
-                )
-            _LOGGER.warning(
-                "Force checkout: reservation boundaries unknown "
-                "for %s, proceeding anyway",
-                self.coordinator.name,
-            )
-
-        # Guard 3: Must be on or after the last day of the reservation
-        if end is not None:
-            local_now = dt_util.as_local(now)
-            local_end = dt_util.as_local(end)
-            if local_now.date() < local_end.date():
-                if not force:
-                    raise ServiceValidationError(
-                        f"Checkout is only available on the last "
-                        f"day of the reservation or later "
-                        f"(current: "
-                        f"{local_now.date().isoformat()}, "
-                        f"checkout day: "
-                        f"{local_end.date().isoformat()})"
-                    )
-                _LOGGER.warning(
-                    "Force checkout: overriding last-day guard "
-                    "for %s (current: %s, checkout day: %s)",
-                    self.coordinator.name,
-                    local_now.date().isoformat(),
-                    local_end.date().isoformat(),
-                )
-
-        # Early expiry: shorten lock code if switch is on (FR-022)
-        entry_data = get_entry_data(self._hass, self._config_entry.entry_id)
-        early_expiry_switch = (
-            entry_data.get(EARLY_CHECKOUT_EXPIRY_SWITCH)
-            if entry_data is not None
-            else None
-        )
-
-        if early_expiry_switch is not None and early_expiry_switch.is_on:
-            if self._tracked_event_end is not None:
-                new_end = compute_early_expiry_time(now, self._tracked_event_end)
-                if new_end < self._tracked_event_end:
-                    _LOGGER.info(
-                        "Early checkout expiry: shortening end "
-                        "time from %s to %s for %s",
-                        self._tracked_event_end,
-                        new_end,
-                        self._tracked_event_summary,
-                    )
-                    self._tracked_event_end = new_end
-                    await self._async_update_lock_code_expiry(new_end)
-
-        # Use event end as linger baseline when past end so that
-        # follow-on event detection uses the correct reference
-        # point.  When boundaries are unknown fall back to now.
-        effective_baseline = min(now, end) if end is not None else now
-        self._transition_to_checked_out(
-            source="manual", linger_baseline=effective_baseline
-        )
+        """Handle manual checkout service call."""
+        await runtime.async_checkout(self, force)
 
     async def async_set_state(self, state: str) -> None:
-        """Force-set the sensor to an arbitrary valid state.
-
-        This is a **debug / testing** action that bypasses all
-        guard conditions and transition logic.  It performs a raw
-        state assignment, clears all tracked event and transition
-        fields, cancels pending timers, and writes HA state.
-        This does not fire the integration's custom
-        ``rental_control`` check-in/checkout bus events, but
-        ``async_write_ha_state()`` still emits Home Assistant's
-        standard ``state_changed`` event.
-
-        Args:
-            state: Target state — must be one of the four valid
-                check-in states.
-
-        Raises:
-            ServiceValidationError: If *state* is not valid.
-        """
-        valid = self._attr_options
-        if valid is None or state not in valid:
-            raise ServiceValidationError(
-                f"Invalid state '{state}'. Valid states: {', '.join(valid or [])}"
-            )
-
-        _LOGGER.warning(
-            "DEBUG override: forcing %s from '%s' to '%s'",
-            self.entity_id,
-            self._state,
-            state,
-        )
-
-        self._state = state
-        self._tracked_event_summary = None
-        self._tracked_event_start = None
-        self._tracked_event_end = None
-        self._tracked_event_slot_name = None
-        self._checkin_source = None
-        self._checkout_source = None
-        self._checkout_time = None
-        self._transition_target_time = None
-        self._checked_out_event_key = None
-        self._next_event_start_day = None
-        self._checkin_lock_name = None
-        self._linger_followon_key = None
-        self._linger_baseline = None
-        self._event_missing_warned = False
-        self._cancel_timer()
-        self.async_write_ha_state()
+        """Force-set the sensor to an arbitrary valid state."""
+        await runtime.async_set_state(self, state)
 
     async def async_added_to_hass(self) -> None:
-        """Restore persisted state and validate against current time/data.
-
-        Retrieves the last stored extra data (if any) via
-        ``async_get_last_extra_data``, repopulates all instance fields,
-        then runs stale-state validation to auto-correct outdated state
-        and reschedule timers.
-
-        If no prior state exists the sensor starts in
-        ``no_reservation`` and falls through to normal coordinator
-        processing.
-        """
+        """Restore persisted state and validate against current time/data."""
         await super().async_added_to_hass()
-
         last_extra = await self.async_get_last_extra_data()
         if last_extra is not None:
-            data = last_extra.as_dict()
-            restored = CheckinExtraStoredData.from_dict(data)
-
-            self._state = restored.state
-            self._tracked_event_summary = restored.tracked_event_summary
-            self._tracked_event_start = restored.tracked_event_start
-            self._tracked_event_end = restored.tracked_event_end
-            self._tracked_event_slot_name = restored.tracked_event_slot_name
-            self._checkin_source = restored.checkin_source
-            self._checkout_source = restored.checkout_source
-            self._checkout_time = restored.checkout_time
-            self._transition_target_time = restored.transition_target_time
-            self._checked_out_event_key = restored.checked_out_event_key
-            self._next_event_start_day = restored.next_event_start_day
-            self._checkin_lock_name = restored.checkin_lock_name
-
+            restored = CheckinExtraStoredData.from_dict(last_extra.as_dict())
+            self._apply_snapshot(restored.snapshot)
             _LOGGER.debug(
                 "Restored state '%s' for %s", self._state, self.coordinator.name
             )
-
             self._validate_restored_state()
-
-            # After restoration and stale-state correction, reconcile with
-            # current coordinator data so restored state is immediately
-            # consistent with the latest calendar events.
-            if (
-                self.coordinator.last_update_success
-                and self.coordinator.data is not None
-            ):
-                self._handle_coordinator_update()
         else:
             _LOGGER.debug(
                 "No prior state for %s, starting as %s",
                 self.coordinator.name,
-                CHECKIN_STATE_NO_RESERVATION,
+                rc_const.CHECKIN_STATE_NO_RESERVATION,
             )
-            # Fall through: process any current coordinator data
-            if (
-                self.coordinator.last_update_success
-                and self.coordinator.data is not None
-            ):
-                self._handle_coordinator_update()
+        if self.coordinator.last_update_success and self.coordinator.data is not None:
+            self._handle_coordinator_update()
 
     def _validate_restored_state(self) -> None:
-        """Validate restored state against current time and coordinator data.
+        """Validate restored state against current time and coordinator data."""
+        apply_restore_decision(self, decide_restore_state(self._decision_context()))
 
-        Auto-corrects stale state and reschedules timers:
+    def _apply_silent_checked_in(self, source: str) -> None:
+        """Apply a restore-silent checked-in transition."""
+        runtime.apply_silent_checked_in(self, source)
 
-        * ``checked_in`` with far-future or ended event → ``checked_out``
-        * ``awaiting_checkin`` with passed start (time-based) → ``checked_in``
-        * ``checked_out`` with expired linger / new event → reprocess
-        * Valid state with pending transition → reschedule timer
-        """
-        now = dt_util.now()
-        current_state = self._state
-
-        if current_state == CHECKIN_STATE_CHECKED_IN:
-            if (
-                self._tracked_event_start is not None
-                and self._tracked_event_start > now + _SELF_HEAL_FUTURE_THRESHOLD
-            ):
-                # Tracked event is far in the future — sensor was
-                # tracking the wrong event. Silent checkout so the
-                # coordinator update can pick up the correct event.
-                _LOGGER.debug(
-                    "Stale restore: checked_in but tracked event starts %s "
-                    "(>24h away), forcing checkout (silent)",
-                    self._tracked_event_start,
-                )
-                self._state = CHECKIN_STATE_CHECKED_OUT
-                self._checkout_source = "automatic"
-                self._checkout_time = now
-                if (
-                    self._tracked_event_summary is not None
-                    and self._tracked_event_start is not None
-                ):
-                    self._checked_out_event_key = self._event_key(
-                        self._tracked_event_summary,
-                        self._tracked_event_start,
-                    )
-                self._compute_linger_timing()
-                self.async_write_ha_state()
-                return
-            if self._tracked_event_end is not None and self._tracked_event_end <= now:
-                # Event has ended while we were down → silent checkout
-                # (no HA bus event to avoid triggering automations on
-                # restart catch-up).
-                _LOGGER.debug(
-                    "Stale restore: checked_in but event ended, "
-                    "transitioning to checked_out (silent)"
-                )
-                self._state = CHECKIN_STATE_CHECKED_OUT
-                self._checkout_source = "automatic"
-                self._checkout_time = self._tracked_event_end
-                if (
-                    self._tracked_event_summary is not None
-                    and self._tracked_event_start is not None
-                ):
-                    self._checked_out_event_key = self._event_key(
-                        self._tracked_event_summary,
-                        self._tracked_event_start,
-                    )
-                self._compute_linger_timing()
-                self.async_write_ha_state()
-            else:
-                # Still valid checked_in — reschedule auto-checkout timer
-                if self._tracked_event_end is not None:
-                    self._cancel_timer()
-                    self._schedule_auto_checkout(self._tracked_event_end)
-                else:
-                    self._cancel_timer()
-                    self._transition_target_time = None
-                self.async_write_ha_state()
-
-        elif current_state == CHECKIN_STATE_AWAITING:
-            if (
-                self._tracked_event_start is not None
-                and self._tracked_event_start <= now
-                and not self._is_keymaster_monitoring_enabled()
-            ):
-                # Event start passed while we were down → silent checkin
-                # (no HA bus event to avoid triggering automations on
-                # restart catch-up).  Skipped when keymaster monitoring
-                # is enabled — the guest must use their door code.
-                _LOGGER.debug(
-                    "Stale restore: awaiting_checkin but start passed, "
-                    "transitioning to checked_in (silent)"
-                )
-                self._state = CHECKIN_STATE_CHECKED_IN
-                self._checkin_source = "automatic"
-                self._cancel_timer()
-                self._transition_target_time = None
-                if (
-                    self._tracked_event_end is not None
-                    and self._tracked_event_end <= now
-                ):
-                    # Event also ended — silent checkout too
-                    self._state = CHECKIN_STATE_CHECKED_OUT
-                    self._checkout_source = "automatic"
-                    self._checkout_time = self._tracked_event_end
-                    if (
-                        self._tracked_event_summary is not None
-                        and self._tracked_event_start is not None
-                    ):
-                        self._checked_out_event_key = self._event_key(
-                            self._tracked_event_summary,
-                            self._tracked_event_start,
-                        )
-                    self._compute_linger_timing()
-                elif self._tracked_event_end is not None:
-                    self._schedule_auto_checkout(self._tracked_event_end)
-                self.async_write_ha_state()
-            else:
-                # Still valid awaiting — reschedule auto-checkin timer
-                if self._tracked_event_start is not None:
-                    self._cancel_timer()
-                    self._transition_target_time = self._tracked_event_start
-                    self._unsub_timer = async_track_point_in_time(
-                        self._hass,
-                        self._async_auto_checkin_callback,
-                        self._tracked_event_start,
-                    )
-                else:
-                    self._cancel_timer()
-                    self._transition_target_time = None
-                self.async_write_ha_state()
-
-        elif current_state == CHECKIN_STATE_CHECKED_OUT:
-            # Per spec acceptance scenario US2-4: if a genuinely new
-            # event is now relevant (different from the checked-out
-            # event), skip linger and transition to awaiting for it.
-            event = self._get_relevant_event()
-            if event is not None:
-                event_key = self._event_key(event.summary, event.start)
-                if event_key != self._checked_out_event_key:
-                    _LOGGER.debug(
-                        "Stale restore: checked_out but new event "
-                        "available, transitioning to awaiting_checkin"
-                    )
-                    self._transition_to_awaiting(event)
-                    return
-
-            # No new event (or same checked-out event). Check if the
-            # linger period has expired while HA was down.
-            linger_expired = False
-            if (
-                self._transition_target_time is not None
-                and self._transition_target_time <= now
-            ):
-                linger_expired = True
-            elif self._checkout_time is not None:
-                # No stored transition target — conservatively use the
-                # cleaning window to determine expiry.
-                cleaning_hours = self._get_cleaning_window()
-                linger_expired = (
-                    self._checkout_time + timedelta(hours=cleaning_hours)
-                ) <= now
-
-            if linger_expired:
-                _LOGGER.debug(
-                    "Stale restore: checked_out and linger expired, "
-                    "transitioning to no_reservation"
-                )
-                self._transition_to_no_reservation()
-            elif (
-                self.coordinator.last_update_success
-                and self.coordinator.data is not None
-            ):
-                # Reschedule linger timer based on restored checkout time
-                # and current coordinator data.
-                self._compute_linger_timing()
-                self.async_write_ha_state()
-            else:
-                # Linger has not expired — reschedule the linger timer
-                # so we will transition out of checked_out once the
-                # window ends.
-                self._compute_linger_timing()
-                self.async_write_ha_state()
-
-        elif current_state == CHECKIN_STATE_NO_RESERVATION:
-            # FR-006c: Reschedule follow-up timer if pending
-            if (
-                self._next_event_start_day is not None
-                and self._next_event_start_day > now
-            ):
-                self._cancel_timer()
-                self._transition_target_time = self._next_event_start_day
-                self._unsub_timer = async_track_point_in_time(
-                    self._hass,
-                    self._async_no_reservation_to_awaiting_callback,
-                    self._next_event_start_day,
-                )
-                _LOGGER.debug(
-                    "Restored FR-006c follow-up timer at %s for %s",
-                    self._next_event_start_day.isoformat(),
-                    self.coordinator.name,
-                )
-            elif self._next_event_start_day is not None:
-                # Follow-up time already passed — clear stale data
-                self._next_event_start_day = None
-                self._transition_target_time = None
-            self.async_write_ha_state()
-
-        else:
-            # Unknown or corrupted state — reset to no_reservation
-            _LOGGER.warning(
-                "Unknown restored state '%s', resetting to no_reservation",
-                current_state,
-            )
-            self._transition_to_no_reservation()
+    def _apply_silent_checked_out(
+        self, source: str, checkout_time: datetime | None
+    ) -> None:
+        """Apply a restore-silent checked-out transition."""
+        runtime.apply_silent_checked_out(self, source, checkout_time)
 
     async def async_will_remove_from_hass(self) -> None:
         """Clean up when entity is being removed."""
@@ -1551,136 +389,11 @@ class CheckinTrackingSensor(
 
     @callback
     def async_handle_keymaster_unlock(
-        self,
-        code_slot_num: int,
-        lock_name: str = "",
+        self, code_slot_num: int, lock_name: str = ""
     ) -> None:
-        """Handle a keymaster unlock event.
-
-        Called by the event bus listener after validating lockname,
-        state, slot range, and monitoring switch is on.  This method
-        performs remaining sensor-level checks:
-
-        - ``code_slot_num != 0`` (FR-017: ignore manual/RF unlocks)
-        - ``code_slot_num`` is within the managed slot range
-        - Sensor is in ``awaiting_checkin`` state and overrides are
-          ready: reject if the slot's guest name does not match the
-          tracked event (defense-in-depth against wrong-event check-in)
-        - Sensor is in ``awaiting_checkin`` state → transition to
-          checked_in
-        - Sensor is in ``checked_in`` state → ignored (early checkout
-          expiry is handled by ``async_checkout`` per FR-022/FR-023)
-
-        Args:
-            code_slot_num: The keymaster code slot number that was used.
-            lock_name: The lockname from the keymaster event (parent or child).
-        """
-        # FR-017: Ignore manual/RF unlocks (code_slot_num == 0)
-        if code_slot_num == 0:
-            _LOGGER.debug("Ignoring keymaster unlock: code_slot_num == 0 (manual/RF)")
-            return
-
-        start_slot = self.coordinator.start_slot
-        max_events = self.coordinator.max_events
-        if not (start_slot <= code_slot_num < start_slot + max_events):
-            _LOGGER.debug(
-                "Ignoring keymaster unlock: code_slot_num %d outside "
-                "managed range [%d, %d)",
-                code_slot_num,
-                start_slot,
-                start_slot + max_events,
-            )
-            return
-
-        # Unlock while checked_in is ignored — early expiry is handled
-        # by async_checkout per FR-022/FR-023
-        if self._state == CHECKIN_STATE_CHECKED_IN:
-            tracked_slot = 0
-            if self._tracked_event_slot_name and self.coordinator.event_overrides:
-                tracked_slot = self.coordinator.event_overrides.get_slot_key_by_name(
-                    self._tracked_event_slot_name
-                )
-            if tracked_slot != code_slot_num:
-                _LOGGER.debug(
-                    "Ignoring keymaster unlock: code_slot_num %d "
-                    "does not match tracked event slot %d",
-                    code_slot_num,
-                    tracked_slot,
-                )
-                return
-            return
-
-        # Only process check-in when in awaiting_checkin state
-        if self._state != CHECKIN_STATE_AWAITING:
-            _LOGGER.debug(
-                "Ignoring keymaster unlock: sensor state is %s, not awaiting_checkin",
-                self._state,
-            )
-            return
-
-        # Validate unlock slot matches tracked event when overrides
-        # are ready.  If the slot belongs to a different guest, reject
-        # to prevent checking in the wrong event (defense-in-depth for
-        # the awaiting re-evaluation logic).
-        if self.coordinator.event_overrides and self.coordinator.event_overrides.ready:
-            incoming_slot_name = self.coordinator.event_overrides.get_slot_name(
-                code_slot_num
-            )
-            if (
-                incoming_slot_name
-                and self._tracked_event_slot_name
-                and incoming_slot_name != self._tracked_event_slot_name
-            ):
-                _LOGGER.debug(
-                    "Ignoring keymaster unlock: slot %d belongs to "
-                    "'%s' but tracked event is for '%s'",
-                    code_slot_num,
-                    incoming_slot_name,
-                    self._tracked_event_slot_name,
-                )
-                return
-
-        # All conditions met — transition to checked_in
-        _LOGGER.info(
-            "Keymaster unlock detected for slot %d (lock=%s), "
-            "transitioning to checked_in for %s",
-            code_slot_num,
-            lock_name or self.coordinator.lockname,
-            self._tracked_event_summary,
-        )
-        self._transition_to_checked_in(source="keymaster", lock_name=lock_name)
+        """Handle a keymaster unlock event."""
+        runtime.handle_keymaster_unlock(self, code_slot_num, lock_name)
 
     async def _async_update_lock_code_expiry(self, new_end: datetime) -> None:
-        """Update keymaster lock code expiry after early checkout.
-
-        Calls the ``datetime.set_value`` service to shorten the
-        lock-code date-range end so the physical code expires at
-        *new_end* instead of the original reservation end.
-        """
-        if self._tracked_event_slot_name is None:
-            return
-
-        if not self.coordinator.event_overrides:
-            return
-
-        slot = self.coordinator.event_overrides.get_slot_key_by_name(
-            self._tracked_event_slot_name
-        )
-        lockname = self.coordinator.lockname
-        if not slot or not lockname:
-            return
-
-        coro = add_call(
-            self._hass,
-            [],
-            DATETIME,
-            "set_value",
-            f"datetime.{lockname}_code_slot_{slot}_date_range_end",
-            {"datetime": new_end.isoformat()},
-        )
-        results = await asyncio.gather(*coro, return_exceptions=True)
-        check_gather_results(
-            results,
-            "Early checkout lock code expiry update",
-            _LOGGER,
-        )
+        """Update keymaster lock code expiry after early checkout."""
+        await runtime.async_update_lock_code_expiry(self, new_end)

--- a/specs/014-decompose-checkinsensor/tasks.md
+++ b/specs/014-decompose-checkinsensor/tasks.md
@@ -20,7 +20,7 @@ and user stories from the specification. Implementation must keep
 Assistant entity shell while moving behavior into the internal
 `custom_components/rental_control/sensors/checkin/` package.
 
-## Format: `- [ ] T### [P?] [Story?] Description with file path`
+## Format: `- [x] T### [P?] [Story?] Description with file path`
 
 - **[P]**: Can run in parallel (different files, no dependency on incomplete
   tasks)
@@ -82,14 +82,14 @@ New focused tests live in `tests/unit/test_checkin_decisions.py`,
 **Purpose**: Establish the behavior and complexity baseline before changing any
 production code.
 
-- [ ] T001 Run `.specify/scripts/bash/check-prerequisites.sh --json` with `SPECIFY_FEATURE=014-decompose-checkinsensor` from the repository root and confirm `specs/014-decompose-checkinsensor/` reports `research.md`, `data-model.md`, and `quickstart.md`
-- [ ] T002 Inspect US1-US4, FR-001 through FR-014, and SC-001 through SC-008 in `specs/014-decompose-checkinsensor/spec.md`
-- [ ] T003 Inspect the Project Structure and Concrete Decomposition Design in `specs/014-decompose-checkinsensor/plan.md`
-- [ ] T004 Inspect R-001 through R-005, all data-model entities, and quickstart validation scenarios in `specs/014-decompose-checkinsensor/research.md`, `specs/014-decompose-checkinsensor/data-model.md`, and `specs/014-decompose-checkinsensor/quickstart.md`
-- [ ] T005 Inventory live `CheckinExtraStoredData`, `_handle_coordinator_update`, event-selection helpers, transition methods, timer callbacks, `_validate_restored_state`, `async_checkout`, `async_set_state`, and `async_handle_keymaster_unlock` in `custom_components/rental_control/sensors/checkinsensor.py`
-- [ ] T006 Inventory existing parity coverage for persistence, restore, timers, Keymaster unlocks, debug overrides, and lifecycle behavior in `tests/unit/test_checkin_sensor.py` and `tests/integration/test_checkin_tracking.py`
-- [ ] T007 Run unchanged baseline parity tests with `uv run pytest tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py tests/unit/test_keymaster_event_diagnostics.py tests/unit/test_sensors.py tests/integration/test_full_setup.py -q` against the listed test files
-- [ ] T008 Record the current line, function-length, and initializer-parameter baseline for `custom_components/rental_control/sensors/checkinsensor.py` in the implementation PR notes, including that `CheckinTrackingSensor.__init__` has only `hass`, `coordinator`, and `config_entry`
+- [x] T001 Run `.specify/scripts/bash/check-prerequisites.sh --json` with `SPECIFY_FEATURE=014-decompose-checkinsensor` from the repository root and confirm `specs/014-decompose-checkinsensor/` reports `research.md`, `data-model.md`, and `quickstart.md`
+- [x] T002 Inspect US1-US4, FR-001 through FR-014, and SC-001 through SC-008 in `specs/014-decompose-checkinsensor/spec.md`
+- [x] T003 Inspect the Project Structure and Concrete Decomposition Design in `specs/014-decompose-checkinsensor/plan.md`
+- [x] T004 Inspect R-001 through R-005, all data-model entities, and quickstart validation scenarios in `specs/014-decompose-checkinsensor/research.md`, `specs/014-decompose-checkinsensor/data-model.md`, and `specs/014-decompose-checkinsensor/quickstart.md`
+- [x] T005 Inventory live `CheckinExtraStoredData`, `_handle_coordinator_update`, event-selection helpers, transition methods, timer callbacks, `_validate_restored_state`, `async_checkout`, `async_set_state`, and `async_handle_keymaster_unlock` in `custom_components/rental_control/sensors/checkinsensor.py`
+- [x] T006 Inventory existing parity coverage for persistence, restore, timers, Keymaster unlocks, debug overrides, and lifecycle behavior in `tests/unit/test_checkin_sensor.py` and `tests/integration/test_checkin_tracking.py`
+- [x] T007 Run unchanged baseline parity tests with `uv run pytest tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py tests/unit/test_keymaster_event_diagnostics.py tests/unit/test_sensors.py tests/integration/test_full_setup.py -q` against the listed test files
+- [x] T008 Record the current line, function-length, and initializer-parameter baseline for `custom_components/rental_control/sensors/checkinsensor.py` in the implementation PR notes, including that `CheckinTrackingSensor.__init__` has only `hass`, `coordinator`, and `config_entry`
 
 ---
 
@@ -103,19 +103,19 @@ Models must land before modules that import them.
 
 ### Foundational Tests
 
-- [ ] T009 [P] Add stored-dict contract tests for exact keys, ISO datetime output, missing-field defaults, invalid datetime warnings, `checkin_lock_name`, and `next_event_start_day` in `tests/unit/test_checkin_persistence.py`
-- [ ] T010 Add snapshot round-trip and legacy keyword-construction tests proving `CheckinExtraStoredData` targets the persisted-data initializer, not `CheckinTrackingSensor.__init__`, in `tests/unit/test_checkin_persistence.py`
-- [ ] T011 [P] Add event-key, relevant-event, tracked-event, follow-on, checked-out-key exclusion, coordinator-order, and slot-name extraction tests in `tests/unit/test_checkin_decisions.py`
+- [x] T009 [P] Add stored-dict contract tests for exact keys, ISO datetime output, missing-field defaults, invalid datetime warnings, `checkin_lock_name`, and `next_event_start_day` in `tests/unit/test_checkin_persistence.py`
+- [x] T010 Add snapshot round-trip and legacy keyword-construction tests proving `CheckinExtraStoredData` targets the persisted-data initializer, not `CheckinTrackingSensor.__init__`, in `tests/unit/test_checkin_persistence.py`
+- [x] T011 [P] Add event-key, relevant-event, tracked-event, follow-on, checked-out-key exclusion, coordinator-order, and slot-name extraction tests in `tests/unit/test_checkin_decisions.py`
 
 ### Foundational Implementation
 
-- [ ] T012 Add `custom_components/rental_control/sensors/checkin/__init__.py` with SPDX headers, a module docstring, and typed exports for the internal check-in helper package
-- [ ] T013 Add `CheckinStateSnapshot`, `CoordinatorUpdateContext`, `DecisionEffect`, `LogIntent`, `TransitionDecision`, `RestoreReconciliationDecision`, `ScheduledTransition`, state constants, and timer-purpose value types in `custom_components/rental_control/sensors/checkin/models.py`
-- [ ] T014 [P] Move `CheckinExtraStoredData` into `custom_components/rental_control/sensors/checkin/persistence.py` with `from_snapshot()`, snapshot-based construction, legacy keyword compatibility, unchanged `from_dict()`, and unchanged `as_dict()` output
-- [ ] T015 Re-export `CheckinExtraStoredData` from `custom_components/rental_control/sensors/checkinsensor.py` and update `extra_restore_state_data` to use `CheckinStateSnapshot` without changing the stored-dict contract in `custom_components/rental_control/sensors/checkinsensor.py`
-- [ ] T016 [P] Extract `_event_key`, `_get_relevant_event`, `_find_tracked_event`, `_find_followon_event`, and `_extract_slot_name` behavior into `custom_components/rental_control/sensors/checkin/event_selection.py` without changing event scan ordering or checked-out event exclusion
-- [ ] T017 Wire `custom_components/rental_control/sensors/checkinsensor.py` to delegate event-selection calls to `custom_components/rental_control/sensors/checkin/event_selection.py` while preserving private helper compatibility for existing tests
-- [ ] T018 Run foundational validation with `uv run pytest tests/unit/test_checkin_persistence.py tests/unit/test_checkin_decisions.py tests/unit/test_checkin_sensor.py -q` against the listed test files
+- [x] T012 Add `custom_components/rental_control/sensors/checkin/__init__.py` with SPDX headers, a module docstring, and typed exports for the internal check-in helper package
+- [x] T013 Add `CheckinStateSnapshot`, `CoordinatorUpdateContext`, `DecisionEffect`, `LogIntent`, `TransitionDecision`, `RestoreReconciliationDecision`, `ScheduledTransition`, state constants, and timer-purpose value types in `custom_components/rental_control/sensors/checkin/models.py`
+- [x] T014 [P] Move `CheckinExtraStoredData` into `custom_components/rental_control/sensors/checkin/persistence.py` with `from_snapshot()`, snapshot-based construction, legacy keyword compatibility, unchanged `from_dict()`, and unchanged `as_dict()` output
+- [x] T015 Re-export `CheckinExtraStoredData` from `custom_components/rental_control/sensors/checkinsensor.py` and update `extra_restore_state_data` to use `CheckinStateSnapshot` without changing the stored-dict contract in `custom_components/rental_control/sensors/checkinsensor.py`
+- [x] T016 [P] Extract `_event_key`, `_get_relevant_event`, `_find_tracked_event`, `_find_followon_event`, and `_extract_slot_name` behavior into `custom_components/rental_control/sensors/checkin/event_selection.py` without changing event scan ordering or checked-out event exclusion
+- [x] T017 Wire `custom_components/rental_control/sensors/checkinsensor.py` to delegate event-selection calls to `custom_components/rental_control/sensors/checkin/event_selection.py` while preserving private helper compatibility for existing tests
+- [x] T018 Run foundational validation with `uv run pytest tests/unit/test_checkin_persistence.py tests/unit/test_checkin_decisions.py tests/unit/test_checkin_sensor.py -q` against the listed test files
 
 **Checkpoint**: The internal package exists, persistence remains backward
 compatible, event selection is pure and covered, and the entity shell still
@@ -138,19 +138,19 @@ log intents, and timer intents match the pre-refactor behavior.
 > **NOTE: Add focused tests for extracted decisions first. Existing parity tests
 > must keep their behavior assertions unchanged.**
 
-- [ ] T019 [US1] Add `no_reservation` and `awaiting_checkin` coordinator-decision tests for no-op writes, awaiting transitions, mutable tracked-field refresh, earlier-event replacement, cancelled-event fallback, automatic check-in with monitoring off, and monitoring-on deferral in `tests/unit/test_checkin_decisions.py`
-- [ ] T020 [US1] Add `checked_in` coordinator-decision tests for tracked-event refresh, far-future self-healing checkout-then-awaiting ordering, ended-event safety checkout, changed-end auto-checkout reschedule, transient missing-event warning/debug preservation, and missing-all-tracking reset in `tests/unit/test_checkin_decisions.py`
-- [ ] T021 [US1] Add `checked_out` coordinator-decision tests for same follow-on no-op/write, changed follow-on recompute, removed follow-on recompute, no-active-timer recompute, and checked-out event-key exclusion in `tests/unit/test_checkin_decisions.py`
-- [ ] T022 [US1] Add shell/applicator compatibility tests that exercise `_transition_to_awaiting`, `_transition_to_checked_in`, `_transition_to_checked_out`, `_transition_to_no_reservation`, `async_checkout`, `async_set_state`, and `async_handle_keymaster_unlock` in `tests/unit/test_checkin_sensor.py`
+- [x] T019 [US1] Add `no_reservation` and `awaiting_checkin` coordinator-decision tests for no-op writes, awaiting transitions, mutable tracked-field refresh, earlier-event replacement, cancelled-event fallback, automatic check-in with monitoring off, and monitoring-on deferral in `tests/unit/test_checkin_decisions.py`
+- [x] T020 [US1] Add `checked_in` coordinator-decision tests for tracked-event refresh, far-future self-healing checkout-then-awaiting ordering, ended-event safety checkout, changed-end auto-checkout reschedule, transient missing-event warning/debug preservation, and missing-all-tracking reset in `tests/unit/test_checkin_decisions.py`
+- [x] T021 [US1] Add `checked_out` coordinator-decision tests for same follow-on no-op/write, changed follow-on recompute, removed follow-on recompute, no-active-timer recompute, and checked-out event-key exclusion in `tests/unit/test_checkin_decisions.py`
+- [x] T022 [US1] Add shell/applicator compatibility tests that exercise `_transition_to_awaiting`, `_transition_to_checked_in`, `_transition_to_checked_out`, `_transition_to_no_reservation`, `async_checkout`, `async_set_state`, and `async_handle_keymaster_unlock` in `tests/unit/test_checkin_sensor.py`
 
 ### Implementation for User Story 1
 
-- [ ] T023 [US1] Implement `decide_coordinator_update`, `decide_no_reservation_update`, and `decide_awaiting_update` in `custom_components/rental_control/sensors/checkin/transition_decisions.py` using `CheckinStateSnapshot` and `CoordinatorUpdateContext` only
-- [ ] T024 [US1] Implement `decide_checked_in_update` and `decide_checked_out_update` in `custom_components/rental_control/sensors/checkin/transition_decisions.py`, preserving self-healing effect ordering, log levels, and write intents
-- [ ] T025 [US1] Implement coordinator-update effect application in `custom_components/rental_control/sensors/checkin/applicator.py` so HA bus events, service calls, timers, `async_write_ha_state()`, and mutation remain owned by the entity shell
-- [ ] T026 [US1] Replace `_handle_coordinator_update` in `custom_components/rental_control/sensors/checkinsensor.py` with a wrapper below 80 lines that logs, handles failed coordinator updates, builds the context, calls `decide_coordinator_update`, applies ordered effects, and writes state only where the old path did
-- [ ] T027 [US1] Preserve state, icon, `extra_state_attributes`, device metadata, service-facing behavior, debug override clearing, Keymaster-unlock-triggered check-in, and private transition-method compatibility in `custom_components/rental_control/sensors/checkinsensor.py`
-- [ ] T028 [US1] Run US1 validation with `uv run pytest tests/unit/test_checkin_decisions.py tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py -q` against the listed test files
+- [x] T023 [US1] Implement `decide_coordinator_update`, `decide_no_reservation_update`, and `decide_awaiting_update` in `custom_components/rental_control/sensors/checkin/transition_decisions.py` using `CheckinStateSnapshot` and `CoordinatorUpdateContext` only
+- [x] T024 [US1] Implement `decide_checked_in_update` and `decide_checked_out_update` in `custom_components/rental_control/sensors/checkin/transition_decisions.py`, preserving self-healing effect ordering, log levels, and write intents
+- [x] T025 [US1] Implement coordinator-update effect application in `custom_components/rental_control/sensors/checkin/applicator.py` so HA bus events, service calls, timers, `async_write_ha_state()`, and mutation remain owned by the entity shell
+- [x] T026 [US1] Replace `_handle_coordinator_update` in `custom_components/rental_control/sensors/checkinsensor.py` with a wrapper below 80 lines that logs, handles failed coordinator updates, builds the context, calls `decide_coordinator_update`, applies ordered effects, and writes state only where the old path did
+- [x] T027 [US1] Preserve state, icon, `extra_state_attributes`, device metadata, service-facing behavior, debug override clearing, Keymaster-unlock-triggered check-in, and private transition-method compatibility in `custom_components/rental_control/sensors/checkinsensor.py`
+- [x] T028 [US1] Run US1 validation with `uv run pytest tests/unit/test_checkin_decisions.py tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py -q` against the listed test files
 
 **Checkpoint**: US1 proves FR-001, FR-002, FR-003, FR-004, FR-009, FR-010,
 FR-011, FR-013, FR-014, SC-001, SC-002, SC-006, and SC-007 for coordinator
@@ -170,17 +170,17 @@ data, silent event behavior, and HA state writes match the current source.
 
 ### Tests for User Story 2
 
-- [ ] T029 [US2] Add restored `checked_in` and `awaiting_checkin` decision tests for ended events, far-future self-healing, valid auto-checkout reschedule, missing end handling, silent automatic check-in, immediate silent checkout, monitoring-on deferral, valid auto-check-in reschedule, and missing start cleanup in `tests/unit/test_checkin_restore.py`
-- [ ] T030 [US2] Add restored `checked_out`, `no_reservation`, and unknown-state decision tests for new-event handoff, expired linger reset, linger recompute, future FR-006c follow-up timer recreation, stale follow-up cleanup, and unknown-state reset in `tests/unit/test_checkin_restore.py`
-- [ ] T031 [US2] Add restore shell parity tests proving no check-in or checkout bus events fire during silent restore catch-up and `async_added_to_hass()` still runs the non-silent coordinator-update second pass when coordinator data exists in `tests/unit/test_checkin_sensor.py`
+- [x] T029 [US2] Add restored `checked_in` and `awaiting_checkin` decision tests for ended events, far-future self-healing, valid auto-checkout reschedule, missing end handling, silent automatic check-in, immediate silent checkout, monitoring-on deferral, valid auto-check-in reschedule, and missing start cleanup in `tests/unit/test_checkin_restore.py`
+- [x] T030 [US2] Add restored `checked_out`, `no_reservation`, and unknown-state decision tests for new-event handoff, expired linger reset, linger recompute, future FR-006c follow-up timer recreation, stale follow-up cleanup, and unknown-state reset in `tests/unit/test_checkin_restore.py`
+- [x] T031 [US2] Add restore shell parity tests proving no check-in or checkout bus events fire during silent restore catch-up and `async_added_to_hass()` still runs the non-silent coordinator-update second pass when coordinator data exists in `tests/unit/test_checkin_sensor.py`
 
 ### Implementation for User Story 2
 
-- [ ] T032 [US2] Implement `decide_restore_state`, `decide_restore_checked_in`, and `decide_restore_awaiting` in `custom_components/rental_control/sensors/checkin/restore_decisions.py` with silent effects and source-equivalent time checks
-- [ ] T033 [US2] Implement `decide_restore_checked_out`, `decide_restore_no_reservation`, and `decide_restore_unknown` in `custom_components/rental_control/sensors/checkin/restore_decisions.py`, preserving warning/reset and follow-up timer semantics
-- [ ] T034 [US2] Implement restore-silent effect application in `custom_components/rental_control/sensors/checkin/applicator.py`, reusing ordered effects without firing HA check-in or checkout bus events during restore reconciliation
-- [ ] T035 [US2] Replace `_validate_restored_state` in `custom_components/rental_control/sensors/checkinsensor.py` with a wrapper below 80 lines and preserve `async_added_to_hass()` restored-data loading plus current-data second-pass behavior
-- [ ] T036 [US2] Run US2 validation with `uv run pytest tests/unit/test_checkin_restore.py tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py -q` against the listed test files
+- [x] T032 [US2] Implement `decide_restore_state`, `decide_restore_checked_in`, and `decide_restore_awaiting` in `custom_components/rental_control/sensors/checkin/restore_decisions.py` with silent effects and source-equivalent time checks
+- [x] T033 [US2] Implement `decide_restore_checked_out`, `decide_restore_no_reservation`, and `decide_restore_unknown` in `custom_components/rental_control/sensors/checkin/restore_decisions.py`, preserving warning/reset and follow-up timer semantics
+- [x] T034 [US2] Implement restore-silent effect application in `custom_components/rental_control/sensors/checkin/applicator.py`, reusing ordered effects without firing HA check-in or checkout bus events during restore reconciliation
+- [x] T035 [US2] Replace `_validate_restored_state` in `custom_components/rental_control/sensors/checkinsensor.py` with a wrapper below 80 lines and preserve `async_added_to_hass()` restored-data loading plus current-data second-pass behavior
+- [x] T036 [US2] Run US2 validation with `uv run pytest tests/unit/test_checkin_restore.py tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py -q` against the listed test files
 
 **Checkpoint**: US2 proves FR-001, FR-002, FR-005, FR-007, FR-010, FR-013,
 FR-014, SC-001, SC-002, SC-003, and SC-006 for restore reconciliation.
@@ -200,16 +200,16 @@ cleanup while asserting the same target times and cancellation order.
 
 ### Tests for User Story 3
 
-- [ ] T037 [US3] Add `CheckinTimerManager` unit tests for cancel-before-replace, one active handle, callback-entry handle clearing, stale callback no-op guards, and entity-removal cleanup in `tests/unit/test_checkin_timers.py`
-- [ ] T038 [US3] Add timer target parity tests for auto-check-in, auto-checkout, same-day midpoint, different-day midnight, cleaning-window linger, and FR-006c follow-up timers in `tests/unit/test_checkin_timers.py`
-- [ ] T039 [US3] Add or confirm integration parity tests for time-change-driven callbacks, duplicate-callback prevention, manual checkout cancellation, debug `async_set_state` timer clearing, and restored pending timers in `tests/integration/test_checkin_tracking.py`
+- [x] T037 [US3] Add `CheckinTimerManager` unit tests for cancel-before-replace, one active handle, callback-entry handle clearing, stale callback no-op guards, and entity-removal cleanup in `tests/unit/test_checkin_timers.py`
+- [x] T038 [US3] Add timer target parity tests for auto-check-in, auto-checkout, same-day midpoint, different-day midnight, cleaning-window linger, and FR-006c follow-up timers in `tests/unit/test_checkin_timers.py`
+- [x] T039 [US3] Add or confirm integration parity tests for time-change-driven callbacks, duplicate-callback prevention, manual checkout cancellation, debug `async_set_state` timer clearing, and restored pending timers in `tests/integration/test_checkin_tracking.py`
 
 ### Implementation for User Story 3
 
-- [ ] T040 [US3] Implement `CheckinTimerManager` in `custom_components/rental_control/sensors/checkin/timers.py` using `async_track_point_in_time()`, one unsubscribe handle, cancel-before-replace, callback handle clearing, and `ScheduledTransition` metadata
-- [ ] T041 [US3] Move auto-check-in, auto-checkout, linger-to-awaiting, linger-to-no-reservation, and no-reservation-to-awaiting scheduling through `CheckinTimerManager` while preserving state guards in `custom_components/rental_control/sensors/checkinsensor.py`
-- [ ] T042 [US3] Preserve transition target, follow-up day, linger follow-on key, linger baseline, `async_will_remove_from_hass`, `async_set_state`, manual checkout, and state-exit cancellation ordering in `custom_components/rental_control/sensors/checkinsensor.py`
-- [ ] T043 [US3] Run US3 validation with `uv run pytest tests/unit/test_checkin_timers.py tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py -q` against the listed test files
+- [x] T040 [US3] Implement `CheckinTimerManager` in `custom_components/rental_control/sensors/checkin/timers.py` using `async_track_point_in_time()`, one unsubscribe handle, cancel-before-replace, callback handle clearing, and `ScheduledTransition` metadata
+- [x] T041 [US3] Move auto-check-in, auto-checkout, linger-to-awaiting, linger-to-no-reservation, and no-reservation-to-awaiting scheduling through `CheckinTimerManager` while preserving state guards in `custom_components/rental_control/sensors/checkinsensor.py`
+- [x] T042 [US3] Preserve transition target, follow-up day, linger follow-on key, linger baseline, `async_will_remove_from_hass`, `async_set_state`, manual checkout, and state-exit cancellation ordering in `custom_components/rental_control/sensors/checkinsensor.py`
+- [x] T043 [US3] Run US3 validation with `uv run pytest tests/unit/test_checkin_timers.py tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py -q` against the listed test files
 
 **Checkpoint**: US3 proves FR-001, FR-002, FR-006, FR-008, FR-010, FR-013,
 FR-014, SC-001, SC-002, SC-004, SC-006, and SC-007 for timer behavior.
@@ -227,17 +227,17 @@ scope against the plan and issue #577.
 
 ### Tests for User Story 4
 
-- [ ] T044 [US4] Add final import-boundary tests proving `CheckinTrackingSensor` and `CheckinExtraStoredData` remain importable from `custom_components/rental_control/sensors/checkinsensor.py` while helper internals are importable from `custom_components/rental_control/sensors/checkin/` in `tests/unit/test_checkin_sensor.py`
-- [ ] T045 [US4] Add or confirm focused pure-helper tests can cover coordinator decisions, restore decisions, timer scheduling, and persistence without a full Home Assistant entity fixture in `tests/unit/test_checkin_decisions.py`, `tests/unit/test_checkin_restore.py`, `tests/unit/test_checkin_timers.py`, and `tests/unit/test_checkin_persistence.py`
+- [x] T044 [US4] Add final import-boundary tests proving `CheckinTrackingSensor` and `CheckinExtraStoredData` remain importable from `custom_components/rental_control/sensors/checkinsensor.py` while helper internals are importable from `custom_components/rental_control/sensors/checkin/` in `tests/unit/test_checkin_sensor.py`
+- [x] T045 [US4] Add or confirm focused pure-helper tests can cover coordinator decisions, restore decisions, timer scheduling, and persistence without a full Home Assistant entity fixture in `tests/unit/test_checkin_decisions.py`, `tests/unit/test_checkin_restore.py`, `tests/unit/test_checkin_timers.py`, and `tests/unit/test_checkin_persistence.py`
 
 ### Implementation for User Story 4
 
-- [ ] T046 [US4] Shrink `custom_components/rental_control/sensors/checkinsensor.py` to the HA entity shell responsibilities from PLAN, keeping lifecycle hooks, properties, service methods, event bus effects, state writes, coordinator subscription, private transition compatibility, and intentional compatibility re-exports only
-- [ ] T047 [US4] Ensure every project-owned function in `custom_components/rental_control/sensors/checkinsensor.py` and `custom_components/rental_control/sensors/checkin/*.py` is below 80 lines and split any remaining oversized helper without changing behavior
-- [ ] T048 [US4] Ensure `CheckinExtraStoredData.__init__` in `custom_components/rental_control/sensors/checkin/persistence.py` uses the snapshot-plus-legacy compatibility approach and every project-owned initializer in the check-in feature has no more than six explicit parameters
-- [ ] T049 [US4] Remove temporary extraction shims from `custom_components/rental_control/sensors/checkinsensor.py` and `custom_components/rental_control/sensors/checkin/*.py` after tests pass, leaving only the planned compatibility re-exports and private transition-method compatibility required by existing tests
-- [ ] T050 [US4] Confirm the final implementation diff is limited to `custom_components/rental_control/sensors/checkinsensor.py`, `custom_components/rental_control/sensors/checkin/`, `tests/unit/test_checkin_sensor.py`, `tests/unit/test_checkin_decisions.py`, `tests/unit/test_checkin_restore.py`, `tests/unit/test_checkin_timers.py`, `tests/unit/test_checkin_persistence.py`, and `tests/integration/test_checkin_tracking.py`
-- [ ] T051 [US4] Run US4 focused validation with `uv run pytest tests/unit/test_checkin_decisions.py tests/unit/test_checkin_restore.py tests/unit/test_checkin_timers.py tests/unit/test_checkin_persistence.py -q` against the listed test files
+- [x] T046 [US4] Shrink `custom_components/rental_control/sensors/checkinsensor.py` to the HA entity shell responsibilities from PLAN, keeping lifecycle hooks, properties, service methods, event bus effects, state writes, coordinator subscription, private transition compatibility, and intentional compatibility re-exports only
+- [x] T047 [US4] Ensure every project-owned function in `custom_components/rental_control/sensors/checkinsensor.py` and `custom_components/rental_control/sensors/checkin/*.py` is below 80 lines and split any remaining oversized helper without changing behavior
+- [x] T048 [US4] Ensure `CheckinExtraStoredData.__init__` in `custom_components/rental_control/sensors/checkin/persistence.py` uses the snapshot-plus-legacy compatibility approach and every project-owned initializer in the check-in feature has no more than six explicit parameters
+- [x] T049 [US4] Remove temporary extraction shims from `custom_components/rental_control/sensors/checkinsensor.py` and `custom_components/rental_control/sensors/checkin/*.py` after tests pass, leaving only the planned compatibility re-exports and private transition-method compatibility required by existing tests
+- [x] T050 [US4] Confirm the final implementation diff is limited to `custom_components/rental_control/sensors/checkinsensor.py`, `custom_components/rental_control/sensors/checkin/`, `tests/unit/test_checkin_sensor.py`, `tests/unit/test_checkin_decisions.py`, `tests/unit/test_checkin_restore.py`, `tests/unit/test_checkin_timers.py`, `tests/unit/test_checkin_persistence.py`, and `tests/integration/test_checkin_tracking.py`
+- [x] T051 [US4] Run US4 focused validation with `uv run pytest tests/unit/test_checkin_decisions.py tests/unit/test_checkin_restore.py tests/unit/test_checkin_timers.py tests/unit/test_checkin_persistence.py -q` against the listed test files
 
 **Checkpoint**: US4 proves FR-002, FR-004, FR-005, FR-006, FR-007, FR-012,
 FR-013, FR-014, SC-003, SC-005, SC-006, and SC-007.
@@ -251,18 +251,18 @@ traceability, and no unintended production behavior changes.
 
 ### Acceptance and Quality Gates
 
-- [ ] T052 Run unchanged existing check-in parity tests with `uv run pytest tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py -q` against the listed test files
-- [ ] T053 Run unchanged call-site coverage with `uv run pytest tests/unit/test_keymaster_event_diagnostics.py tests/unit/test_sensors.py tests/integration/test_full_setup.py -q` against the listed test files
-- [ ] T054 Run all new focused helper tests with `uv run pytest tests/unit/test_checkin_decisions.py tests/unit/test_checkin_restore.py tests/unit/test_checkin_timers.py tests/unit/test_checkin_persistence.py -q` against the listed test files
-- [ ] T055 Verify every FR-001 through FR-014 has a test, implementation, or acceptance task mapped in `specs/014-decompose-checkinsensor/tasks.md`
-- [ ] T056 Verify every SC-001 through SC-008 has a test, implementation, or acceptance task mapped in `specs/014-decompose-checkinsensor/tasks.md`
-- [ ] T057 Confirm no new check-in states, HA events, configuration options, service contracts, event payload fields, timing rules, or unrelated Rental Control public APIs were introduced in `custom_components/rental_control/sensors/checkinsensor.py` and `custom_components/rental_control/sensors/checkin/*.py`
-- [ ] T058 Stage the implementation files and run the staged aislop hook with `uv run pre-commit run aislop`; confirm `custom_components/rental_control/sensors/checkinsensor.py` is below 400 lines, all in-scope functions are below 80 lines, and project-owned initializers have no more than six explicit parameters
-- [ ] T059 Run full regression tests with `uv run pytest tests/` against `tests/`
-- [ ] T060 Run full regression tests with `uv run pytest tests/ -x -q` against `tests/` for the quickstart final validation command
-- [ ] T061 Run linting with `uv run ruff check custom_components/ tests/` against `custom_components/` and `tests/`
-- [ ] T062 Run full pre-commit validation with `uv run pre-commit run --all-files` against repository-tracked files, including reuse, yamllint, actionlint, aislop, ruff, ruff-format, mypy, and interrogate
-- [ ] T063 Review `specs/014-decompose-checkinsensor/quickstart.md` and confirm the implementation PR notes list the existing parity commands, new focused test commands, hot-path safeguards, and final validation results
+- [x] T052 Run unchanged existing check-in parity tests with `uv run pytest tests/unit/test_checkin_sensor.py tests/integration/test_checkin_tracking.py -q` against the listed test files
+- [x] T053 Run unchanged call-site coverage with `uv run pytest tests/unit/test_keymaster_event_diagnostics.py tests/unit/test_sensors.py tests/integration/test_full_setup.py -q` against the listed test files
+- [x] T054 Run all new focused helper tests with `uv run pytest tests/unit/test_checkin_decisions.py tests/unit/test_checkin_restore.py tests/unit/test_checkin_timers.py tests/unit/test_checkin_persistence.py -q` against the listed test files
+- [x] T055 Verify every FR-001 through FR-014 has a test, implementation, or acceptance task mapped in `specs/014-decompose-checkinsensor/tasks.md`
+- [x] T056 Verify every SC-001 through SC-008 has a test, implementation, or acceptance task mapped in `specs/014-decompose-checkinsensor/tasks.md`
+- [x] T057 Confirm no new check-in states, HA events, configuration options, service contracts, event payload fields, timing rules, or unrelated Rental Control public APIs were introduced in `custom_components/rental_control/sensors/checkinsensor.py` and `custom_components/rental_control/sensors/checkin/*.py`
+- [x] T058 Stage the implementation files and run the staged aislop hook with `uv run pre-commit run aislop`; confirm `custom_components/rental_control/sensors/checkinsensor.py` is below 400 lines, all in-scope functions are below 80 lines, and project-owned initializers have no more than six explicit parameters
+- [x] T059 Run full regression tests with `uv run pytest tests/` against `tests/`
+- [x] T060 Run full regression tests with `uv run pytest tests/ -x -q` against `tests/` for the quickstart final validation command
+- [x] T061 Run linting with `uv run ruff check custom_components/ tests/` against `custom_components/` and `tests/`
+- [x] T062 Run full pre-commit validation with `uv run pre-commit run --all-files` against repository-tracked files, including reuse, yamllint, actionlint, aislop, ruff, ruff-format, mypy, and interrogate
+- [x] T063 Review `specs/014-decompose-checkinsensor/quickstart.md` and confirm the implementation PR notes list the existing parity commands, new focused test commands, hot-path safeguards, and final validation results
 
 ---
 

--- a/tests/unit/test_checkin_decisions.py
+++ b/tests/unit/test_checkin_decisions.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused coordinator decision tests for check-in helper modules."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+
+from homeassistant.components.calendar import CalendarEvent
+from homeassistant.util import dt as dt_util
+
+from custom_components.rental_control.const import CHECKIN_STATE_AWAITING
+from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_IN
+from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_OUT
+from custom_components.rental_control.const import CHECKIN_STATE_NO_RESERVATION
+from custom_components.rental_control.sensors.checkin.event_selection import event_key
+from custom_components.rental_control.sensors.checkin.event_selection import (
+    extract_slot_name,
+)
+from custom_components.rental_control.sensors.checkin.event_selection import (
+    find_followon_event,
+)
+from custom_components.rental_control.sensors.checkin.event_selection import (
+    find_tracked_event,
+)
+from custom_components.rental_control.sensors.checkin.event_selection import (
+    get_relevant_event,
+)
+from custom_components.rental_control.sensors.checkin.models import CheckinStateSnapshot
+from custom_components.rental_control.sensors.checkin.models import (
+    CoordinatorUpdateContext,
+)
+from custom_components.rental_control.sensors.checkin.transition_decisions import (
+    decide_coordinator_update,
+)
+
+NOW = datetime(2026, 6, 1, 12, tzinfo=dt_util.UTC)
+
+
+def _event(summary: str, start: datetime, end: datetime) -> CalendarEvent:
+    """Create a calendar event."""
+    return CalendarEvent(
+        summary=summary, start=start, end=end, description="Guest: Ada"
+    )
+
+
+def _ctx(
+    snapshot: CheckinStateSnapshot,
+    events: list[CalendarEvent],
+    monitoring: bool = False,
+) -> CoordinatorUpdateContext:
+    """Build a coordinator update context."""
+    return CoordinatorUpdateContext(
+        snapshot, events, lambda: NOW, True, monitoring, 2.0, "", False, "Rental"
+    )
+
+
+def test_event_selection_preserves_identity_order_and_slot_extraction() -> None:
+    """Event helper behavior matches the entity helper contract."""
+    old = _event("Old", NOW - timedelta(days=2), NOW - timedelta(days=1))
+    current = _event(
+        "Reserved - Ada", NOW + timedelta(hours=1), NOW + timedelta(days=1)
+    )
+    later = _event("Later", NOW + timedelta(days=2), NOW + timedelta(days=3))
+
+    assert event_key(current.summary, current.start).startswith("Reserved - Ada|")
+    assert get_relevant_event([old, current, later], NOW) == current
+    assert (
+        find_tracked_event([later, current], current.summary, current.start) == current
+    )
+    assert (
+        find_followon_event(
+            [current, later], NOW, event_key(current.summary, current.start)
+        )
+        == later
+    )
+    assert extract_slot_name(current, "") == "Ada"
+
+
+def test_no_reservation_with_event_transitions_to_awaiting() -> None:
+    """A relevant event produces an awaiting transition effect."""
+    event = _event("Reserved - Ada", NOW + timedelta(hours=1), NOW + timedelta(days=1))
+    decision = decide_coordinator_update(_ctx(CheckinStateSnapshot(), [event]))
+
+    assert [effect.kind for effect in decision.effects] == ["transition_awaiting"]
+    assert decision.effects[0].event == event
+
+
+def test_awaiting_past_start_checks_in_when_monitoring_off() -> None:
+    """Awaiting updates silently model automatic check-in eligibility."""
+    event = _event("Reserved - Ada", NOW - timedelta(hours=1), NOW + timedelta(days=1))
+    snapshot = CheckinStateSnapshot(CHECKIN_STATE_AWAITING, event.summary, event.start)
+    decision = decide_coordinator_update(_ctx(snapshot, [event], monitoring=False))
+
+    assert [effect.kind for effect in decision.effects] == [
+        "update_tracked_event",
+        "transition_checked_in",
+    ]
+
+
+def test_checked_in_changed_end_reschedules_checkout() -> None:
+    """Changed tracked end produces cancel-before-reschedule effects."""
+    event = _event("Reserved - Ada", NOW - timedelta(hours=1), NOW + timedelta(days=2))
+    snapshot = CheckinStateSnapshot(
+        CHECKIN_STATE_CHECKED_IN, event.summary, event.start, NOW + timedelta(days=1)
+    )
+    decision = decide_coordinator_update(_ctx(snapshot, [event]))
+
+    assert [effect.kind for effect in decision.effects][-2:] == [
+        "cancel_timer",
+        "schedule_auto_checkout",
+    ]
+    assert decision.write_state is True
+
+
+def test_checked_out_without_timer_recomputes_linger() -> None:
+    """Checked-out state recomputes linger when no active timer exists."""
+    snapshot = CheckinStateSnapshot(CHECKIN_STATE_CHECKED_OUT, checkout_time=NOW)
+    decision = decide_coordinator_update(_ctx(snapshot, []))
+
+    assert [effect.kind for effect in decision.effects] == ["compute_linger"]
+    assert decision.write_state is True
+
+
+def test_no_event_in_no_reservation_writes_only() -> None:
+    """No-reservation with no event requests only a state write."""
+    decision = decide_coordinator_update(
+        _ctx(CheckinStateSnapshot(CHECKIN_STATE_NO_RESERVATION), [])
+    )
+
+    assert decision.effects == ()
+    assert decision.write_state is True

--- a/tests/unit/test_checkin_persistence.py
+++ b/tests/unit/test_checkin_persistence.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused persistence tests for decomposed check-in sensor helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_IN
+from custom_components.rental_control.const import CHECKIN_STATE_NO_RESERVATION
+from custom_components.rental_control.sensors.checkin.models import CheckinStateSnapshot
+from custom_components.rental_control.sensors.checkin.persistence import (
+    CheckinExtraStoredData,
+)
+
+_EXPECTED_KEYS = {
+    "state",
+    "tracked_event_summary",
+    "tracked_event_start",
+    "tracked_event_end",
+    "tracked_event_slot_name",
+    "checkin_source",
+    "checkout_source",
+    "checkout_time",
+    "transition_target_time",
+    "checked_out_event_key",
+    "next_event_start_day",
+    "checkin_lock_name",
+}
+
+
+def _snapshot() -> CheckinStateSnapshot:
+    """Return a populated persistence snapshot."""
+    start = datetime(2026, 6, 1, 16, tzinfo=dt_util.UTC)
+    end = start + timedelta(days=3)
+    return CheckinStateSnapshot(
+        state=CHECKIN_STATE_CHECKED_IN,
+        tracked_event_summary="Reserved - Ada",
+        tracked_event_start=start,
+        tracked_event_end=end,
+        tracked_event_slot_name="Ada",
+        checkin_source="keymaster",
+        checkout_source=None,
+        checkout_time=None,
+        transition_target_time=end,
+        checked_out_event_key="Reserved - Ada|2026-06-01T16:00:00+00:00",
+        next_event_start_day=start,
+        checkin_lock_name="front_door",
+    )
+
+
+def test_as_dict_emits_exact_key_set_and_iso_datetimes() -> None:
+    """Stored data emits the legacy key set and ISO datetime strings."""
+    data = CheckinExtraStoredData.from_snapshot(_snapshot()).as_dict()
+
+    assert set(data) == _EXPECTED_KEYS
+    assert data["tracked_event_start"] == "2026-06-01T16:00:00+00:00"
+    assert data["transition_target_time"] == "2026-06-04T16:00:00+00:00"
+    assert data["checkin_lock_name"] == "front_door"
+
+
+def test_round_trip_and_legacy_keyword_construction() -> None:
+    """Round-trip and legacy keyword construction preserve fields."""
+    stored = CheckinExtraStoredData.from_snapshot(_snapshot())
+    restored = CheckinExtraStoredData.from_dict(stored.as_dict())
+    legacy = CheckinExtraStoredData(
+        **stored.as_dict()
+        | {
+            "tracked_event_start": _snapshot().tracked_event_start,
+            "tracked_event_end": _snapshot().tracked_event_end,
+            "transition_target_time": _snapshot().transition_target_time,
+            "next_event_start_day": _snapshot().next_event_start_day,
+        }
+    )
+
+    assert restored.as_dict() == stored.as_dict()
+    assert legacy.state == CHECKIN_STATE_CHECKED_IN
+
+
+def test_missing_fields_default_to_no_reservation() -> None:
+    """Older dictionaries with missing optional fields still load."""
+    restored = CheckinExtraStoredData.from_dict({})
+
+    assert restored.state == CHECKIN_STATE_NO_RESERVATION
+    assert restored.checkin_lock_name is None
+    assert restored.next_event_start_day is None
+
+
+def test_invalid_datetimes_log_warning(caplog) -> None:  # type: ignore[no-untyped-def]
+    """Invalid datetime strings log and restore as None."""
+    restored = CheckinExtraStoredData.from_dict({"tracked_event_start": "not-a-date"})
+
+    assert restored.tracked_event_start is None
+    assert "Failed to parse stored datetime" in caplog.text

--- a/tests/unit/test_checkin_restore.py
+++ b/tests/unit/test_checkin_restore.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused restore decision tests for check-in helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+
+from homeassistant.components.calendar import CalendarEvent
+from homeassistant.util import dt as dt_util
+
+from custom_components.rental_control.const import CHECKIN_STATE_AWAITING
+from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_IN
+from custom_components.rental_control.const import CHECKIN_STATE_CHECKED_OUT
+from custom_components.rental_control.const import CHECKIN_STATE_NO_RESERVATION
+from custom_components.rental_control.sensors.checkin.models import CheckinStateSnapshot
+from custom_components.rental_control.sensors.checkin.models import (
+    CoordinatorUpdateContext,
+)
+from custom_components.rental_control.sensors.checkin.restore_decisions import (
+    decide_restore_state,
+)
+
+NOW = datetime(2026, 6, 1, 12, tzinfo=dt_util.UTC)
+
+
+def _event() -> CalendarEvent:
+    """Return a future event."""
+    return CalendarEvent(
+        summary="Reserved - Ada",
+        start=NOW + timedelta(days=1),
+        end=NOW + timedelta(days=2),
+    )
+
+
+def _ctx(
+    snapshot: CheckinStateSnapshot,
+    events: list[CalendarEvent] | None = None,
+    monitoring: bool = False,
+) -> CoordinatorUpdateContext:
+    """Build a restore context."""
+    return CoordinatorUpdateContext(
+        snapshot, events or [], lambda: NOW, True, monitoring, 2.0, "", False, "Rental"
+    )
+
+
+def test_restore_checked_in_ended_event_silent_checkout() -> None:
+    """Ended checked-in restore silently checks out and computes linger."""
+    snapshot = CheckinStateSnapshot(
+        CHECKIN_STATE_CHECKED_IN,
+        "Reserved - Ada",
+        NOW - timedelta(days=2),
+        NOW - timedelta(hours=1),
+    )
+    decision = decide_restore_state(_ctx(snapshot))
+
+    assert [effect.kind for effect in decision.effects] == [
+        "silent_checked_out",
+        "compute_linger",
+    ]
+    assert decision.write_state is True
+
+
+def test_restore_awaiting_past_start_silent_checkin_checkout() -> None:
+    """Awaiting restore catches up both check-in and checkout silently."""
+    snapshot = CheckinStateSnapshot(
+        CHECKIN_STATE_AWAITING,
+        "Reserved - Ada",
+        NOW - timedelta(days=2),
+        NOW - timedelta(hours=1),
+    )
+    decision = decide_restore_state(_ctx(snapshot, monitoring=False))
+
+    assert [effect.kind for effect in decision.effects] == [
+        "cancel_timer",
+        "set_transition_target",
+        "silent_checked_in",
+        "silent_checked_out",
+        "compute_linger",
+    ]
+
+
+def test_restore_checked_out_new_event_hands_off_to_awaiting() -> None:
+    """A new relevant event after restore transitions to awaiting."""
+    decision = decide_restore_state(
+        _ctx(CheckinStateSnapshot(CHECKIN_STATE_CHECKED_OUT), [_event()])
+    )
+
+    assert [effect.kind for effect in decision.effects] == ["transition_awaiting"]
+
+
+def test_restore_no_reservation_recreates_future_followup() -> None:
+    """Future FR-006c follow-up day recreates its timer."""
+    snapshot = CheckinStateSnapshot(
+        CHECKIN_STATE_NO_RESERVATION, next_event_start_day=NOW + timedelta(days=1)
+    )
+    decision = decide_restore_state(_ctx(snapshot))
+
+    assert [effect.kind for effect in decision.effects] == [
+        "cancel_timer",
+        "schedule_no_reservation_to_awaiting",
+    ]
+    assert decision.write_state is True
+
+
+def test_restore_unknown_resets_to_no_reservation() -> None:
+    """Unknown restored state resets through the safe no-reservation path."""
+    decision = decide_restore_state(_ctx(CheckinStateSnapshot("corrupt")))
+
+    assert [effect.kind for effect in decision.effects] == ["transition_no_reservation"]
+    assert decision.log_records[0].level == "warning"

--- a/tests/unit/test_checkin_timers.py
+++ b/tests/unit/test_checkin_timers.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused timer manager tests for the check-in sensor."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.rental_control.sensors.checkin.timers import CheckinTimerManager
+
+NOW = datetime(2026, 6, 1, 12, tzinfo=dt_util.UTC)
+
+
+class _Cancel:
+    """Recording cancellation handle."""
+
+    def __init__(self) -> None:
+        """Initialize the cancellation recorder."""
+        self.calls = 0
+
+    def __call__(self) -> None:
+        """Record cancellation."""
+        self.calls += 1
+
+
+def test_schedule_cancels_existing_handle_before_replace() -> None:
+    """Scheduling a replacement cancels the old handle once."""
+    handles = [_Cancel(), _Cancel()]
+    seen: list[datetime] = []
+
+    def tracker(*args: Any) -> _Cancel:
+        """Record timer targets and return the next handle."""
+        seen.append(args[2])
+        return handles[len(seen) - 1]
+
+    manager = CheckinTimerManager(object(), tracker)  # type: ignore[arg-type]
+    manager.schedule("auto_checkin", lambda now: None, NOW)
+    manager.schedule("auto_checkout", lambda now: None, NOW)
+
+    assert handles[0].calls == 1
+    assert handles[1].calls == 0
+    assert manager.scheduled is not None
+    assert manager.scheduled.purpose == "auto_checkout"
+
+
+def test_clear_callback_handle_removes_active_handle() -> None:
+    """Callback entry clears the active handle metadata."""
+    manager = CheckinTimerManager(object(), lambda *args: _Cancel())  # type: ignore[arg-type]
+    manager.schedule("auto_checkin", lambda now: None, NOW)
+
+    manager.clear_callback_handle()
+
+    assert manager.handle is None
+    assert manager.scheduled is None
+
+
+def test_cancel_without_handle_is_safe() -> None:
+    """Cancelling with no active timer is a no-op."""
+    manager = CheckinTimerManager(object(), lambda *args: _Cancel())  # type: ignore[arg-type]
+
+    manager.cancel()
+
+    assert manager.handle is None
+
+
+def test_followup_metadata_is_recorded() -> None:
+    """Scheduled transition records target and follow-up metadata."""
+    followup = datetime(2026, 6, 2, tzinfo=dt_util.UTC)
+    manager = CheckinTimerManager(object(), lambda *args: _Cancel())  # type: ignore[arg-type]
+
+    manager.schedule("linger_to_no_reservation", lambda now: None, NOW, followup)
+
+    assert manager.scheduled is not None
+    assert manager.scheduled.target_time == NOW
+    assert manager.scheduled.followon_start_day == followup


### PR DESCRIPTION
## Summary
- Split the check-in sensor into internal modules for models, persistence, event selection, coordinator decisions, restore decisions, timer handling, and effect application.
- Preserve the Home Assistant-facing `CheckinTrackingSensor` shell and compatibility re-export for `CheckinExtraStoredData`.
- Add focused helper coverage for transition decisions, restore reconciliation, timers, and persistence while keeping existing parity tests unchanged.

Closes #577

This is the implementation stage of the 014 speckit pipeline.
