### PR TITLE
Docs(plan): Add implementation plan for spec 015

### DIFF
--- a/specs/015-decompose-reconciliation/data-model.md
+++ b/specs/015-decompose-reconciliation/data-model.md
@@ -1,0 +1,283 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Data Model: Decompose Reconciliation Engine
+
+## Compatibility Export Set
+
+The package root `custom_components.rental_control.reconciliation` remains the
+only public compatibility boundary. It re-exports:
+
+| Symbol | Owner module | Preservation rule |
+|--------|--------------|-------------------|
+| `FINGERPRINT_VERSION` | `enums.py` | Keep value `"v1"`. |
+| `SlotStatus` | `enums.py` | Keep enum values `free`, `occupied`, `pending_clear`, `blocked`, `phantom`, `unknown`. |
+| `ObservedSlotStatus` | `enums.py` | Keep enum values `empty`, `occupied`, `phantom`, `unknown`. |
+| `ActionKind` | `enums.py` | Keep all current legacy and stateless action values. |
+| `SlotAction` | `action_models.py` | Keep fields, defaults, and action metadata semantics. |
+| `Reservation` | `plan_models.py` | Keep constructor fields, validation, and mutable planning fields. |
+| `ManagedSlot` | `plan_models.py` | Keep observed/persisted slot fields and defaults. |
+| `ObservedSlot` | `stateless_models.py` | Keep physical classification derivation and `raw_pin` redaction. |
+| `DesiredReservation` | `stateless_models.py` | Keep stateless desired fields and normalized-name derivation. |
+| `StatelessPlan` | `stateless_models.py` | Keep selected, overflow, actions, diagnostics containers. |
+| `CacheOnlyStoreRecord` | `store_models.py` | Keep cache-only metadata fields; never authoritative. |
+| `PlannedSlot` | `plan_models.py` | Keep per-slot desired/actual/action comparison fields. |
+| `DesiredPlan` | `plan_models.py` | Keep selected, protected, overflow, slots, actions, diagnostics, and validation. |
+| `StoredIdentity` | `store_models.py` | Keep persisted identity fields and alias lists. |
+| `StoredActual` | `store_models.py` | Keep redacted last-observed physical fields. |
+| `SlotMapping` | `store_models.py` | Keep Store mapping fields and validation for compatibility. |
+| `RematchKind` | `rematch_models.py` | Keep hierarchy classification values. |
+| `RematchResult` | `rematch_models.py` | Keep result fields and ambiguity/date-shift semantics. |
+| `normalize_slot_name_for_fingerprint` | `identity.py` | Keep strip/casefold normalization. |
+| `make_reservation_fingerprint` | `identity.py` | Keep v1 canonical string and SHA-256 output. |
+| `extract_booking_aliases` | `identity.py` | Keep Airbnb confirmation-code extraction. |
+| `find_reservation_rematch` | `rematch.py` | Keep exact rule priority and return semantics. |
+| `compute_desired_plan` | `desired.py` | Keep legacy caller call patterns and output identity. |
+| `compute_stateless_plan` | `stateless.py` | Keep current caller signature and output identity. |
+
+## Engine Entities
+
+### Reservation
+
+**Owner**: `plan_models.py`
+
+A normalized calendar stay eligible for legacy desired-plan computation.
+
+**Fields to preserve**: `identity_key`, `start`, `end`, `buffered_start`,
+`buffered_end`, `summary`, `slot_name`, `display_slot_name`, `slot_code`,
+`uid_aliases`, `booking_aliases`, `fingerprint_history`, `eligible`,
+`protected_active`, `checked_out`, `missing_count`, `desired_slot`,
+`overflow_reason`, `sensor_lookup_keys`, and `code_source`.
+
+**Validation**: `start < end`; `missing_count >= 0`.
+
+**Relationships**:
+
+- Grouped by `identity.normalize_slot_name_for_fingerprint(slot_name)` for
+  stable-name duplicate matching.
+- Selected into `DesiredPlan.selected` by `desired.py`.
+- Compared with `ManagedSlot` by `actions.py` for drift and date updates.
+- Reconnected to Store cache entries by `rematch.py` without making Store data
+  authoritative for correctness.
+
+### ManagedSlot
+
+**Owner**: `plan_models.py`
+
+A Keymaster slot in or near the Rental-Control-managed range for legacy
+`DesiredPlan` computation.
+
+**Fields to preserve**: `slot`, `managed`, `status`, `actual_name`,
+`actual_code`, `actual_code_present`, `actual_start`, `actual_end`,
+`date_range_enabled`, `enabled`, `desired_identity_key`,
+`persisted_identity_key`, `blocked_reason`, `preserve_unmatched`, `retry_count`,
+`last_operation_id`, `dirty_during_operation`, and `last_error`.
+
+**State rules**:
+
+- `PENDING_CLEAR`, `BLOCKED`, and `UNKNOWN` do not receive different
+  reservations.
+- `FREE` slots are assignable by lowest slot number.
+- `OCCUPIED` or `PHANTOM` slots participate in stable-name matching and may
+  clear, retry, update in place, or no-op based on current fields.
+- Duplicate non-canonical physical matches reset through the same clear path.
+
+### ObservedSlot
+
+**Owner**: `stateless_models.py`
+
+A stateless physical slot fact read during one refresh.
+
+**Fields to preserve**: `slot`, `managed`, `raw_name`, `raw_pin`, `has_pin`,
+`actual_start`, `actual_end`, `date_range_enabled`, `enabled`, `readable`,
+`empty_confirmed`, `classification`, `normalized_name_forms`, and
+`matched_desired_id`.
+
+**Validation/state derivation**:
+
+- `raw_pin` remains memory-only and is excluded from diagnostics and Store data.
+- Present blank, `unknown`, and `none` text values are cleared; `has_pin=False`
+  is also confirmed clear. A missing PIN state where both `raw_pin is None` and
+  `has_pin is None` remains unreadable/unknown, not confirmed empty.
+- `unavailable` makes the slot unreadable and not confirmed empty.
+- Managed readable slots classify as `EMPTY`, `OCCUPIED`, or `PHANTOM`; unmanaged
+  or unreadable slots classify as `UNKNOWN`.
+
+### DesiredReservation
+
+**Owner**: `stateless_models.py`
+
+A stateless planner reservation derived from current calendar and check-in state.
+
+**Fields to preserve**: `desired_id`, `stable_slot_name`, `display_slot_name`,
+`start`, `end`, `buffered_start`, `buffered_end`, `slot_code`, `code_source`,
+`event_uid`, `booking_aliases`, `eligible`, `protected_active`, `checked_out`,
+`selected_rank`, `matched_slot`, `assigned_slot`, `sensor_lookup_keys`,
+`physical_time_override`, `overflow_reason`, and `normalized_name_forms`.
+
+**Validation**: `start < end`; normalized forms include stable and display names.
+
+**Relationships**:
+
+- Grouped by stable name for stateless slot matching.
+- Matched to `ObservedSlot` by `stateless.py` and `pairing.py`.
+- Selected into `StatelessPlan.selected` at most once.
+
+### DesiredPlan
+
+**Owner**: `plan_models.py`; assembled by `desired.py`; diagnostics by
+`diagnostics.py`.
+
+**Fields to preserve**: `plan_id`, `generated_at`, `selected`, `protected`,
+`overflow`, `slots`, `actions`, and `diagnostics`.
+
+**Invariants**:
+
+- Every selected identity appears at most once.
+- Every selected slot appears at most once.
+- `NOOP` actions are suppressed from `actions` but represented in `slots`.
+- Diagnostics include the same plan metadata, slot entries, reservation entries,
+  overflow details, stable-name matches, sorted aliases, drift fields, retry
+  counts, and last errors as the current source.
+
+### StatelessPlan
+
+**Owner**: `stateless_models.py`; assembled by `stateless.py`; diagnostics by
+`diagnostics.py`.
+
+**Fields to preserve**: `plan_id`, `generated_at`, `observed_slots`,
+`desired_reservations`, `selected`, `overflow`, `actions`, and `diagnostics`.
+
+**Invariants**:
+
+- Every selected `desired_id` appears in at most one slot.
+- Unknown slots emit blocked actions.
+- Duplicate non-canonical observed slots reset.
+- New assignments require confirmed-empty physical slots.
+- Update-in-place for code/name replacement stays bound to the matched physical
+  slot and requires confirmed empty before reapply.
+
+### SlotAction and PlannedSlot
+
+**Owners**: `action_models.py` for `SlotAction` and `plan_models.py` for
+`PlannedSlot`; populated by `actions.py`, `desired.py`, and `stateless.py`.
+
+`SlotAction` carries executable action intent: `kind`, `slot`, `identity_key`,
+`reason`, `desired_id`, `matched_by`, `requires_confirmed_empty`, `sequence`,
+`preflight_read`, and `blocked_reason`.
+
+`PlannedSlot` carries per-slot diagnostic comparison: `slot`,
+`desired_identity_key`, `actual_classification`, `action`, `pending_reason`,
+`retry_count`, and `last_error`.
+
+**Action rules to preserve**:
+
+- `SET`/`ASSIGN` only target confirmed-free or confirmed-empty slots.
+- `OVERWRITE_MANUAL_CHANGE`/`UPDATE_IN_PLACE` keep stable-name matched
+  reservations in their current physical slot.
+- `CLEAR`/`RESET` handles stale, phantom, duplicate, and mis-assigned occupants.
+- `RETRY_CLEAR` and `BLOCKED` preserve pending and unreadable safety behavior.
+- `requires_confirmed_empty` and `preflight_read` remain set on replacement and
+  assignment paths exactly as today.
+
+### RematchResult and Store records
+
+**Owners**: `store_models.py` and `rematch_models.py` for data; `rematch.py` for
+behavior.
+
+`StoredIdentity`, `StoredActual`, `SlotMapping`, and `CacheOnlyStoreRecord`
+remain importable for compatibility and diagnostics. Stale Store snapshots must
+not become authoritative for selection, duplicate prevention, reset decisions,
+or assignment safety. The decomposition still preserves the current
+`ManagedSlot.persisted_identity_key` continuity signal when the coordinator has
+already resolved it for the refresh and fresh physical state does not contradict
+it; current `compute_desired_plan` uses that field for same-slot matching and
+protected pending-clear behavior.
+
+`find_reservation_rematch()` returns `RematchResult` with:
+
+1. `EXACT` for unchanged primary fingerprint unless fresh physical name
+   contradicts the reservation;
+2. `UID_ALIAS` plus name with `date_shifted=True`;
+3. `BOOKING_ALIAS` plus name;
+4. `NAME_TIME` for normalized name plus exact UTC start/end;
+5. `CONTINUITY` for one conservative compatible candidate with no competing
+   current reservation;
+6. `CONTINUITY` for the one date-matching candidate when multiple continuity
+   candidates exist but exactly one matches stored or observed dates;
+7. `AMBIGUOUS` for unresolved competing candidates;
+8. `NO_MATCH` otherwise.
+
+## Internal Request Models
+
+### DesiredPlanRequest
+
+**Owner**: `desired.py`
+
+Bundles the legacy `compute_desired_plan` inputs:
+
+| Field | Purpose |
+|-------|---------|
+| `reservations` | Current `Reservation` records. |
+| `managed_slots` | Current `ManagedSlot` observations. |
+| `max_events` | Managed slot capacity. |
+| `plan_id` | Refresh-scoped plan identifier. |
+| `generated_at` | Plan timestamp. |
+| `entry_id` | Optional diagnostics context. |
+| `lockname` | Optional diagnostics context. |
+| `start_slot` | Optional diagnostics context. |
+
+The public shim accepts legacy arguments and builds this request. Phase helpers
+accept the request or smaller derived contexts, not the original eight
+parameters.
+
+### StatelessPlanRequest
+
+**Owner**: `stateless.py`
+
+Bundles the `compute_stateless_plan` inputs: observed slots, desired
+reservations, max events, plan id, generated timestamp, and prefix. The public
+function may keep the existing six-parameter signature while internal helpers use
+this request object.
+
+## State Transitions Preserved by the Split
+
+### Desired reservation selection
+
+```text
+Reservation list
+  └─ filter eligible / not checked_out / missing-count tolerance
+      └─ protected active first
+          └─ remaining capacity filled by soonest non-protected
+              ├─ selected -> stable-name matching / assignment
+              └─ overflow -> capacity or no_empty_slot
+```
+
+### Physical slot reconciliation
+
+```text
+Readable empty slot ── selected unmatched desired ──► SET/ASSIGN
+Readable occupied matching stable name ─────────────► NOOP / UPDATE_TIMES /
+                                                      OVERWRITE_MANUAL_CHANGE /
+                                                      UPDATE_IN_PLACE
+Readable occupied no selected match ────────────────► CLEAR/RESET stale
+Readable duplicate non-canonical match ─────────────► CLEAR/RESET duplicate
+Pending clear ──────────────────────────────────────► RETRY_CLEAR or BLOCKED
+Unreadable / blocked ───────────────────────────────► BLOCKED
+```
+
+### Confirmed reset before reapply
+
+```text
+matched slot needs replacement PIN/name
+  └─ action remains bound to same physical slot
+      └─ preflight read
+          └─ clear/reset
+              └─ reapply only after physical empty confirmation
+                  └─ otherwise retry/block from next observed physical state
+```
+
+No Store field transitions a slot between empty, occupied, blocked, reset, or
+assignable states.

--- a/specs/015-decompose-reconciliation/plan.md
+++ b/specs/015-decompose-reconciliation/plan.md
@@ -1,0 +1,435 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Implementation Plan: Decompose Reconciliation Engine
+
+**Feature**: `015-decompose-reconciliation` | **Planning Branch**:
+`015-decompose-reconciliation-plan` | **Date**: 2026-06-27 | **Spec**:
+[spec.md](spec.md)
+**Input**: Feature specification from
+`specs/015-decompose-reconciliation/spec.md` and GitHub issue #627
+
+## Summary
+
+Decompose `custom_components/rental_control/reconciliation.py` without changing
+any runtime behavior of the 3.6.0 stateless slot-reconciliation engine. The
+current 2,584-line source is the load-bearing contract: it defines the legacy
+`DesiredPlan` planner, the newer `StatelessPlan` planner, stable fingerprint and
+alias helpers, persisted rematch hierarchy, slot-name matching, duplicate-name
+pairing, action selection, and diagnostics.
+
+The implementation will replace the single module with a
+`custom_components/rental_control/reconciliation/` package split by phase. The
+package `__init__.py` is the compatibility boundary and re-exports the full
+production and test-consumed surface so coordinator, event override, event
+sensor, and regression-test imports do not change. The refactor is acceptable
+only if identical inputs produce byte-for-byte equivalent plans, diagnostics,
+actions, action ordering, and public helper results.
+
+## Technical Context
+
+**Language/Version**: Python >=3.14.2
+**Primary Dependencies**: Home Assistant runtime >=2026.4.0 per `hacs.json`;
+dev/test dependency `homeassistant>=2026.6.0` per `pyproject.toml`;
+`pytest-homeassistant-custom-component`, `icalendar>=7.0.0`, and
+`x-wr-timezone>=2.0.0`
+**Storage**: Home Assistant `Store` data remains cache-only for reconciliation;
+no new storage and no Store authority in planner correctness
+**Testing**: `uv run pytest tests/`; targeted reconciliation coverage in
+`tests/unit/test_slot_reconciliation.py`, `tests/unit/test_event_overrides.py`,
+`tests/unit/test_coordinator.py`, `tests/unit/test_keymaster_event_diagnostics.py`,
+`tests/integration/test_refresh_cycle.py`, and
+`tests/integration/test_slot_concurrency.py`; ruff via
+`uv run ruff check custom_components/ tests/`; pre-commit hooks for reuse, ruff,
+mypy, interrogate, yamllint, actionlint, and gitlint
+**Target Platform**: Home Assistant custom integration on the HA asyncio event
+loop for Linux, HA OS, Docker, and HACS-managed installs
+**Project Type**: Single Home Assistant custom integration
+**Performance Goals**: Keep reconciliation pure, synchronous, and bounded by the
+already-observed managed slots plus current reservations. Do not add blocking
+I/O, coordinator refreshes, Store reads, Store writes, or Keymaster service calls
+inside planning.
+**Constraints**: Documentation-only PLAN PR; no production code. Runtime refactor
+must preserve the no-duplicate lock-code assignment guarantee, slot-name identity
+matching, in-place updates, confirmed-reset-before-reapply ordering, diagnostics,
+and cache-only persisted Store semantics exactly.
+**Scale/Scope**: One 2,584-line module becomes a focused internal package. The
+implementation target is reconciliation files below 400 lines, functions below 80
+lines, and project-owned parameter lists no more than six parameters.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I: Code Quality & Testing | PASS | Plan requires existing reconciliation unit/integration tests to pass unchanged and adds focused parity tests around each extracted phase. |
+| II: Atomic Commit Discipline | PASS | This PR is one docs-only PLAN commit. Future implementation can split models, identity, pairing, planners, diagnostics, wiring, and tests into atomic commits. |
+| III: Licensing & Attribution | PASS | New markdown artifacts include SPDX headers. Future Python modules must retain project SPDX headers. |
+| IV: Pre-Commit Integrity | PASS | No hook bypass is planned. Quickstart defines local validation before implementation merge. |
+| V: Agent Co-Authorship & DCO | PASS | The PLAN commit uses `git commit -s` and the requested AI co-author trailer. |
+| VI: User Experience Consistency | PASS | Public imports, caller call patterns, plan contents, diagnostics, actions, and lock-code behavior are explicitly preserved. |
+| VII: Performance Requirements | PASS | The split keeps the planner in-memory and side-effect-free, with no added I/O, refreshes, or Store authority. |
+
+**Gate result: PASS** — no violations. Proceeding to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-decompose-reconciliation/
+├── plan.md                    # This file
+├── research.md                # Phase 0 decisions and alternatives
+├── data-model.md              # Phase 1 entities and module ownership
+├── quickstart.md              # Phase 1 parity validation guide
+└── tasks.md                   # Phase 2 output only; not created in PLAN stage
+```
+
+`contracts/` is intentionally omitted. This refactor introduces no external
+HTTP, WebSocket, Home Assistant service, entity-service, event, or public API
+contract. The internal compatibility boundary is specified in this plan and in
+[data-model.md](data-model.md).
+
+### Source Code (repository root)
+
+```text
+custom_components/rental_control/
+├── coordinator.py                 # Existing imports and call patterns stay
+├── event_overrides.py             # Existing action/plan imports stay
+├── sensors/
+│   └── calsensor.py               # Existing fingerprint import stays
+└── reconciliation/
+    ├── __init__.py                # Compatibility boundary; re-exports the
+    │                              # full consumed reconciliation surface
+    ├── enums.py                   # FINGERPRINT_VERSION, SlotStatus,
+    │                              # ObservedSlotStatus, ActionKind
+    ├── action_models.py           # SlotAction
+    ├── plan_models.py             # Reservation, ManagedSlot, PlannedSlot,
+    │                              # DesiredPlan
+    ├── stateless_models.py        # ObservedSlot, DesiredReservation,
+    │                              # StatelessPlan
+    ├── store_models.py            # CacheOnlyStoreRecord, StoredIdentity,
+    │                              # StoredActual, SlotMapping
+    ├── rematch_models.py          # RematchKind, RematchResult
+    ├── identity.py                # fingerprint, UTC canonicalization,
+    │                              # booking aliases, name normalization/forms
+    ├── pairing.py                 # slot-name matching, distance helpers,
+    │                              # _pair_partial_* and duplicate ordering
+    ├── rematch_names.py           # Store/rematch name-form helpers
+    ├── rematch_dates.py           # UTC parsing and date comparison helpers
+    ├── rematch_continuity.py      # Continuity and competition checks
+    ├── rematch.py                 # find_reservation_rematch dispatcher and
+    │                              # exact/alias/name-time rule helpers
+    ├── desired.py                 # compute_desired_plan compatibility shim,
+    │                              # request/context model, legacy planner phases
+    ├── stateless.py               # compute_stateless_plan compatibility shim,
+    │                              # request/context model, stateless phases
+    ├── actions.py                 # _compute_drift_fields, _build_slot_action,
+    │                              # action metadata/preflight flags
+    └── diagnostics.py             # DesiredPlan and StatelessPlan diagnostic
+                                   # snapshots, redaction, carry-over keys
+
+tests/
+├── unit/
+│   ├── test_slot_reconciliation.py          # Existing behavior oracle;
+│   │                                       # add phase-level parity tests
+│   ├── test_event_overrides.py              # Existing apply/action behavior
+│   ├── test_coordinator.py                  # Existing caller compatibility
+│   └── test_keymaster_event_diagnostics.py  # Existing diagnostics behavior
+└── integration/
+    ├── test_refresh_cycle.py                # End-to-end no-duplicate oracle
+    └── test_slot_concurrency.py             # Apply/callback ordering oracle
+```
+
+**Structure Decision**: Convert `reconciliation.py` into a package named
+`reconciliation`. Python import sites already use
+`custom_components.rental_control.reconciliation`; after the file-to-package move
+that import path resolves to `reconciliation/__init__.py`. No production caller
+or existing test should import from the new internal modules. Internal modules
+may be tested directly only for new phase-level coverage; existing compatibility
+tests must continue importing from the package root.
+
+## Concrete Decomposition Design
+
+### Compatibility boundary
+
+`custom_components/rental_control/reconciliation/__init__.py` must re-export the
+full consumed surface verified from production imports, current tests, and
+FR-014/FR-015:
+
+```text
+ActionKind
+CacheOnlyStoreRecord
+DesiredPlan
+DesiredReservation
+FINGERPRINT_VERSION
+ManagedSlot
+ObservedSlot
+ObservedSlotStatus
+PlannedSlot
+RematchKind
+RematchResult
+Reservation
+SlotAction
+SlotMapping
+SlotStatus
+StatelessPlan
+StoredActual
+StoredIdentity
+compute_desired_plan
+compute_stateless_plan
+extract_booking_aliases
+find_reservation_rematch
+make_reservation_fingerprint
+normalize_slot_name_for_fingerprint
+```
+
+Production callers currently consume `DesiredPlan`, `ManagedSlot`,
+`Reservation`, `SlotStatus`, `compute_desired_plan`, `extract_booking_aliases`,
+`make_reservation_fingerprint`, `normalize_slot_name_for_fingerprint`,
+`ActionKind`, `SlotAction`, and `make_reservation_fingerprint` from this module.
+Tests additionally consume the stateless models, rematch models, Store/cache
+models, and planner helpers above. The implementation must add an import
+compatibility test that imports every name from the package root and asserts the
+objects are the same objects exported by their internal owner modules.
+
+### Module responsibilities
+
+The model layer is split so each file can satisfy the sub-400-line gate.
+`enums.py` owns `FINGERPRINT_VERSION`, `SlotStatus`, `ObservedSlotStatus`, and
+`ActionKind`; `action_models.py` owns `SlotAction`; `plan_models.py` owns
+`Reservation`, `ManagedSlot`, `PlannedSlot`, and `DesiredPlan`;
+`stateless_models.py` owns `ObservedSlot`, `DesiredReservation`, and
+`StatelessPlan`; `store_models.py` owns `CacheOnlyStoreRecord`,
+`StoredIdentity`, `StoredActual`, and `SlotMapping`; `rematch_models.py` owns
+`RematchKind` and `RematchResult`. These modules preserve field names, defaults,
+`slots=True`, post-init validation, enum values, and docstring semantics. They
+must not import planner modules, perform I/O, or mutate process-global state.
+
+`identity.py` owns `normalize_slot_name_for_fingerprint`,
+`make_reservation_fingerprint`, `extract_booking_aliases`, `_dt_to_utc_iso`,
+`_desired_name_forms`, `_slot_name_variants`, `_names_match`,
+`_reservation_name_key`, and `_desired_name_key`. The exact v1 fingerprint
+canonical string, UTC formatting, Airbnb alias extraction, casefold/strip
+normalization, prefix stripping, and non-generic-prefix matching remain
+unchanged.
+
+`pairing.py` owns `_slot_times_match`, `_datetime_distance`,
+`_managed_slot_distance`, `_observed_slot_distance`, `_select_managed_subset`,
+`_select_observed_subset`, `_pair_partial_managed`, and
+`_pair_partial_observed`. These helpers preserve minimum-distance matching,
+start-time ordered duplicate disambiguation, deterministic slot fallback, and
+canonical duplicate selection.
+
+The rematch layer is also split to satisfy the file-size gate. `rematch.py` owns
+`find_reservation_rematch` as a short dispatcher plus exact, UID-alias,
+booking-alias, name-time, and continuity rule helpers. `rematch_names.py` owns
+`_get_nested`, `_normalized_name_forms`, `_mapping_name_forms`,
+`_mapping_name_matches_reservation`, `_is_adopted_mapping`,
+`_should_include_observed_mapping`, and `_fresh_observed_name_conflicts`.
+`rematch_dates.py` owns `_as_utc_datetime` and
+`_mapping_dates_match_reservation`. `rematch_continuity.py` owns
+`_is_continuity_compatible` and `_has_competing_reservation`. Ambiguous results,
+fresh-observed-name conflict filtering, the multiple-continuity-candidate
+date-match tie-break, and `date_shifted=True` semantics must remain identical.
+
+`desired.py` owns the legacy `DesiredPlan` flow. It introduces an internal
+`DesiredPlanRequest` dataclass bundling reservations, managed slots, max events,
+plan id, generated timestamp, and optional diagnostics context. The public
+`compute_desired_plan` remains the root import and keeps existing caller call
+patterns while delegating immediately to a request object and phase helpers.
+
+`stateless.py` owns the `StatelessPlan` flow. It introduces a
+`StatelessPlanRequest` dataclass bundling observed slots, desired reservations,
+max events, plan id, generated timestamp, and prefix. The public
+`compute_stateless_plan` remains importable from the package root and delegates
+to phase helpers without changing the six-parameter caller contract.
+
+`actions.py` owns `_compute_drift_fields` and `_build_slot_action`. It also
+centralizes action metadata that is currently assembled inline: `matched_by`,
+`requires_confirmed_empty`, `preflight_read`, `reason`, `blocked_reason`, and
+legacy `ActionKind` choices.
+
+`diagnostics.py` owns `_build_plan_diagnostics_snapshot` and the stateless
+snapshot builder. It splits plan metadata, slot diagnostics, reservation
+diagnostics, action diagnostics, and carry-over merging into separately testable
+functions. Raw slot codes remain excluded.
+
+### `compute_desired_plan` split and parameter-count strategy
+
+Current ground truth is:
+
+```python
+compute_desired_plan(
+    reservations,
+    managed_slots,
+    max_events,
+    plan_id,
+    generated_at,
+    *,
+    entry_id=None,
+    lockname=None,
+    start_slot=None,
+)
+```
+
+That is the public caller contract used by coordinator and tests. The
+implementation must preserve those call patterns exactly, including positional
+use of the first five arguments and keyword use of `entry_id`, `lockname`, and
+`start_slot`, but internal helpers must not keep eight-parameter signatures.
+
+The plan resolves the 8-parameter to <=6-parameter tension by making the package
+root export a compatibility shim with no more than six declared project-owned
+parameters, for example:
+
+```python
+def compute_desired_plan(
+    reservations: list[Reservation] | DesiredPlanRequest,
+    managed_slots: list[ManagedSlot] | None = None,
+    max_events: int | None = None,
+    plan_id: str | None = None,
+    generated_at: datetime | None = None,
+    **context: object,
+) -> DesiredPlan: ...
+```
+
+The shim accepts the existing calls, validates that `context` contains only
+`entry_id`, `lockname`, and `start_slot`, constructs `DesiredPlanRequest`, and
+then delegates. New internal callers may pass `DesiredPlanRequest` directly.
+This preserves source compatibility for existing callers while satisfying the
+active parameter-count gate on the compatibility entry point and every internal
+helper. Tests should pin both legacy call style and direct request style.
+
+The decomposed desired-plan phases are:
+
+1. `build_desired_plan_request()` validates legacy arguments and context.
+2. `select_eligible_reservations()` preserves `eligible`, `checked_out`,
+   `missing_count`, and protected-active filtering.
+3. `select_desired_candidates()` preserves protected-first selection and
+   non-protected soonest ordering by `(start, identity_key)`.
+4. `record_capacity_overflow()` preserves `overflow_details` ranks and reasons.
+5. `group_selected_by_stable_name()` preserves normalized slot-name grouping and
+   start/end/identity ordering.
+6. `match_existing_managed_slots()` preserves stable-name, persisted-identity,
+   exact-time, partial-pair, minimum-distance, and duplicate physical-slot
+   matching.
+7. `assign_unmatched_reservations()` preserves lowest confirmed-free slot
+   allocation and `no_empty_slot` overflow.
+8. `classify_desired_plan_slots()` preserves pending-clear, blocked, unreadable,
+   duplicate, stale, phantom, mis-assigned, drift, `UPDATE_TIMES`, and `NOOP`
+   decisions.
+9. `assemble_desired_actions()` preserves action order and suppression of `NOOP`
+   actions.
+10. `build_desired_diagnostics()` preserves diagnostics keys, sorting, redaction,
+    and carry-over behavior.
+
+Each helper must be below 80 lines and accept either one request/context object
+or no more than six scalar parameters.
+
+### `compute_stateless_plan` split
+
+`compute_stateless_plan` already has six declared parameters and remains
+source-compatible. Its 259-line body splits into:
+
+1. `build_stateless_plan_request()` and `initialize_stateless_plan()`.
+2. `select_stateless_reservations()` for eligible/protected/non-protected
+   ordering, selected ranks, and capacity overflow.
+3. `group_stateless_reservations_by_name()` for normalized stable-name groups.
+4. `match_observed_slots_by_name()` for prefix-aware stable-name matching,
+   exact-time matches, partial observed pairing, duplicate canonical selection,
+   and `matched_slot`/`assigned_slot` mutation.
+5. `assign_unmatched_stateless_reservations()` for lowest confirmed-empty slot
+   assignment and `no_empty_slot` overflow.
+6. `build_stateless_actions()` for unreadable blocks, duplicate resets, stale
+   resets, assignments, update-in-place replacement, and date updates.
+7. `build_stateless_diagnostics()` for the current selected/overflow/action
+   snapshot shape.
+
+The implementation must not simplify the duplicated desired/stateless matching
+logic unless parity tests prove the shared helper emits byte-for-byte identical
+results for both model families.
+
+### Behavior-equivalence strategy
+
+The source of truth is current `origin/main` plus existing tests. The
+implementation should first introduce serialization helpers in tests, then
+capture before/after outputs for representative `DesiredPlan`, `StatelessPlan`,
+`find_reservation_rematch`, fingerprint, alias, and diagnostics scenarios. For
+identical inputs, serialized dataclasses, dictionaries, action lists, action
+ordering, diagnostics, enum values, error behavior, and helper return values must
+match byte-for-byte. No algorithmic improvement, new business rule, or caller
+rewrite belongs in this feature.
+
+Critical parity assertions:
+
+- no selected reservation appears in more than one managed slot;
+- stable slot-name matching remains trim-aware, prefix-aware, exact-display-name
+  aware, and deliberately avoids unsafe generic prefix matching;
+- duplicate or ambiguous reservation names remain start-time and
+  minimum-distance disambiguated;
+- changed reservations with stable slot-name identity update in place and do not
+  allocate second slots;
+- resets, replacements, retries, duplicates, stale occupants, phantoms, and drift
+  corrections preserve confirmed-reset-before-reapply ordering;
+- stale Store snapshots remain cache-only. Current `persisted_identity_key`
+  continuity hints are preserved only where the current source already uses them
+  and fresh physical state does not contradict them;
+- diagnostics stay redacted and structurally identical.
+
+### `aislop` directive removal
+
+The implementation must remove the file-level
+`# aislop-ignore-file complexity/file-too-large complexity/function-too-long`
+directive only after the package files, project-owned functions, and
+project-owned parameter lists satisfy active thresholds. No replacement
+suppression should be added for this feature.
+
+## Phase 0 Research
+
+Research is complete in [research.md](research.md). It records the package split,
+compatibility boundary, request-object parameter strategy, desired/stateless
+phase decomposition, rematch decomposition, diagnostics/action extraction, and
+behavior-parity approach, with alternatives grounded in the current source.
+
+## Phase 1 Design Artifacts
+
+- [research.md](research.md): required and complete.
+- [data-model.md](data-model.md): required and complete.
+- [quickstart.md](quickstart.md): required and complete.
+- `contracts/`: omitted because no external API, service, event, or entity
+  contract is introduced or changed.
+- `update-agent-context.sh`: intentionally not run. The plan adds no new
+  language, framework, database, runtime, package manager, or agent-relevant
+  technology beyond the Python/Home Assistant stack already documented in the
+  repository.
+
+## Post-Design Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I: Code Quality & Testing | PASS | Quickstart requires existing reconciliation tests unchanged plus phase-level parity tests for imports, identity, pairing, rematch, desired/stateless planning, actions, diagnostics, and cache-only Store semantics. |
+| II: Atomic Commit Discipline | PASS | PLAN artifacts are one docs-only change; future implementation can be split into small extraction and test commits. |
+| III: Licensing & Attribution | PASS | `plan.md`, `research.md`, `data-model.md`, and `quickstart.md` include SPDX headers. |
+| IV: Pre-Commit Integrity | PASS | The PR must pass hooks and CI without bypass flags. |
+| V: Agent Co-Authorship & DCO | PASS | The planned commit uses sign-off and the requested co-author trailer. |
+| VI: User Experience Consistency | PASS | All production/test imports and legacy `compute_desired_plan` call patterns are preserved from the package root. |
+| VII: Performance Requirements | PASS | Extracted planner phases are pure in-memory work over existing inputs and add no I/O, refreshes, Store authority, or Keymaster operations. |
+
+**Gate result: PASS** — no complexity violations.
+
+## Complexity Tracking
+
+> No violations to justify — all constitution gates pass.
+
+## Phase Notes
+
+- PLAN stage stops here. Do not create `tasks.md` or modify runtime source in
+  this PR.
+- Implementation must treat current `origin/main` as truth. Planning shorthand
+  and issue text are secondary when they disagree with `reconciliation.py`.
+- Before deleting the original module, implementation must run the unchanged
+  reconciliation tests as the oracle and add import-compatibility coverage for
+  the full package-root re-export list.

--- a/specs/015-decompose-reconciliation/quickstart.md
+++ b/specs/015-decompose-reconciliation/quickstart.md
@@ -1,0 +1,248 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart: Decompose Reconciliation Validation
+
+## Scope
+
+This guide validates the implementation stage for spec
+`015-decompose-reconciliation`. It proves that the package split is
+behavior-preserving for the 3.6.0 stateless reconciliation engine. The validation
+oracle is current `origin/main`: identical inputs must produce identical public
+imports, fingerprints, rematch results, desired plans, stateless plans, actions,
+action ordering, and diagnostics.
+
+## Developer Setup
+
+```bash
+cd path/to/homeassistant-rental-control
+uv sync
+```
+
+Run targeted reconciliation tests first. Escalate to broader tests only when the
+changed behavior touches those areas or when targeted failures require it.
+
+```bash
+uv run pytest tests/unit/test_slot_reconciliation.py \
+  tests/unit/test_event_overrides.py \
+  tests/unit/test_coordinator.py \
+  tests/unit/test_keymaster_event_diagnostics.py \
+  tests/integration/test_refresh_cycle.py \
+  tests/integration/test_slot_concurrency.py -q
+uv run ruff check custom_components/ tests/
+```
+
+Before merging implementation, run the full suite and hooks:
+
+```bash
+uv run pytest tests/ -x -q
+uv run ruff check custom_components/ tests/
+uv run pre-commit run --all-files
+```
+
+## Import Compatibility Tests
+
+Add or update a focused test that imports every compatibility symbol from
+`custom_components.rental_control.reconciliation`:
+
+```text
+ActionKind
+CacheOnlyStoreRecord
+DesiredPlan
+DesiredReservation
+FINGERPRINT_VERSION
+ManagedSlot
+ObservedSlot
+ObservedSlotStatus
+PlannedSlot
+RematchKind
+RematchResult
+Reservation
+SlotAction
+SlotMapping
+SlotStatus
+StatelessPlan
+StoredActual
+StoredIdentity
+compute_desired_plan
+compute_stateless_plan
+extract_booking_aliases
+find_reservation_rematch
+make_reservation_fingerprint
+normalize_slot_name_for_fingerprint
+```
+
+The test should also assert that production modules still import unchanged:
+coordinator, event_overrides, and sensors/calsensor must not require import
+rewrites.
+
+## Public Call Pattern Compatibility
+
+Keep existing `compute_desired_plan` calls unchanged in tests and production.
+Add explicit coverage for the legacy call shape:
+
+```python
+compute_desired_plan(
+    reservations,
+    managed_slots,
+    max_events,
+    plan_id,
+    generated_at,
+    entry_id=entry_id,
+    lockname=lockname,
+    start_slot=start_slot,
+)
+```
+
+The implementation may internally build a `DesiredPlanRequest`, but this call
+must continue to work. Add negative coverage for unknown context keywords so the
+compatibility shim fails loudly rather than silently ignoring typos.
+
+## Byte-for-Byte Parity Harness
+
+Before moving code, create test helpers that serialize plans deterministically:
+
+- dataclasses converted with field order preserved;
+- enum values serialized as their `.value` strings;
+- datetimes serialized with the existing `isoformat()` output;
+- sets sorted where the current diagnostics sort them;
+- raw PINs excluded wherever the current diagnostics exclude them.
+
+For representative fixtures, compare current and decomposed outputs for:
+
+1. `normalize_slot_name_for_fingerprint()`;
+2. `make_reservation_fingerprint()`;
+3. `extract_booking_aliases()`;
+4. `find_reservation_rematch()`;
+5. `compute_desired_plan()`;
+6. `compute_stateless_plan()`;
+7. diagnostics snapshots and action lists.
+
+## DesiredPlan Regression Scenarios
+
+Use existing `tests/unit/test_slot_reconciliation.py`,
+`tests/unit/test_event_overrides.py`, `tests/unit/test_coordinator.py`, and
+`tests/integration/test_refresh_cycle.py` as the oracle. Ensure each scenario
+passes unchanged and, where helpful, add phase-level tests that compare extracted
+helper output to the final plan.
+
+1. **Already correct no-op**: selected physical slot matches name, code, dates,
+   and switches; action remains `NOOP` and is omitted from `plan.actions`.
+2. **Length increase/decrease**: same stable slot name remains in the same
+   physical slot; dates update in place and no duplicate slot is selected.
+3. **Full date shift with generated-code change**: stable slot-name identity
+   matches the old physical slot; replacement stays bound to that slot and never
+   assigns a second slot.
+4. **Code/name drift**: action kind, reason, drift fields, preflight flag, and
+   confirmed-empty requirement match current output.
+5. **Duplicate reservation names**: desired groups sort by start, end, and
+   identity key; physical groups sort by observed start, end, and slot number;
+   each selected reservation appears once.
+6. **Duplicate physical slot-name matches**: canonical minimum-distance slot
+   remains matched; non-canonical duplicates clear/reset with the same reason.
+7. **Protected active guest**: protected reservations select first, count against
+   capacity, and block unsafe pending clears as today.
+8. **Capacity and no-empty overflow**: overflow reasons and `overflow_details`
+   ranks stay identical.
+9. **Pending/blocked/unknown slots**: `RETRY_CLEAR` and `BLOCKED` decisions keep
+   current blocked reasons, retry counts, and last errors.
+10. **Stale and phantom slots**: clear actions and diagnostic reasons remain
+    `stale`, `phantom`, or `mis_assigned` exactly as current source emits.
+
+## StatelessPlan Regression Scenarios
+
+Use the existing stateless tests in `tests/unit/test_slot_reconciliation.py`.
+Add phase-level coverage only after the unchanged tests pass.
+
+1. `ObservedSlot` classification preserves empty, occupied, phantom, and unknown
+   behavior for `None`, blank, `unknown`, `none`, and `unavailable` text states.
+2. Protected and non-protected `DesiredReservation` selection preserves selected
+   ranks and capacity overflow.
+3. Prefix-aware physical names match the same desired stable/display forms.
+4. Duplicate observed slots select the same canonical slot and reset the same
+   non-canonical slots.
+5. Empty confirmed slots receive `ASSIGN`; non-empty mismatches reset before any
+   later assignment.
+6. Code or display-name replacement emits `UPDATE_IN_PLACE` for the matched slot
+   with `requires_confirmed_empty=True` and `preflight_read=True`.
+7. Date-only drift emits `UPDATE_TIMES` with the same `matched_by` and reason.
+8. Diagnostics preserve the current `plan_id`, `generated_at`, `selected`,
+   `overflow`, and action summary shape.
+
+## Rematch Regression Scenarios
+
+Keep existing `find_reservation_rematch()` tests unchanged and add direct helper
+coverage only around extracted private phases.
+
+1. Exact fingerprint wins when fresh physical name does not conflict.
+2. Fresh observed physical-name conflict skips otherwise exact or alias
+   candidates.
+3. UID alias plus normalized name returns `UID_ALIAS` and `date_shifted=True`.
+4. Booking alias plus normalized name returns `BOOKING_ALIAS`.
+5. Normalized name plus exact UTC start/end returns `NAME_TIME`.
+6. Conservative continuity returns one candidate only when no other current
+   reservation competes.
+7. Multiple continuity candidates with exactly one stored or observed date match
+   return `CONTINUITY` for that date-matching candidate.
+8. Multiple compatible candidates without a single date tie-break return
+   `AMBIGUOUS` with the same key order.
+9. No compatible candidate returns `NO_MATCH`.
+
+## Diagnostics and Redaction Checks
+
+For both plan types, assert diagnostics are byte-for-byte identical for the same
+inputs:
+
+- plan id and generated timestamp;
+- `entry_id`, `lockname`, and `start_slot` context when provided;
+- slot desired identity, classification, action, blocked reason, retry count,
+  last error, and drift fields;
+- reservation selected/protected/overflow/missing/assigned fields;
+- sorted UID and booking aliases;
+- stable-name match details;
+- absence of raw slot codes.
+
+## Cache-Only Store Safety Checks
+
+The decomposition must not add Store authority. Re-run scenarios with cache data
+present, missing, stale, contradictory, and deleted. Planned selections and
+actions must remain determined by current reservations plus physical slots.
+
+Required cases:
+
+1. deleted Store cold start with existing coded physical slots;
+2. stale `SlotMapping` claiming a different slot than physical truth;
+3. cache entry with old pending-clear fields while physical state is empty;
+4. cache entry with aliases used only for rematch diagnostics;
+5. Store save/load failure not changing the computed plan.
+
+## Complexity and `aislop` Validation
+
+After extraction:
+
+1. verify no reconciliation package file is 400 lines or more;
+2. verify project-owned functions are below 80 lines;
+3. verify project-owned parameter lists are no more than six parameters;
+4. remove the old `aislop-ignore-file complexity/file-too-large
+   complexity/function-too-long` directive;
+5. run the active complexity checks through pre-commit without adding new
+   suppressions.
+
+## Manual Review Checklist
+
+Before opening the implementation PR, rubber-duck the diff against these
+questions:
+
+- Are all public symbols still importable from the package root?
+- Do existing coordinator, event override, calsensor, and test call sites remain
+  unchanged?
+- Does `compute_desired_plan` still accept the legacy five positional arguments
+  plus `entry_id`, `lockname`, and `start_slot` keywords?
+- Can every extracted helper be mapped directly to current source lines with no
+  business-rule change?
+- Do no-duplicate assignment, stable slot-name matching, in-place update,
+  confirmed-reset-before-reapply, and cache-only Store guarantees have explicit
+  tests?
+- Are diagnostics and action ordering byte-for-byte identical?

--- a/specs/015-decompose-reconciliation/research.md
+++ b/specs/015-decompose-reconciliation/research.md
@@ -1,0 +1,277 @@
+<!--
+SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Research: Decompose Reconciliation Engine
+
+## R-001: Package split with root compatibility boundary
+
+**Decision**: Convert `custom_components/rental_control/reconciliation.py` into a
+`custom_components/rental_control/reconciliation/` package. Keep all external
+imports pointed at `custom_components.rental_control.reconciliation` by making
+`__init__.py` re-export every production and test-consumed symbol.
+
+**Rationale**:
+
+- Production callers import only from the current module root: coordinator uses
+  `DesiredPlan`, `ManagedSlot`, `Reservation`, `SlotStatus`,
+  `compute_desired_plan`, `extract_booking_aliases`,
+  `make_reservation_fingerprint`, and
+  `normalize_slot_name_for_fingerprint`; event overrides use `ActionKind`,
+  `DesiredPlan`, `Reservation`, and `SlotAction`; calsensor uses
+  `make_reservation_fingerprint`.
+- Tests import a wider root surface, including `FINGERPRINT_VERSION`,
+  `ObservedSlotStatus`, `ObservedSlot`, `DesiredReservation`, `StatelessPlan`,
+  `PlannedSlot`, `StoredIdentity`, `StoredActual`, `SlotMapping`, `RematchKind`,
+  `RematchResult`, `find_reservation_rematch`, and `compute_stateless_plan`.
+  FR-015 also pins `CacheOnlyStoreRecord`, which exists in the source and should
+  be re-exported even though current grep did not find a test import.
+- A package split allows files to stay below 400 lines while preserving the
+  import path that callers already use. The public root is the contract; internal
+  module paths are implementation details.
+- The current model definitions and rematch helpers are each too large for a
+  single sub-400-line file once imports and docstrings are included, so the plan
+  splits models and rematch helpers into narrower owner modules instead of using
+  one catch-all `models.py` or `rematch_helpers.py`.
+
+**Alternatives considered**:
+
+- **Sibling modules such as `reconciliation_models.py` and
+  `reconciliation_plan.py`**: Rejected because it leaves the oversized
+  `reconciliation.py` compatibility module in place or forces callers to change
+  imports. It also makes the feature area harder to discover.
+- **A new package named `slot_reconciliation`**: Rejected because existing
+  imports would require a larger caller migration and would weaken the
+  behavior-preserving review story.
+- **Keep one module and extract only helper classes**: Rejected because the
+  current file is already 2,584 lines and must remove the file-size/function-size
+  `aislop` suppression.
+
+## R-002: Model submodules stay behavior-identical and side-effect-free
+
+**Decision**: Move constants, enums, and dataclasses to focused model modules:
+`enums.py`, `action_models.py`, `plan_models.py`, `stateless_models.py`,
+`store_models.py`, and `rematch_models.py`. Do not change field names, defaults,
+enum values, `slots=True`, validation, or public object identity through the
+package root.
+
+**Rationale**:
+
+- The top half of the current module defines all core data structures:
+  `SlotStatus`, `ObservedSlotStatus`, `ActionKind`, `SlotAction`, `Reservation`,
+  `ManagedSlot`, `ObservedSlot`, `DesiredReservation`, `StatelessPlan`,
+  `CacheOnlyStoreRecord`, `PlannedSlot`, `DesiredPlan`, `StoredIdentity`,
+  `StoredActual`, and `SlotMapping`.
+- Tests instantiate many of these classes directly and assert enum identities.
+  Changing defaults, validation timing, or enum values would be a behavior
+  change, not a decomposition.
+- Keeping model submodules free of planner imports avoids circular dependencies
+  and makes root re-export compatibility straightforward.
+- Splitting by model family keeps each target file under 400 lines: legacy plan
+  models, stateless models, Store/cache models, action models, enums, and rematch
+  result models can evolve independently without another file-size suppression.
+
+**Alternatives considered**:
+
+- **Single `models.py` file**: Rejected because the current model classes alone
+  are too large to leave enough room for imports, SPDX headers, and docstrings
+  while satisfying the sub-400-line file gate.
+- **Separate legacy and stateless models but keep actions/enums mixed in**:
+  Rejected because shared `SlotAction` and `ActionKind` semantics are clearer and
+  smaller as their own files.
+- **Replace dataclasses with richer request/domain classes**: Rejected because
+  the feature is explicitly behavior-preserving and existing tests use dataclass
+  construction and fields as an oracle.
+
+## R-003: Identity and alias helpers remain exact
+
+**Decision**: Move fingerprinting, booking alias extraction, and slot-name
+normalization/matching helpers into `identity.py` with no algorithm changes.
+
+**Rationale**:
+
+- `make_reservation_fingerprint()` currently hashes
+  `FINGERPRINT_VERSION`, config entry id, normalized slot name, and UTC start/end
+  into a 64-character SHA-256 value. This is consumed by coordinator, calsensor,
+  and tests.
+- `normalize_slot_name_for_fingerprint()` uses `strip().casefold()` and is part
+  of the production import surface.
+- `_names_match()` accepts exact stable/display forms and configured
+  prefix-stripped physical forms, but intentionally avoids unsafe generic prefix
+  matching between distinct names such as `Ann` and `Anna`.
+- `extract_booking_aliases()` currently extracts Airbnb-style confirmation codes
+  from summary and description. Rematch tests rely on those aliases.
+
+**Alternatives considered**:
+
+- **Broaden matching to fuzzy or generic-prefix comparisons**: Rejected because
+  FR-005 requires the current exact display-name and prefix-aware model, and the
+  source explicitly documents that generic prefix matching is unsafe.
+- **Version the fingerprint during the split**: Rejected because FR-011 requires
+  existing normalized values and versioning to stay unchanged.
+
+## R-004: Pairing helpers own duplicate disambiguation
+
+**Decision**: Move slot/date distance helpers and `_pair_partial_*` functions to
+`pairing.py`. Desired-plan and stateless-plan modules call those helpers rather
+than duplicating dynamic-programming subset selection.
+
+**Rationale**:
+
+- The duplicate-assignment guarantee depends on canonical matching when there
+  are duplicate reservation names or duplicate physical slot-name matches.
+- Current pairing uses date distance, start/end ordering, slot number fallback,
+  and minimum-distance subset selection to pick canonical physical slots before
+  marking non-canonical duplicates for reset.
+- Isolating this phase makes it independently testable without changing the
+  planner's public output.
+
+**Alternatives considered**:
+
+- **Inline pairing inside each planner**: Rejected because the current bodies are
+  already oversized and the duplicate-name logic is one of the highest-risk
+  invariants.
+- **Replace dynamic programming with greedy matching**: Rejected as an algorithm
+  change. Greedy matching could reintroduce duplicate or wrong-slot assignment in
+  same-name date-shift scenarios.
+
+## R-005: Rematch hierarchy becomes one helper per rule
+
+**Decision**: Move `find_reservation_rematch()` to `rematch.py` and split its
+241-line body into rule-specific helpers while preserving the current rule order:
+exact fingerprint, UID alias plus name, booking alias plus name, name plus exact
+UTC start/end, conservative continuity with competition checking, ambiguity, and
+no match. Move supporting name, date, and continuity helpers to
+`rematch_names.py`, `rematch_dates.py`, and `rematch_continuity.py` so no rematch
+file exceeds the size gate. Preserve the current date-match tie-break inside the
+continuity rule: when multiple continuity candidates exist but exactly one
+matches stored or observed dates, the result remains `CONTINUITY` rather than
+`AMBIGUOUS`.
+
+**Rationale**:
+
+- FR-010 pins the hierarchy and ambiguity behavior. The current implementation
+  returns the first successful rule and uses `date_shifted=True` for UID alias
+  rematches after the primary fingerprint fails.
+- Current private helpers already isolate much of the rule logic; the public
+  function can become a short dispatcher without changing outcomes.
+- Fresh observed physical slot-name conflicts must continue to exclude stale
+  Store mappings from exact and alias candidates.
+- The multiple-candidate continuity date tie-break is an existing behavior, not
+  a new rule; omitting it would change rematch outcomes for adopted/observed
+  mappings that share weak continuity signals.
+- The current rematch region is large enough that one `rematch.py` containing
+  all helpers would likely fail the file-size goal. Splitting helpers by concern
+  keeps the dispatcher readable and separately testable.
+
+**Alternatives considered**:
+
+- **Retire rematch because Store is cache-only**: Rejected because production and
+  tests still import it, and cache-only aliases/diagnostics remain useful.
+- **Collapse all alias rules into one scoring function**: Rejected because the
+  explicit rule priority is part of the behavior contract and tests exercise it.
+
+## R-006: Request objects resolve parameter pressure
+
+**Decision**: Introduce `DesiredPlanRequest` and `StatelessPlanRequest` internal
+context dataclasses. Keep public planner call patterns source-compatible, but
+make public shims and all helper functions accept no more than six declared
+project-owned parameters.
+
+**Rationale**:
+
+- The current `compute_desired_plan` caller contract accepts five positional
+  arguments plus keyword-only `entry_id`, `lockname`, and `start_slot`.
+  Coordinator and tests use that contract heavily.
+- FR-017 requires the completed decomposition to satisfy the active
+  parameter-count gate even for compatibility entry points that preserve current
+  call patterns.
+- A shim with five named legacy arguments plus `**context` can accept existing
+  calls, reject unknown context keys, build `DesiredPlanRequest`, and delegate to
+  small helpers. New internal callers pass the request object directly.
+- `compute_stateless_plan` already has six parameters, but a request object keeps
+  its extracted phases small and consistent.
+
+**Alternatives considered**:
+
+- **Keep the exact eight-parameter public signature**: Rejected because the spec
+  explicitly requires the compatibility entry point to pass parameter-count
+  checks.
+- **Change all callers to pass a request object**: Rejected because FR-014
+  requires existing callers to use the same import names and call patterns.
+- **Use a broad `*args, **kwargs` shim**: Rejected because it would make argument
+  validation less explicit and harder to test. Five named arguments plus
+  validated context preserves source compatibility more clearly.
+
+## R-007: Desired and stateless planners split by phase, not behavior
+
+**Decision**: Split `compute_desired_plan` and `compute_stateless_plan` into
+phase helpers that mirror the current order: initialize, filter/select, group by
+stable name, match existing physical slots, assign unmatched reservations,
+classify actions, and build diagnostics.
+
+**Rationale**:
+
+- `compute_desired_plan` is currently 335 lines and performs all selection,
+  duplicate matching, assignment, action classification, and diagnostics setup in
+  one body.
+- `compute_stateless_plan` is currently 259 lines and repeats the same high-risk
+  duplicate matching and action-building concepts for `ObservedSlot` and
+  `DesiredReservation`.
+- Phase extraction lets tests compare each phase's output to the current
+  end-to-end oracle without introducing new business rules.
+
+**Alternatives considered**:
+
+- **Unify desired and stateless planner algorithms first**: Rejected for the
+  plan stage because shared code is only safe after byte-for-byte parity tests
+  exist for both model families.
+- **Rewrite planner logic around a new graph/matching abstraction**: Rejected as
+  too risky for a behavior-preserving decomposition of lock-code safety logic.
+
+## R-008: Actions and diagnostics get dedicated modules
+
+**Decision**: Move drift/action classification to `actions.py` and redacted
+snapshot construction to `diagnostics.py`.
+
+**Rationale**:
+
+- `_build_slot_action()` is 84 lines and action assembly is also repeated inline
+  in both planner bodies. Action metadata such as `matched_by`,
+  `requires_confirmed_empty`, `preflight_read`, `reason`, and `blocked_reason`
+  is critical to confirmed-reset-before-reapply safety.
+- `_build_plan_diagnostics_snapshot()` is 97 lines and must preserve keys,
+  sorting, redaction, drift-field representation, and existing carry-over keys.
+- Splitting these phases makes it easier to prove that raw slot codes remain
+  excluded and that diagnostics remain structurally identical.
+
+**Alternatives considered**:
+
+- **Leave diagnostics in planner modules**: Rejected because diagnostics are a
+  significant portion of the oversized functions and are independently pinned by
+  FR-012.
+- **Reduce diagnostics to a new schema**: Rejected because this feature must not
+  change support or sensor-visible output.
+
+## R-009: Remove `aislop` suppression only after thresholds pass
+
+**Decision**: Delete the file-level `aislop-ignore-file` directive only after the
+new package satisfies file-size, function-length, and parameter-count thresholds.
+Do not replace it with new suppressions.
+
+**Rationale**:
+
+- FR-016 explicitly requires removal of the file-level suppression once the
+  underlying complexity problems are resolved.
+- Removing the directive before extraction would create noisy failures without
+  improving safety.
+- New files should each stay below 400 lines and helper functions below 80 lines
+  as part of the decomposition acceptance criteria.
+
+**Alternatives considered**:
+
+- **Keep a compatibility file with a smaller suppression**: Rejected because the
+  goal is to remove hidden complexity exceptions from this engine.
+- **Suppress only the compatibility shim**: Rejected because the request-object
+  strategy lets the shim satisfy the gate without suppression.


### PR DESCRIPTION
## Summary
- Add PLAN-stage implementation design for feature 015 / issue #627.
- Document the behavior-preserving reconciliation package split and compatibility boundary.
- Add research, data-model, and quickstart artifacts for the speckit pipeline.

Part of #627