### PR TITLE
Refactor(overrides): Decompose event overrides

### DIFF
--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -16,102 +16,71 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import date
 from datetime import datetime
-from datetime import time
 import logging
-from time import monotonic
-from typing import TYPE_CHECKING
+import sys
 from typing import Any
 from typing import NamedTuple
 from typing import TypedDict
-import uuid
+from typing import cast
+import uuid  # noqa: F401 - accessed through self._module for patch compatibility
 
 from homeassistant.util import dt
 
-from .const import DEFAULT_MAX_RETRY_CYCLES
-from .reconciliation import ActionKind
-from .reconciliation import DesiredPlan
-from .reconciliation import Reservation
-from .reconciliation import SlotAction
-from .util import EventIdentity
+from .event_overrides_helpers import shell_apply as _shell_apply
+from .event_overrides_helpers import shell_cleanup as _shell_cleanup
+from .event_overrides_helpers import shell_compat as _shell_compat
+from .event_overrides_helpers import shell_slots as _shell_slots
+from .event_overrides_helpers.models import SlotReservationRequest
+from .event_overrides_helpers.models import SlotUpdateRequest
+from .event_overrides_helpers.trim import is_trimmed_match
+from .event_overrides_helpers.trim import strip_prefix
 from .util import OperationResult
-from .util import async_fire_clear_code
-from .util import async_fire_set_code
-from .util import async_fire_update_times
-from .util import get_event_identities
-from .util import is_cleared_keymaster_text_state
-from .util import is_unreadable_keymaster_text_state
-from .util import normalize_uid
-from .util import trim_name
-
-# aislop-ignore-file complexity/file-too-large complexity/function-too-long -- Existing module size is outside this emergency fix scope.
-
-if TYPE_CHECKING:
-    from homeassistant.components.calendar import CalendarEvent
+from .util import async_fire_clear_code  # noqa: F401 - accessed via self._module
+from .util import async_fire_set_code  # noqa: F401 - accessed via self._module
+from .util import async_fire_update_times  # noqa: F401 - accessed via self._module
+from .util import get_event_identities  # noqa: F401 - accessed via self._module
 
 _LOGGER = logging.getLogger(__name__)
-
-SLOT_MISS_THRESHOLD = 2
-SUPPRESSED_STATE_CHANGE_TTL = 5.0
+_PREFLIGHT_WARNINGS = {
+    "read_failed": "Skipping clear for slot %d because a fresh Keymaster read failed",
+    "non_string": "Skipping clear for slot %d because Keymaster text states are not concrete strings",
+    "unreadable": "Skipping clear for slot %d because a fresh Keymaster read is unreadable",
+    "name_changed": "Skipping clear for slot %d because physical name changed after planning",
+    "name_appeared": "Skipping clear for slot %d because physical name appeared after planning",
+    "pin_changed": "Skipping clear for slot %d because physical PIN presence changed after planning",
+}
 
 
 def _to_utc(value: datetime) -> datetime:
-    """Normalize a datetime to UTC for timezone-safe comparison.
-
-    Aware datetimes are converted via ``dt.as_utc``.  Naive datetimes
-    (missing ``tzinfo`` or returning ``None`` from ``utcoffset()``)
-    are assumed to represent Home Assistant's configured local timezone
-    before conversion.
-
-    ``dt.as_utc`` is intentionally **not** used for naive values because
-    it treats them as already-UTC, whereas values arriving here without
-    timezone info (e.g. from ``dt.parse_datetime`` on a tz-less string)
-    are more likely to be in the user's configured local timezone.
-    """
+    """Normalize a datetime to UTC for timezone-safe comparison."""
     if value.tzinfo is None or value.utcoffset() is None:
-        local: datetime = dt.as_local(value)
-        result: datetime = dt.as_utc(local)
-        return result
-    utc: datetime = dt.as_utc(value)
-    return utc
+        local: datetime = cast(datetime, dt.as_local(value))
+        return cast(datetime, dt.as_utc(local))
+    return cast(datetime, dt.as_utc(value))
 
 
 def _states_match(expected: str, actual: str) -> bool:
     """Compare raw HA state strings, normalizing datetimes when possible."""
     if expected == actual:
         return True
-
     expected_dt = dt.parse_datetime(expected)
     actual_dt = dt.parse_datetime(actual)
-    if expected_dt is not None and actual_dt is not None:
-        return _to_utc(expected_dt) == _to_utc(actual_dt)
-    return False
+    return (
+        expected_dt is not None
+        and actual_dt is not None
+        and _to_utc(expected_dt) == _to_utc(actual_dt)
+    )
 
 
 def _strip_prefix(slot_name: str, prefix: str) -> str:
-    """Remove a leading prefix and space from slot_name.
-
-    Uses ``str.removeprefix`` for deterministic matching that is safe
-    regardless of regex metacharacters in *prefix*.
-    """
-    candidate = prefix + " "
-    if slot_name.startswith(candidate):
-        return slot_name[len(candidate) :]
-    return slot_name
+    """Remove a leading prefix and space from ``slot_name``."""
+    return strip_prefix(slot_name, prefix)
 
 
 def _is_trimmed_match(name_a: str, name_b: str, guest_max: int) -> bool:
-    """Check if *name_a* and *name_b* are related by trim_name.
-
-    Returns True when trimming the longer name to *guest_max*
-    produces the shorter name, covering both word-boundary and
-    hard-truncated single-word cases.
-    """
-    if name_a == name_b or guest_max <= 0:
-        return False
-    shorter, longer = sorted((name_a, name_b), key=len)
-    return trim_name(longer, guest_max) == shorter
+    """Return whether one name is the trimmed form of the other."""
+    return is_trimmed_match(name_a, name_b, guest_max)
 
 
 class ReserveResult(NamedTuple):
@@ -135,14 +104,10 @@ class _SlotEvent:
     """Minimal event adapter for util slot-operation helpers."""
 
     def __init__(
-        self,
-        slot_name: str,
-        slot_code: str,
-        start: datetime,
-        end: datetime,
+        self, slot_name: str, slot_code: str, start: datetime, end: datetime
     ) -> None:
         """Populate the attributes expected by util service helpers."""
-        self.extra_state_attributes: dict[str, Any] = {
+        self.extra_state_attributes = {
             "slot_name": slot_name,
             "slot_code": slot_code,
             "start": start,
@@ -153,90 +118,132 @@ class _SlotEvent:
 class EventOverrides:
     """Event Overrides object and methods."""
 
+    _logger, _reserve_result = _LOGGER, ReserveResult
+    _operation_result_type, _preflight_warnings = OperationResult, _PREFLIGHT_WARNINGS
+    _states_match = staticmethod(_states_match)
+    _shell_to_utc = staticmethod(_to_utc)
+    _today_date = staticmethod(lambda: dt.start_of_local_day().date())
+    _module, _slot_event_cls = sys.modules[__name__], _SlotEvent
+    _reservation_request_type = SlotReservationRequest
+    _update_request_type = SlotUpdateRequest
+    suppress_state_changes = _shell_compat.suppress_state_changes
+    should_suppress_state_change = _shell_compat.should_suppress_state_change
+    get_last_slot_error = _shell_compat.get_last_slot_error
+    _record_slot_error = _shell_compat._record_slot_error
+    _clear_slot_error = _shell_compat._clear_slot_error
+    update_diagnostics_snapshot = _shell_compat.update_diagnostics_snapshot
+    load_persisted_mappings = _shell_compat.load_persisted_mappings
+    update_actual_state = _shell_compat.update_actual_state
+    get_actual_state = _shell_compat.get_actual_state
+    release_pending_clear_slot = _shell_compat.release_pending_clear_slot
+    _assign_next_slot = _shell_compat._assign_next_slot
+    __assign_next_slot = _shell_compat._assign_next_slot
+    _get_slots_with_values = _shell_compat._get_slots_with_values
+    __get_slots_with_values = _shell_compat._get_slots_with_values
+    _get_slots_without_values = _shell_compat._get_slots_without_values
+    __get_slots_without_values = _shell_compat._get_slots_without_values
+    _match_catalog = _shell_slots._match_catalog
+    _override_dict = _shell_compat._override_dict
+    _restore_slot_name = _shell_compat._restore_slot_name
+    _clear_assignment = _shell_compat._clear_assignment
+    _find_overlapping_slot = _shell_compat._find_overlapping_slot
+    async_reserve_or_get_slot = _shell_compat.async_reserve_or_get_slot
+    async_update = _shell_compat.async_update
+    verify_slot_ownership = _shell_compat.verify_slot_ownership
+    record_retry_failure = _shell_compat.record_retry_failure
+    record_retry_success = _shell_compat.record_retry_success
+    _slot_confirmed_empty = _shell_compat._slot_confirmed_empty
+    _fresh_slot_text_states = _shell_compat._fresh_slot_text_states
+    _preflight_clear_result = _shell_compat._preflight_clear_result
+    _slot_has_matching_event = _shell_slots._slot_has_matching_event
+    _event_has_other_uid_owner = _shell_slots._event_has_other_uid_owner
+    _slot_has_other_uid_owner = _shell_slots._slot_has_other_uid_owner
+    _get_same_start_uid_bypass_slot = _shell_slots._get_same_start_uid_bypass_slot
+    get_slot_name = _shell_slots.get_slot_name
+    get_slot_with_name = _shell_slots.get_slot_with_name
+    get_slot_key_by_name = _shell_slots.get_slot_key_by_name
+    get_slot_start_date = _shell_slots.get_slot_start_date
+    get_slot_start_time = _shell_slots.get_slot_start_time
+    get_slot_end_date = _shell_slots.get_slot_end_date
+    get_slot_end_time = _shell_slots.get_slot_end_time
+    async_apply_plan = _shell_apply.async_apply_plan
+    _apply_clear = _shell_apply._apply_clear
+    _apply_set = _shell_apply._apply_set
+    _apply_update_times = _shell_apply._apply_update_times
+    _apply_overwrite_manual_change = _shell_apply._apply_overwrite_manual_change
+    async_check_overrides = _shell_cleanup.async_check_overrides
+    update = _shell_slots.update
+
     def __init__(self, start_slot: int, max_slots: int) -> None:
         """Setup the overrides object."""
-
         self._escalated: dict[int, bool] = {}
-        self._lock: asyncio.Lock = asyncio.Lock()
-        self._max_slots: int = max_slots
+        self._lock = asyncio.Lock()
+        self._max_slots = max_slots
         self._next_slot: int | None = None
         self._overrides: dict[int, EventOverride | None] = {}
-        self._ready: bool = False
+        self._ready = False
         self._retry_counts: dict[int, int] = {}
         self._slot_miss_counts: dict[int, int] = {}
         self._slot_uids: dict[int, str | None] = {}
-        self._start_slot: int = start_slot
-        self._trim_names: bool = False
-        self._max_name_length: int = 0
-        self._event_prefix: str = ""
-        self._prefix_length: int = 0
-
-        # Store-backed fields (T018)
+        self._start_slot = start_slot
+        (
+            self._trim_names,
+            self._max_name_length,
+            self._event_prefix,
+            self._prefix_length,
+        ) = False, 0, "", 0
         self._persisted_mappings: dict[str, dict[str, Any]] = {}
         self._pending_clear_slots: dict[int, str] = {}
         self._pending_fences: dict[int, str] = {}
         self._actual_state_cache: dict[int, dict[str, Any]] = {}
-        self._reconciliation_active: bool = False
-
-        # Per-slot error tracking for diagnostics (T096)
+        self._reconciliation_active = False
         self._last_slot_errors: dict[int, str] = {}
-        # Coordinator-originated state feedback awaiting callback suppression
         self._suppressed_state_changes: dict[int, dict[str, tuple[str, float]]] = {}
-        # Latest diagnostics snapshot for HA diagnostics collection (T096)
         self._diagnostics_snapshot: dict[str, Any] = {}
 
     @property
     def max_slots(self) -> int:
-        """Return the max_slots known."""
+        """Return the configured slot count."""
         return self._max_slots
 
     @property
     def next_slot(self) -> int | None:
-        """Return the next available slot index for the greedy path.
-
-        .. deprecated::
-            This property is part of the retired greedy slot-assignment path.
-            The reconciliation coordinator (``compute_desired_plan`` /
-            ``async_apply_plan``) owns slot selection and does not consult
-            ``_next_slot``.  The property is retained as a backward-compatible
-            shim for tests that exercise :meth:`async_reserve_or_get_slot`
-            directly; production code must not read it.
-        """
+        """Return the next available greedy slot."""
         return self._next_slot
 
     @property
     def overrides(self) -> dict[int, EventOverride | None]:
-        """Return the overrides."""
+        """Return the override mapping."""
         return self._overrides
 
     @property
     def ready(self) -> bool:
-        """Return if the overrides are ready."""
+        """Return whether the override mapping is fully populated."""
         return self._ready
 
     @property
     def start_slot(self) -> int:
-        """Return the start_slot."""
+        """Return the first managed slot."""
         return self._start_slot
 
     @property
     def trim_names(self) -> bool:
-        """Return whether name trimming is enabled."""
+        """Return whether trimmed-name matching is enabled."""
         return self._trim_names
 
     @trim_names.setter
     def trim_names(self, value: bool) -> None:
-        """Set whether name trimming is enabled."""
+        """Set whether trimmed-name matching is enabled."""
         self._trim_names = value
 
     @property
     def max_name_length(self) -> int:
-        """Return the configured max name length."""
+        """Return the configured maximum slot-name length."""
         return self._max_name_length
 
     @max_name_length.setter
     def max_name_length(self, value: int) -> None:
-        """Set the configured max name length."""
+        """Set the configured maximum slot-name length."""
         self._max_name_length = value
 
     @property
@@ -247,1618 +254,23 @@ class EventOverrides:
     @event_prefix.setter
     def event_prefix(self, value: str | None) -> None:
         """Set the configured event prefix."""
-        self._event_prefix = value or ""
-        prefix = f"{self._event_prefix} " if self._event_prefix else ""
-        self._prefix_length = len(prefix)
+        self._event_prefix, self._prefix_length = (
+            value or "",
+            len(f"{value or ''} ") if value else 0,
+        )
 
     @property
     def prefix_length(self) -> int:
-        """Return the event prefix length including separator."""
+        """Return the prefix length including its separator."""
         return self._prefix_length
 
     @prefix_length.setter
     def prefix_length(self, value: int) -> None:
-        """Set the event prefix length including separator."""
+        """Set the cached prefix length."""
         self._prefix_length = value
 
-    @property
-    def persisted_mappings(self) -> dict[str, dict[str, Any]]:
-        """Return a read-only copy of the persisted slot mappings."""
-        return dict(self._persisted_mappings)
-
-    @property
-    def pending_clear_slots(self) -> dict[int, str]:
-        """Return a read-only copy of the pending-clear slot map."""
-        return dict(self._pending_clear_slots)
-
-    @property
-    def pending_fences(self) -> dict[int, str]:
-        """Return a read-only copy of pending operation fences."""
-        return dict(self._pending_fences)
-
-    @property
-    def reconciliation_active(self) -> bool:
-        """True while async_apply_plan is executing."""
-        return self._reconciliation_active
-
-    def suppress_state_changes(self, slot: int, changes: dict[str, Any]) -> None:
-        """Mark coordinator-originated state changes to ignore in callbacks."""
-        now = monotonic()
-        pending = self._suppressed_state_changes.setdefault(slot, {})
-        for entity_id, value in changes.items():
-            pending[entity_id] = (str(value), now)
-
-    def should_suppress_state_change(
-        self, slot: int, entity_id: str, state: str
-    ) -> bool:
-        """Return True when a callback is feedback from our own service call."""
-        pending = self._suppressed_state_changes.get(slot)
-        if not pending:
-            return False
-
-        now = monotonic()
-        for pending_entity_id, (_, created) in list(pending.items()):
-            if now - created > SUPPRESSED_STATE_CHANGE_TTL:
-                pending.pop(pending_entity_id, None)
-
-        expected = pending.get(entity_id)
-        if expected is None:
-            if not pending:
-                self._suppressed_state_changes.pop(slot, None)
-            return False
-
-        expected_state, _ = expected
-        if _states_match(expected_state, state):
-            pending.pop(entity_id, None)
-            if not pending:
-                self._suppressed_state_changes.pop(slot, None)
-            return True
-        return False
-
-    @property
-    def diagnostics_snapshot(self) -> dict[str, Any]:
-        """Return the latest diagnostics snapshot for HA diagnostics collection.
-
-        The snapshot is built after each :meth:`async_apply_plan` call and
-        captures matched slots, pending corrections, blocked clear reasons,
-        retry counts, and last errors.  Raw slot codes are never included.
-
-        Returns:
-            A shallow copy of the current diagnostics snapshot dict, or an
-            empty dict if no plan has been applied yet.
-        """
-        return dict(self._diagnostics_snapshot)
-
-    def get_last_slot_error(self, slot: int) -> str | None:
-        """Return the last error string for *slot*, or ``None`` if no error.
-
-        Args:
-            slot: Keymaster slot number.
-
-        Returns:
-            The last recorded error string for the slot, or ``None``.
-        """
-        return self._last_slot_errors.get(slot)
-
-    def _record_slot_error(self, slot: int, error: str) -> None:
-        """Record a failed operation error for *slot*.
-
-        Args:
-            slot: Keymaster slot number.
-            error: Human-readable error description.
-        """
-        self._last_slot_errors[slot] = error
-
-    def _clear_slot_error(self, slot: int) -> None:
-        """Clear the recorded error for *slot* on a successful operation.
-
-        Args:
-            slot: Keymaster slot number.
-        """
-        self._last_slot_errors.pop(slot, None)
-
-    def update_diagnostics_snapshot(self, plan: "DesiredPlan") -> None:
-        """Build and store a diagnostics snapshot from the completed plan.
-
-        Called after :meth:`async_apply_plan` completes.  Captures matched
-        slots (those with desired assignments), pending corrections (slots
-        with ``retry_clear`` or ``blocked`` actions), manual drift slots
-        (those with ``overwrite_manual_change`` actions), blocked clear
-        reasons, per-slot retry counts, and last errors.  Raw slot codes
-        are never included.
-
-        Args:
-            plan: The :class:`~.reconciliation.DesiredPlan` that was just applied.
-        """
-        matched: dict[int, dict[str, Any]] = {}
-        pending_corrections: dict[int, dict[str, Any]] = {}
-        manual_drift_slots: dict[int, dict[str, Any]] = {}
-
-        for slot_num, ps in plan.slots.items():
-            if ps.desired_identity_key is not None:
-                matched[slot_num] = {
-                    "identity_key": ps.desired_identity_key,
-                    "action": ps.action.value,
-                }
-            if ps.action.value in (
-                ActionKind.RETRY_CLEAR.value,
-                ActionKind.BLOCKED.value,
-            ):
-                pending_corrections[slot_num] = {
-                    "action": ps.action.value,
-                    "blocked_reason": ps.pending_reason,
-                    "retry_count": ps.retry_count,
-                }
-            if ps.action is ActionKind.OVERWRITE_MANUAL_CHANGE:
-                drift_fields: list[str] = []
-                if ps.pending_reason and ps.pending_reason.startswith(
-                    "drifted fields: "
-                ):
-                    drift_fields = [
-                        f.strip()
-                        for f in ps.pending_reason[len("drifted fields: ") :].split(",")
-                        if f.strip()
-                    ]
-                manual_drift_slots[slot_num] = {
-                    "action": ps.action.value,
-                    "identity_key": ps.desired_identity_key,
-                    "drift_fields": drift_fields,
-                }
-
-        self._diagnostics_snapshot = {
-            "plan_id": plan.plan_id,
-            "generated_at": plan.generated_at.isoformat(),
-            "matched_slots": matched,
-            "pending_corrections": pending_corrections,
-            "manual_drift_slots": manual_drift_slots,
-            "pending_clear_slots": sorted(self._pending_clear_slots.keys()),
-            "slot_retry_counts": {
-                slot: self._retry_counts.get(slot, 0)
-                for slot in range(self._start_slot, self._start_slot + self._max_slots)
-            },
-            "last_slot_errors": dict(self._last_slot_errors),
-        }
-
-    def load_persisted_mappings(self, mappings: dict[str, dict[str, Any]]) -> None:
-        """Load cache-only mappings without creating assignment fences."""
-        self._persisted_mappings = {k: dict(v) for k, v in mappings.items()}
-
-    def update_actual_state(self, slot: int, state: dict[str, Any]) -> None:
-        """Store the observed Keymaster state snapshot for a slot.
-
-        Args:
-            slot: Keymaster slot number.
-            state: Dict capturing the observed entity states for the slot.
-        """
-        self._actual_state_cache[slot] = state
-
-    def get_actual_state(self, slot: int) -> dict[str, Any] | None:
-        """Return the cached actual state for a slot, or None.
-
-        Args:
-            slot: Keymaster slot number.
-
-        Returns:
-            The cached state dict, or ``None`` if not yet observed.
-        """
-        return self._actual_state_cache.get(slot)
-
-    @staticmethod
-    def _slot_confirmed_empty(coordinator: Any, slot: int) -> bool:
-        """Return whether a fresh Keymaster read shows blank name and PIN."""
-        lockname = getattr(coordinator, "lockname", None)
-        hass = getattr(coordinator, "hass", None)
-        if not lockname or hass is None:
-            return False
-        name_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_name")
-        pin_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_pin")
-        if name_state is None or pin_state is None:
-            return False
-        return is_cleared_keymaster_text_state(
-            name_state.state
-        ) and is_cleared_keymaster_text_state(pin_state.state)
-
-    @staticmethod
-    def _fresh_slot_text_states(coordinator: Any, slot: int) -> tuple[Any, Any] | None:
-        """Return a fresh physical Keymaster name/PIN read for *slot*."""
-        lockname = getattr(coordinator, "lockname", None)
-        hass = getattr(coordinator, "hass", None)
-        if not lockname or hass is None:
-            return None
-        name_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_name")
-        pin_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_pin")
-        if name_state is None or pin_state is None:
-            return None
-        return name_state.state, pin_state.state
-
-    def _preflight_clear_result(
-        self,
-        coordinator: Any,
-        slot: int,
-        expected_name: str | None,
-    ) -> OperationResult | None:
-        """Abort stale clear actions when the physical slot changed after plan."""
-        fresh = self._fresh_slot_text_states(coordinator, slot)
-        if fresh is None:
-            _LOGGER.warning(
-                "Skipping clear for slot %d because a fresh Keymaster read failed",
-                slot,
-            )
-            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
-
-        fresh_name, fresh_pin = fresh
-        if not isinstance(fresh_name, (str, type(None))) or not isinstance(
-            fresh_pin, (str, type(None))
-        ):
-            _LOGGER.debug(
-                "Skipping clear preflight for slot %d because Keymaster text "
-                "states are not concrete strings",
-                slot,
-            )
-            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
-
-        if is_unreadable_keymaster_text_state(
-            fresh_name
-        ) or is_unreadable_keymaster_text_state(fresh_pin):
-            _LOGGER.warning(
-                "Skipping clear for slot %d because a fresh Keymaster read is unreadable",
-                slot,
-            )
-            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
-
-        fresh_empty = is_cleared_keymaster_text_state(
-            fresh_name
-        ) and is_cleared_keymaster_text_state(fresh_pin)
-        if fresh_empty:
-            self.release_pending_clear_slot(slot)
-            return OperationResult(kind="clear", slot=slot, confirmed=True)
-
-        actual = self._actual_state_cache.get(slot) or {}
-        planned_name = (
-            actual.get("name_state") if "name_state" in actual else expected_name
-        )
-        planned_has_code = actual.get("has_code")
-        fresh_name_text = "" if fresh_name is None else str(fresh_name)
-        fresh_has_code = not is_cleared_keymaster_text_state(fresh_pin)
-
-        if planned_name:
-            if not _states_match(str(planned_name), fresh_name_text):
-                _LOGGER.warning(
-                    "Skipping clear for slot %d because physical name changed "
-                    "after planning",
-                    slot,
-                )
-                return OperationResult(kind="clear", slot=slot, unconfirmed=True)
-        elif not is_cleared_keymaster_text_state(fresh_name):
-            _LOGGER.warning(
-                "Skipping clear for slot %d because physical name appeared "
-                "after planning",
-                slot,
-            )
-            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
-
-        if isinstance(planned_has_code, bool) and planned_has_code != fresh_has_code:
-            _LOGGER.warning(
-                "Skipping clear for slot %d because physical PIN presence changed "
-                "after planning",
-                slot,
-            )
-            return OperationResult(kind="clear", slot=slot, unconfirmed=True)
-
-        return None
-
-    def release_pending_clear_slot(self, slot: int) -> None:
-        """Release a pending-clear fence after observing an empty slot.
-
-        Coordinator observations are the authoritative physical state for
-        persisted clear fences.  When both Keymaster name and PIN are
-        observed empty, stale pending-clear bookkeeping must not continue
-        to block future assignments.
-        """
-        self._pending_clear_slots.pop(slot, None)
-        self._pending_fences.pop(slot, None)
-        self._overrides[slot] = None
-        self._slot_uids.pop(slot, None)
-        self._slot_miss_counts.pop(slot, None)
-        self._clear_slot_error(slot)
-
-    def __assign_next_slot(self) -> None:
-        """Recompute ``_next_slot`` for the deprecated greedy path.
-
-        Called only from the greedy-path methods (:meth:`update`,
-        :meth:`async_update`, :meth:`async_reserve_or_get_slot`,
-        :meth:`async_check_overrides`) so that :attr:`next_slot` stays
-        accurate for callers that still use the legacy API.
-
-        Reconciliation methods (:meth:`_apply_clear`, :meth:`_apply_set`,
-        :meth:`_apply_overwrite_manual_change`) do *not* call this helper;
-        slot selection in the reconciliation path is determined by
-        ``compute_desired_plan``, not by ``_next_slot``.
-
-        .. deprecated::
-            Do not call from new code.  Will be removed when the greedy
-            path shims are retired.
-        """
-
-        _LOGGER.debug("In EventOverrides.assign_next_slot")
-
-        if len(self._overrides) != self.max_slots:
-            _LOGGER.debug("System starting up")
-            return
-
-        slots_with_values = self.__get_slots_with_values()
-        if len(slots_with_values) == self.max_slots:
-            _LOGGER.debug("Overrides at max")
-            self._next_slot = None
-            return
-
-        if len(slots_with_values):
-            max_slot = slots_with_values[-1]
-        else:
-            max_slot = self.start_slot - 1
-
-        avail_slots = self.__get_slots_without_values(max_slot)
-        if len(avail_slots):
-            _LOGGER.debug("Next slot is %s", avail_slots[0])
-            self._next_slot = avail_slots[0]
-            return
-
-        # Slots greater than our current max don't work, so find the first free
-        # slot
-        avail_slots = self.__get_slots_without_values()
-
-        if len(avail_slots):
-            _LOGGER.debug("Next slot is %s", avail_slots[0])
-            self._next_slot = avail_slots[0]
-            return
-
-        # We should never hit this directly, but if we do, set our next to None
-        self._next_slot = None
-
-    def __get_slots_with_values(self) -> list[int]:
-        """Get a sorted list of the keys that have values."""
-        return sorted(
-            k for k in self._overrides.keys() if self._overrides[k] is not None
-        )
-
-    def __get_slots_without_values(self, max_slot: int = 0) -> list[int]:
-        """
-        Get the sorted list of the keys that have no value greater than
-        max_slot.
-        """
-        return sorted(
-            k
-            for k in self._overrides.keys()
-            if self._overrides[k] is None and k > max_slot
-        )
-
-    def _find_overlapping_slot(
-        self,
-        slot_name: str,
-        start_time: datetime,
-        end_time: datetime,
-        uid: str | None = None,
-        exclude_slot: int | None = None,
-    ) -> int | None:
-        """Find existing slot matching by UID or overlapping time range.
-
-        Uses a three-phase search:
-
-        Phase 1 — UID positive match.  When both the incoming event and
-        a stored slot carry a non-None UID that is equal, the slot is
-        returned immediately (provided the name also matches).  This
-        ensures that a reservation whose dates shifted beyond the
-        original overlap window is still recognised as the same booking.
-
-        Phase 2 — Strict interval overlap with a UID-aware same-start
-        bypass. ``start_a < end_b AND start_b < end_a``. If both UIDs
-        are non-None and differ, different start times are rejected but
-        same-start candidates are reconsidered as possible date-change
-        updates. When multiple same-start candidates exist, the best
-        matching slot is chosen and any exact UID owner still wins.
-
-        Phase 3 — Trim-aware fallback for trimmed names.  After a
-        Home Assistant restart the override may contain a trimmed
-        display name read back from Keymaster.  If the incoming
-        *slot_name* is the trimmed form of the stored name (or
-        vice-versa) the slot is returned.  Uses the actual
-        ``trim_name`` function so both word-boundary and
-        hard-truncated single-word cases are handled correctly.
-        Phase 3a checks UID-positive matches without requiring
-        time overlap (mirroring Phase 1).  Phase 3b checks
-        overlap-based matches (mirroring Phase 2).
-
-        When *exclude_slot* is set that slot number is skipped entirely,
-        allowing ``async_update`` to avoid matching the slot it is about
-        to write to.
-        """
-        uid = normalize_uid(uid)
-
-        if uid is not None:
-            for slot in self.__get_slots_with_values():
-                if slot == exclude_slot:
-                    continue
-                stored_uid = normalize_uid(self._slot_uids.get(slot))
-                if stored_uid is not None and stored_uid == uid:
-                    override = self._overrides[slot]
-                    if override is not None and override["slot_name"] == slot_name:
-                        return slot
-
-        start_utc = _to_utc(start_time)
-        end_utc = _to_utc(end_time)
-        preferred_same_start_slot: int | None = None
-        if uid is not None:
-            preferred_same_start_slot = self._get_same_start_uid_bypass_slot(
-                EventIdentity(slot_name, start_time, end_time, uid),
-                exclude_slot=exclude_slot,
-            )
-        for slot in self.__get_slots_with_values():
-            if slot == exclude_slot:
-                continue
-            override = self._overrides[slot]
-            if override is None:
-                continue
-            if override["slot_name"] != slot_name:
-                continue
-            if not (
-                start_utc < _to_utc(override["end_time"])
-                and _to_utc(override["start_time"]) < end_utc
-            ):
-                continue
-            stored_uid = normalize_uid(self._slot_uids.get(slot))
-            if uid is not None:
-                if stored_uid is None:
-                    if self._slot_has_other_uid_owner(
-                        slot_name, uid, exclude_slot=slot
-                    ):
-                        continue
-                    if (
-                        preferred_same_start_slot is not None
-                        and preferred_same_start_slot != slot
-                    ):
-                        continue
-                elif uid != stored_uid:
-                    # Same-start bypass: if start times match, this is likely
-                    # the same reservation with a regenerated UID (date
-                    # extension/shortening) rather than a different booking.
-                    if _to_utc(start_time) != _to_utc(override["start_time"]):
-                        continue
-                    if self._slot_has_other_uid_owner(
-                        slot_name, uid, exclude_slot=slot
-                    ):
-                        continue
-                    if preferred_same_start_slot != slot:
-                        continue
-            return slot
-
-        if self._trim_names:
-            guest_max = self._max_name_length - self._prefix_length
-
-            # Phase 3a: UID-positive trim match (no overlap required),
-            # mirrors Phase 1 but tolerates trimmed names.
-            if uid is not None:
-                for slot in self.__get_slots_with_values():
-                    if slot == exclude_slot:
-                        continue
-                    stored_uid = normalize_uid(self._slot_uids.get(slot))
-                    if stored_uid is None or stored_uid != uid:
-                        continue
-                    override = self._overrides[slot]
-                    if override is None:
-                        continue
-                    stored = override["slot_name"]
-                    if stored == slot_name:
-                        continue  # already matched in Phase 1
-                    if not _is_trimmed_match(stored, slot_name, guest_max):
-                        continue
-                    if len(slot_name) > len(stored):
-                        override["slot_name"] = slot_name
-                    return slot
-
-            # Phase 3b: trim match with overlap (no UID required).
-            for slot in self.__get_slots_with_values():
-                if slot == exclude_slot:
-                    continue
-                override = self._overrides[slot]
-                if override is None:
-                    continue
-                stored = override["slot_name"]
-                if stored == slot_name:
-                    continue  # already checked in Phase 2
-                if not _is_trimmed_match(stored, slot_name, guest_max):
-                    continue
-                if not (
-                    start_utc < _to_utc(override["end_time"])
-                    and _to_utc(override["start_time"]) < end_utc
-                ):
-                    continue
-                stored_uid = normalize_uid(self._slot_uids.get(slot))
-                if uid is not None:
-                    if stored_uid is None:
-                        if self._slot_has_other_uid_owner(
-                            slot_name, uid, exclude_slot=slot
-                        ):
-                            continue
-                        if (
-                            preferred_same_start_slot is not None
-                            and preferred_same_start_slot != slot
-                        ):
-                            continue
-                    elif uid != stored_uid:
-                        if _to_utc(start_time) != _to_utc(override["start_time"]):
-                            continue
-                        if self._slot_has_other_uid_owner(
-                            slot_name, uid, exclude_slot=slot
-                        ):
-                            continue
-                        if preferred_same_start_slot != slot:
-                            continue
-                if len(slot_name) > len(stored):
-                    override["slot_name"] = slot_name
-                return slot
-
-        return None
-
-    async def async_reserve_or_get_slot(
-        self,
-        slot_name: str,
-        slot_code: str,
-        start_time: datetime,
-        end_time: datetime,
-        uid: str | None = None,
-        prefix: str | None = None,
-    ) -> ReserveResult:
-        """Atomically find existing slot or reserve next available (greedy path).
-
-        All work is performed under ``_lock`` so concurrent callers
-        are serialised.
-
-        .. deprecated::
-            This method is the retired greedy slot-assignment path.  The
-            reconciliation coordinator (``compute_desired_plan`` /
-            ``async_apply_plan``) is now the sole authority for slot
-            assignments and does not call this method.  The method is
-            retained as a backward-compatible shim for tests that exercise
-            the greedy path directly; it must not be called from production
-            coordinator or sensor code.
-        """
-        async with self._lock:
-            if prefix is None:
-                prefix = ""
-            if slot_name and prefix:
-                slot_name = _strip_prefix(slot_name, prefix)
-
-            existing = self._find_overlapping_slot(slot_name, start_time, end_time, uid)
-            if existing is not None:
-                self._slot_miss_counts.pop(existing, None)
-                if uid is not None:
-                    self._slot_uids[existing] = normalize_uid(uid)
-                override = self._overrides[existing]
-                start_utc = _to_utc(start_time)
-                end_utc = _to_utc(end_time)
-                if override is not None and (
-                    _to_utc(override["start_time"]) != start_utc
-                    or _to_utc(override["end_time"]) != end_utc
-                ):
-                    override["start_time"] = start_time
-                    override["end_time"] = end_time
-                    return ReserveResult(existing, False, True)
-                return ReserveResult(existing, False, False)
-
-            if self._next_slot is not None:
-                new_slot = self._next_slot
-                new_override: EventOverride = {
-                    "slot_name": slot_name,
-                    "slot_code": slot_code,
-                    "start_time": start_time,
-                    "end_time": end_time,
-                }
-                self._overrides[new_slot] = new_override
-                self._slot_miss_counts.pop(new_slot, None)
-                if uid is not None:
-                    self._slot_uids[new_slot] = normalize_uid(uid)
-                self.__assign_next_slot()
-                return ReserveResult(new_slot, True, False)
-
-            _LOGGER.warning(
-                "All %d override slots are occupied; "
-                "reservation '%s' could not be assigned a slot",
-                self._max_slots,
-                slot_name,
-            )
-            return ReserveResult(None, False, False)
-
-    async def async_update(
-        self,
-        slot: int,
-        slot_code: str,
-        slot_name: str,
-        start_time: datetime,
-        end_time: datetime,
-        prefix: str | None = None,
-    ) -> None:
-        """Update slot with dedup enforcement (FR-004).
-
-        All work is performed under ``_lock`` so concurrent callers
-        are serialised.
-        """
-        async with self._lock:
-            if prefix is None:
-                prefix = ""
-            if slot_name:
-                if prefix:
-                    slot_name = _strip_prefix(slot_name, prefix)
-
-                dup = self._find_overlapping_slot(
-                    slot_name,
-                    start_time,
-                    end_time,
-                    exclude_slot=slot,
-                )
-                if dup is not None:
-                    _LOGGER.warning(
-                        "Duplicate slot_name '%s' detected in slot %d "
-                        "while writing slot %d; redirecting write",
-                        slot_name,
-                        dup,
-                        slot,
-                    )
-                    slot = dup
-
-                override: EventOverride = {
-                    "slot_name": slot_name,
-                    "slot_code": slot_code,
-                    "start_time": start_time,
-                    "end_time": end_time,
-                }
-                self._overrides[slot] = override
-                self._slot_miss_counts.pop(slot, None)
-            else:
-                self._overrides[slot] = None
-                self._slot_uids.pop(slot, None)
-                self._slot_miss_counts.pop(slot, None)
-
-            self.__assign_next_slot()
-            if len(self._overrides) == self.max_slots:
-                self._ready = True
-
-    def verify_slot_ownership(self, slot: int, expected_name: str) -> bool:
-        """Check if slot is still assigned to expected_name.
-
-        Read-only check — does not acquire the lock.
-        """
-        override = self._overrides.get(slot)
-        if override is None:
-            return False
-
-        stored_name = override["slot_name"]
-        if stored_name == expected_name:
-            return True
-
-        if not self._trim_names or self._max_name_length <= 0:
-            return False
-
-        if self._event_prefix:
-            stored_name = _strip_prefix(stored_name, self._event_prefix)
-
-        if stored_name == expected_name:
-            return True
-
-        guest_max = self._max_name_length - self._prefix_length
-        return len(expected_name) > len(stored_name) and _is_trimmed_match(
-            stored_name,
-            expected_name,
-            guest_max,
-        )
-
-    def record_retry_failure(self, slot: int) -> bool:
-        """Record failed lock command.
-
-        Returns True if escalation threshold reached.
-        """
-        count = self._retry_counts.get(slot, 0) + 1
-        self._retry_counts[slot] = count
-        if count >= DEFAULT_MAX_RETRY_CYCLES and not self._escalated.get(slot, False):
-            self._escalated[slot] = True
-            return True
-        return False
-
-    def record_retry_success(self, slot: int) -> None:
-        """Reset failure tracking for slot."""
-        self._retry_counts[slot] = 0
-        self._escalated[slot] = False
-
-    async def async_apply_plan(
-        self,
-        coordinator: Any,
-        plan: DesiredPlan,
-        res_by_key: dict[str, Reservation],
-    ) -> list[OperationResult]:
-        """Apply a desired plan by executing slot actions."""
-        async with self._lock:
-            self._reconciliation_active = True
-
-        results: list[OperationResult] = []
-        try:
-            for action in plan.actions:
-                if action.kind in {ActionKind.NOOP, ActionKind.BLOCKED}:
-                    continue
-
-                slot = action.slot
-                identity_key = action.identity_key
-
-                if action.kind in {
-                    ActionKind.CLEAR,
-                    ActionKind.RETRY_CLEAR,
-                    ActionKind.RESET,
-                }:
-                    _clear_reason = action.reason
-                    clear_warning = None
-                    if _clear_reason is not None:
-                        clear_warning = {
-                            "duplicate_non_canonical": (
-                                "Duplicate collapse: clearing non-canonical slot %d "
-                                "(duplicate actual assignment)"
-                            ),
-                            "phantom": (
-                                "Phantom recovery: clearing slot %d "
-                                "(name-only state, no usable PIN)"
-                            ),
-                            "stale": (
-                                "Stale correction: clearing slot %d "
-                                "(expired or absent reservation)"
-                            ),
-                            "mis_assigned": (
-                                "Mis-assignment correction: clearing slot %d "
-                                "(wrong reservation in slot)"
-                            ),
-                        }.get(_clear_reason)
-                    if clear_warning is not None:
-                        _LOGGER.warning(
-                            clear_warning,
-                            slot,
-                        )
-                    result = await self._apply_clear(
-                        coordinator, slot, preflight_read=action.preflight_read
-                    )
-                elif action.kind in {ActionKind.SET, ActionKind.ASSIGN}:
-                    res = res_by_key.get(identity_key) if identity_key else None
-                    if res is None:
-                        _LOGGER.warning(
-                            "SET action for slot %d has no reservation; skipping", slot
-                        )
-                        continue
-                    result = await self._apply_set(coordinator, slot, res, plan.plan_id)
-                elif action.kind is ActionKind.UPDATE_TIMES:
-                    res = res_by_key.get(identity_key) if identity_key else None
-                    if res is None:
-                        _LOGGER.warning(
-                            "UPDATE_TIMES action for slot %d has no reservation; "
-                            "skipping",
-                            slot,
-                        )
-                        continue
-                    result = await self._apply_update_times(coordinator, slot, res)
-                elif action.kind in {
-                    ActionKind.OVERWRITE_MANUAL_CHANGE,
-                    ActionKind.UPDATE_IN_PLACE,
-                }:
-                    res = res_by_key.get(identity_key) if identity_key else None
-                    if res is None:
-                        _LOGGER.warning(
-                            "OVERWRITE_MANUAL_CHANGE action for slot %d has no "
-                            "reservation; skipping",
-                            slot,
-                        )
-                        continue
-                    result = await self._apply_overwrite_manual_change(
-                        coordinator, slot, res, action
-                    )
-                else:
-                    continue
-
-                results.append(result)
-        finally:
-            self.update_diagnostics_snapshot(plan)
-            async with self._lock:
-                self._reconciliation_active = False
-
-        return results
-
-    async def _apply_clear(
-        self,
-        coordinator: Any,
-        slot: int,
-        *,
-        preflight_read: bool = False,
-    ) -> OperationResult:
-        """Apply a CLEAR or RETRY_CLEAR action for one slot."""
-        operation_id = str(uuid.uuid4())
-        expected_name: str | None = None
-
-        async with self._lock:
-            self._pending_fences[slot] = operation_id
-            self._pending_clear_slots[slot] = operation_id
-            override = self._overrides.get(slot)
-            if override is not None:
-                expected_name = override.get("slot_name")
-
-        if preflight_read:
-            preflight_result = self._preflight_clear_result(
-                coordinator, slot, expected_name
-            )
-            if preflight_result is not None:
-                async with self._lock:
-                    self._pending_fences.pop(slot, None)
-                    self._pending_clear_slots.pop(slot, None)
-                return preflight_result
-
-        result = await async_fire_clear_code(
-            coordinator, slot, expected_name=expected_name
-        )
-
-        async with self._lock:
-            current_token = self._pending_fences.get(slot)
-            if current_token != operation_id:
-                _LOGGER.warning(
-                    "Stale clear token for slot %d "
-                    "(expected %s, got %s); discarding result",
-                    slot,
-                    operation_id,
-                    current_token,
-                )
-                return OperationResult(kind="clear", slot=slot, unconfirmed=True)
-
-            if result.confirmed:
-                _LOGGER.debug("Clear confirmed for slot %d; marking free", slot)
-                self._pending_fences.pop(slot, None)
-                self._pending_clear_slots.pop(slot, None)
-                self._overrides[slot] = None
-                self._slot_uids.pop(slot, None)
-                self._slot_miss_counts.pop(slot, None)
-                self._clear_slot_error(slot)
-                # NOTE: __assign_next_slot() is intentionally NOT called here.
-                # Slot selection in the reconciliation path is determined by
-                # compute_desired_plan(), not by the deprecated _next_slot field.
-            elif result.failed:
-                _LOGGER.warning(
-                    "Clear failed for slot %d (error: %s); slot remains pending-clear",
-                    slot,
-                    result.error,
-                )
-                self._record_slot_error(slot, result.error or "clear failed")
-            elif result.lingering_name or result.lingering_pin:
-                _LOGGER.warning(
-                    "Clear not fully confirmed for slot %d "
-                    "(lingering_name=%s, lingering_pin=%s); "
-                    "slot remains pending-clear",
-                    slot,
-                    result.lingering_name,
-                    result.lingering_pin,
-                )
-                self._record_slot_error(
-                    slot,
-                    f"lingering state after clear: "
-                    f"name={result.lingering_name} pin={result.lingering_pin}",
-                )
-            else:
-                _LOGGER.debug(
-                    "Clear unconfirmed for slot %d; slot remains pending-clear", slot
-                )
-
-        return result
-
-    async def _apply_set(
-        self,
-        coordinator: Any,
-        slot: int,
-        res: Reservation,
-        plan_id: str,
-    ) -> OperationResult:
-        """Apply a SET action for one slot."""
-        import hashlib as _hashlib
-
-        if not self._slot_confirmed_empty(coordinator, slot):
-            self._record_slot_error(slot, "slot not confirmed empty before set")
-            return OperationResult(
-                kind="set",
-                slot=slot,
-                unconfirmed=True,
-                error="slot not confirmed empty",
-            )
-
-        operation_id = (
-            f"{plan_id}-set-{slot}-"
-            f"{_hashlib.sha256(res.identity_key.encode()).hexdigest()[:8]}"
-        )
-
-        async with self._lock:
-            self._pending_fences[slot] = operation_id
-            self._overrides[slot] = {
-                "slot_name": res.slot_name,
-                "slot_code": res.slot_code,
-                "start_time": res.buffered_start,
-                "end_time": res.buffered_end,
-            }
-            self._slot_miss_counts.pop(slot, None)
-            self.suppress_state_changes(
-                slot,
-                {
-                    f"switch.{coordinator.lockname}_code_slot_"
-                    f"{slot}_use_date_range_limits": "on",
-                    f"text.{coordinator.lockname}_code_slot_{slot}_name": (
-                        res.display_slot_name
-                    ),
-                    f"text.{coordinator.lockname}_code_slot_{slot}_pin": res.slot_code,
-                    f"datetime.{coordinator.lockname}_code_slot_"
-                    f"{slot}_date_range_start": res.buffered_start.isoformat(),
-                    f"datetime.{coordinator.lockname}_code_slot_"
-                    f"{slot}_date_range_end": res.buffered_end.isoformat(),
-                },
-            )
-
-        event = _SlotEvent(
-            slot_name=res.slot_name,
-            slot_code=res.slot_code,
-            start=res.start,
-            end=res.end,
-        )
-        result = await async_fire_set_code(coordinator, event, slot)
-
-        async with self._lock:
-            current_token = self._pending_fences.get(slot)
-            if current_token != operation_id:
-                _LOGGER.warning("Stale set token for slot %d; discarding result", slot)
-                return OperationResult(kind="set", slot=slot, unconfirmed=True)
-
-            if result.confirmed:
-                _LOGGER.debug(
-                    "Set confirmed for slot %d for reservation %s",
-                    slot,
-                    res.identity_key,
-                )
-                self._pending_fences.pop(slot, None)
-                self._clear_slot_error(slot)
-                # NOTE: __assign_next_slot() is intentionally NOT called here.
-                # Slot selection in the reconciliation path is determined by
-                # compute_desired_plan(), not by the deprecated _next_slot field.
-            elif result.failed:
-                _LOGGER.warning(
-                    "Set failed for slot %d (error: %s); reverting pre-assignment",
-                    slot,
-                    result.error,
-                )
-                self._pending_fences.pop(slot, None)
-                self._overrides[slot] = None
-                self._slot_uids.pop(slot, None)
-                self._record_slot_error(slot, result.error or "set failed")
-                # NOTE: __assign_next_slot() is intentionally NOT called here.
-                # Slot selection in the reconciliation path is determined by
-                # compute_desired_plan(), not by the deprecated _next_slot field.
-            else:
-                _LOGGER.debug(
-                    "Set unconfirmed for slot %d; keeping tentative assignment", slot
-                )
-                self._pending_fences.pop(slot, None)
-
-        return result
-
-    async def _apply_update_times(
-        self,
-        coordinator: Any,
-        slot: int,
-        res: Reservation,
-    ) -> OperationResult:
-        """Apply an UPDATE_TIMES action for one slot."""
-        async with self._lock:
-            self.suppress_state_changes(
-                slot,
-                {
-                    f"datetime.{coordinator.lockname}_code_slot_"
-                    f"{slot}_date_range_start": res.buffered_start.isoformat(),
-                    f"datetime.{coordinator.lockname}_code_slot_"
-                    f"{slot}_date_range_end": res.buffered_end.isoformat(),
-                },
-            )
-
-        event = _SlotEvent(
-            slot_name=res.slot_name,
-            slot_code=res.slot_code,
-            start=res.start,
-            end=res.end,
-        )
-        result = await async_fire_update_times(coordinator, event, slot)
-
-        if result.confirmed:
-            async with self._lock:
-                override = self._overrides.get(slot)
-                if override is not None:
-                    override["start_time"] = res.buffered_start
-                    override["end_time"] = res.buffered_end
-                    _LOGGER.debug(
-                        "update_times confirmed for slot %d; in-memory dates updated",
-                        slot,
-                    )
-
-        return result
-
-    async def _apply_overwrite_manual_change(
-        self,
-        coordinator: Any,
-        slot: int,
-        res: Reservation,
-        action: "SlotAction",
-    ) -> OperationResult:
-        """Apply an OVERWRITE_MANUAL_CHANGE action for one slot.
-
-        Logs a warning with all drift details — slot number, changed field
-        names, desired reservation identity, observed name and
-        classification from the actual-state cache — and then restores the
-        desired state via :func:`~.util.async_fire_set_code`.  Raw PIN
-        values are never written to logs; only code *presence* (boolean) is
-        reported.
-
-        Unmanaged slots never trigger this path because
-        :func:`~.reconciliation.compute_desired_plan` iterates only over
-        managed slots.
-
-        Args:
-            coordinator: The active coordinator instance.
-            slot: Keymaster slot number to overwrite.
-            res: Desired :class:`~.reconciliation.Reservation` for this slot.
-            action: The :class:`~.reconciliation.SlotAction` carrying the
-                ``OVERWRITE_MANUAL_CHANGE`` kind and drift reason string.
-
-        Returns:
-            An :class:`~.util.OperationResult` from the underlying
-            :func:`~.util.async_fire_set_code` call.
-        """
-        drift_fields: list[str] = []
-        if action.reason and action.reason.startswith("drifted fields: "):
-            drift_fields = [
-                f.strip()
-                for f in action.reason[len("drifted fields: ") :].split(",")
-                if f.strip()
-            ]
-
-        # Gather observed state for the log message.  The actual-state cache
-        # is populated by the coordinator before async_apply_plan is called.
-        # Raw PIN values are never stored in the cache; only has_code (bool).
-        actual = self._actual_state_cache.get(slot) or {}
-        observed_name: str = actual.get("name_state") or "(unknown)"
-        observed_classification: str = actual.get("classification") or "(unknown)"
-        observed_has_code: bool | None = actual.get("has_code")
-
-        _LOGGER.warning(
-            "Manual/external drift detected on managed slot %d "
-            "(reservation %s, desired name %r): "
-            "changed fields=%s, "
-            "observed name=%r, observed classification=%s, "
-            "observed has_code=%s; "
-            "restoring desired state.",
-            slot,
-            res.identity_key,
-            res.display_slot_name,
-            drift_fields,
-            observed_name,
-            observed_classification,
-            observed_has_code,
-        )
-
-        clear_result = await self._apply_clear(
-            coordinator, slot, preflight_read=action.preflight_read
-        )
-        if not clear_result.confirmed:
-            _LOGGER.warning(
-                "Skipping replacement set for slot %d because clear was not "
-                "physically confirmed",
-                slot,
-            )
-            return clear_result
-        return await self._apply_set(
-            coordinator,
-            slot,
-            res,
-            f"replace-{slot}-{uuid.uuid4()}",
-        )
-
-    def _slot_has_matching_event(
-        self,
-        slot: int,
-        events: list[EventIdentity],
-    ) -> bool:
-        """Check if an override slot matches any current calendar event.
-
-        Uses a three-phase search mirroring ``_find_overlapping_slot``:
-
-        Phase 1 — UID positive match.  If the stored slot UID equals an
-        event UID and the names match, the slot is considered matched
-        regardless of time overlap.
-
-        Phase 2 — name + strict interval overlap with the same-start
-        UID bypass and preferred-slot tie-breaking.
-
-        Phase 3 — trim-aware fallback for trimmed names with time
-        overlap, restoring the full name on match. The same-start UID
-        bypass and preferred-slot tie-breaking apply here too.
-        """
-        override = self._overrides[slot]
-        if override is None:
-            return False
-
-        slot_name = override["slot_name"]
-        slot_start = override["start_time"]
-        slot_end = override["end_time"]
-        stored_uid = normalize_uid(self._slot_uids.get(slot))
-
-        if stored_uid is not None:
-            for ev in events:
-                ev_uid = normalize_uid(ev.uid)
-                if ev_uid is not None and ev_uid == stored_uid and ev.name == slot_name:
-                    return True
-
-        slot_start_utc = _to_utc(slot_start)
-        slot_end_utc = _to_utc(slot_end)
-        for ev in events:
-            if ev.name != slot_name:
-                continue
-            if not (
-                slot_start_utc < _to_utc(ev.end) and _to_utc(ev.start) < slot_end_utc
-            ):
-                continue
-            ev_uid = normalize_uid(ev.uid)
-            if ev_uid is not None:
-                if stored_uid is None:
-                    if self._event_has_other_uid_owner(ev, exclude_slot=slot):
-                        continue
-                    preferred_slot = self._get_same_start_uid_bypass_slot(ev)
-                    if preferred_slot is not None and preferred_slot != slot:
-                        continue
-                elif stored_uid != ev_uid:
-                    # Same-start bypass: UID regenerated on date change.
-                    if _to_utc(ev.start) != _to_utc(slot_start):
-                        continue
-                    if self._event_has_other_uid_owner(ev, exclude_slot=slot):
-                        continue
-                    preferred_slot = self._get_same_start_uid_bypass_slot(ev)
-                    if preferred_slot != slot:
-                        continue
-            return True
-
-        if self._trim_names:
-            guest_max = self._max_name_length - self._prefix_length
-
-            # Phase 3a: UID-positive trim match (no overlap required),
-            # mirrors Phase 1 but tolerates trimmed names.
-            if stored_uid is not None:
-                for ev in events:
-                    ev_uid = normalize_uid(ev.uid)
-                    if ev_uid is None or ev_uid != stored_uid:
-                        continue
-                    if ev.name == slot_name:
-                        continue  # already matched in Phase 1
-                    if not _is_trimmed_match(slot_name, ev.name, guest_max):
-                        continue
-                    if len(ev.name) > len(slot_name):
-                        override["slot_name"] = ev.name
-                    return True
-
-            # Phase 3b: trim match with overlap (no UID required).
-            for ev in events:
-                if ev.name == slot_name:
-                    continue
-                if not _is_trimmed_match(slot_name, ev.name, guest_max):
-                    continue
-                if not (
-                    slot_start_utc < _to_utc(ev.end)
-                    and _to_utc(ev.start) < slot_end_utc
-                ):
-                    continue
-                ev_uid = normalize_uid(ev.uid)
-                if ev_uid is not None:
-                    if stored_uid is None:
-                        if self._event_has_other_uid_owner(ev, exclude_slot=slot):
-                            continue
-                        preferred_slot = self._get_same_start_uid_bypass_slot(ev)
-                        if preferred_slot is not None and preferred_slot != slot:
-                            continue
-                    elif stored_uid != ev_uid:
-                        if _to_utc(ev.start) != _to_utc(slot_start):
-                            continue
-                        if self._event_has_other_uid_owner(ev, exclude_slot=slot):
-                            continue
-                        preferred_slot = self._get_same_start_uid_bypass_slot(ev)
-                        if preferred_slot != slot:
-                            continue
-                if len(ev.name) > len(slot_name):
-                    override["slot_name"] = ev.name
-                return True
-
-        return False
-
-    def _event_has_other_uid_owner(
-        self,
-        event: EventIdentity,
-        exclude_slot: int,
-    ) -> bool:
-        """Return whether another slot claims *event* via an exact UID match."""
-        return self._slot_has_other_uid_owner(
-            event.name,
-            event.uid,
-            exclude_slot=exclude_slot,
-        )
-
-    def _slot_has_other_uid_owner(
-        self,
-        slot_name: str,
-        uid: str | None,
-        exclude_slot: int | None = None,
-    ) -> bool:
-        """Return whether another slot already owns *uid* for *slot_name*."""
-        uid = normalize_uid(uid)
-        if uid is None:
-            return False
-
-        guest_max = self._max_name_length - self._prefix_length
-        for candidate in self.__get_slots_with_values():
-            if candidate == exclude_slot:
-                continue
-            override = self._overrides[candidate]
-            if override is None:
-                continue
-
-            stored_uid = normalize_uid(self._slot_uids.get(candidate))
-            if stored_uid != uid:
-                continue
-
-            stored_name = override["slot_name"]
-            if stored_name == slot_name:
-                return True
-            if self._trim_names and _is_trimmed_match(
-                stored_name, slot_name, guest_max
-            ):
-                return True
-
-        return False
-
-    def _get_same_start_uid_bypass_slot(
-        self,
-        event: EventIdentity,
-        exclude_slot: int | None = None,
-    ) -> int | None:
-        """Return the preferred same-start fallback slot for *event*."""
-        event_start_utc = _to_utc(event.start)
-        event_end_utc = _to_utc(event.end)
-        guest_max = self._max_name_length - self._prefix_length
-
-        best_slot: int | None = None
-        best_distance: float | None = None
-        best_exact = False
-
-        for candidate in self.__get_slots_with_values():
-            if candidate == exclude_slot:
-                continue
-            override = self._overrides[candidate]
-            if override is None:
-                continue
-
-            stored_name = override["slot_name"]
-            exact_name = stored_name == event.name
-            if not exact_name:
-                if not self._trim_names or not _is_trimmed_match(
-                    stored_name, event.name, guest_max
-                ):
-                    continue
-
-            candidate_start_utc = _to_utc(override["start_time"])
-            candidate_end_utc = _to_utc(override["end_time"])
-            if not (
-                candidate_start_utc < event_end_utc
-                and event_start_utc < candidate_end_utc
-            ):
-                continue
-
-            if candidate_start_utc != event_start_utc:
-                continue
-
-            distance = abs((candidate_end_utc - event_end_utc).total_seconds())
-            if (
-                best_slot is None
-                or best_distance is None
-                or distance < best_distance
-                or (
-                    distance == best_distance
-                    and (
-                        (exact_name and not best_exact)
-                        or (exact_name == best_exact and candidate < best_slot)
-                    )
-                )
-            ):
-                best_slot = candidate
-                best_distance = distance
-                best_exact = exact_name
-
-        return best_slot
-
-    async def async_check_overrides(
-        self,
-        coordinator,
-        calendar: list[CalendarEvent] | None = None,
-    ) -> None:
-        """Check overrides and fire clear-code events for stale slots (greedy path).
-
-        When called from within _async_update_data, pass the fresh
-        calendar list directly because coordinator.data has not been
-        updated yet by the DUC framework.
-
-        .. deprecated::
-            This method implements the retired greedy cleanup policy.  Stale
-            slot detection and clearing is now handled entirely by the
-            reconciliation coordinator via ``compute_desired_plan`` /
-            ``async_apply_plan`` (``ActionKind.CLEAR`` / ``RETRY_CLEAR``).
-            The coordinator no longer calls this method.  The method is
-            retained as a backward-compatible shim; production code must
-            not invoke it.
-        """
-        _LOGGER.debug("In EventOverrides.async_check_overrides")
-
-        cal = calendar if calendar is not None else coordinator.data
-        if cal is None:
-            _LOGGER.debug("Calendar data not available, not checking override validity")
-            return
-
-        _LOGGER.debug(self._overrides)
-        # Only consider events within the sensor boundary so that
-        # slots tied to events beyond max_events get cleared.
-        sensor_cal = cal[: coordinator.max_events]
-        event_ids = get_event_identities(coordinator, calendar=sensor_cal)
-        _LOGGER.debug("event_identities = %s", event_ids)
-
-        async with self._lock:
-            assigned_slots = self.__get_slots_with_values()
-
-            if not len(assigned_slots):
-                _LOGGER.debug("No overrides to check")
-                return
-
-            cur_date_start = dt.start_of_local_day().date()
-
-            for slot in assigned_slots:
-                clear_code = False
-                start_date = self.get_slot_start_date(slot)
-
-                if not self._slot_has_matching_event(slot, event_ids):
-                    if start_date >= cur_date_start:
-                        count = self._slot_miss_counts.get(slot, 0) + 1
-                        self._slot_miss_counts[slot] = count
-                        _LOGGER.debug(
-                            "Slot %d miss count: %d/%d for %s",
-                            slot,
-                            count,
-                            SLOT_MISS_THRESHOLD,
-                            self.get_slot_name(slot),
-                        )
-                        if count >= SLOT_MISS_THRESHOLD:
-                            _LOGGER.debug(
-                                "%s not in current events after %d consecutive misses, "
-                                "clearing",
-                                self._overrides[slot],
-                                count,
-                            )
-                            clear_code = True
-                    else:
-                        _LOGGER.debug(
-                            "%s not in current events, clearing",
-                            self._overrides[slot],
-                        )
-                        clear_code = True
-                else:
-                    self._slot_miss_counts.pop(slot, None)
-
-                end_date = self.get_slot_end_date(slot)
-
-                if not len(cal):
-                    _LOGGER.debug("No events in calendar, clearing %s", slot)
-                    clear_code = True
-
-                if not clear_code and start_date > end_date:
-                    _LOGGER.debug(
-                        "%s start and end times do not make sense, clearing",
-                        slot,
-                    )
-                    clear_code = True
-
-                if not clear_code and end_date < cur_date_start:
-                    _LOGGER.debug("%s end is before today, clearing", slot)
-                    clear_code = True
-
-                if not clear_code:
-                    if coordinator.max_events <= len(cal):
-                        last_end = cal[coordinator.max_events - 1].end.date()
-                    else:
-                        last_end = cal[-1].end.date()
-
-                    if start_date > last_end:
-                        _LOGGER.debug(
-                            "%s start is after last event ends, clearing",
-                            slot,
-                        )
-                        clear_code = True
-
-                if clear_code:
-                    _LOGGER.debug("Firing clear code for slot %s", slot)
-                    try:
-                        result = await async_fire_clear_code(
-                            coordinator, slot, expected_name=self.get_slot_name(slot)
-                        )
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception:
-                        _LOGGER.exception(
-                            "Unexpected error firing clear code for slot %d; "
-                            "slot remains occupied to prevent "
-                            "double-assignment.",
-                            slot,
-                        )
-                        continue
-
-                    if not isinstance(result, OperationResult):
-                        result = OperationResult(
-                            kind="clear",
-                            slot=slot,
-                            unconfirmed=True,
-                        )
-                    if (
-                        not result.confirmed
-                        or result.failed
-                        or result.lingering_name
-                        or result.lingering_pin
-                    ):
-                        _LOGGER.warning(
-                            "Clear not confirmed for slot %d "
-                            "(failed=%s, unconfirmed=%s, "
-                            "lingering_name=%s, lingering_pin=%s); "
-                            "slot remains occupied.",
-                            slot,
-                            result.failed,
-                            result.unconfirmed,
-                            result.lingering_name,
-                            result.lingering_pin,
-                        )
-                        continue
-
-                    self._overrides[slot] = None
-                    self._slot_uids.pop(slot, None)
-                    self._slot_miss_counts.pop(slot, None)
-                    self.__assign_next_slot()
-
-    def get_slot_name(self, slot: int) -> str:
-        """Return the slot name."""
-        override = self._overrides[slot]
-
-        if override and "slot_name" in override:
-            return override["slot_name"]
-        else:
-            return ""
-
-    def get_slot_with_name(self, slot_name: str) -> EventOverride | None:
-        """
-        Find the override that has slot_name and return the data if
-        available.
-        """
-
-        slots_with_values = self.__get_slots_with_values()
-        for slot in slots_with_values:
-            override = self.overrides[slot]
-            if override and override["slot_name"] == slot_name:
-                return override
-
-        return None
-
-    def get_slot_key_by_name(self, slot_name: str) -> int:
-        """
-        Find the override that has slot_name and return the data if
-        available.
-
-        Returns 0 if no slot with name is found
-        """
-
-        slots_with_values = self.__get_slots_with_values()
-        for slot in slots_with_values:
-            override = self.overrides[slot]
-            if override and override["slot_name"] == slot_name:
-                return slot
-
-        return 0
-
-    def get_slot_start_date(self, slot: int) -> date:
-        """Return the start date of slot or today if no override."""
-
-        override = self._overrides[slot]
-        date_return: date = dt.start_of_local_day().date()
-
-        if override:
-            if "start_time" in override:
-                date_return = override["start_time"].date()
-        return date_return
-
-    def get_slot_start_time(self, slot: int) -> time:
-        """Return the start time of slot or the start of day if no override."""
-
-        override = self._overrides[slot]
-        time_return: time = time()
-
-        if override:
-            if "start_time" in override:
-                time_return = override["start_time"].time()
-        return time_return
-
-    def get_slot_end_date(self, slot: int) -> date:
-        """Return the end date of slot or today if no override."""
-
-        override = self._overrides[slot]
-        date_return: date = dt.start_of_local_day().date()
-
-        if override:
-            if "end_time" in override:
-                date_return = override["end_time"].date()
-        return date_return
-
-    def get_slot_end_time(self, slot: int) -> time:
-        """Return the end time of slot or the start of day if no override."""
-
-        override = self._overrides[slot]
-        time_return: time = time()
-
-        if override:
-            if "end_time" in override:
-                time_return = override["end_time"].time()
-        return time_return
-
-    def update(
-        self,
-        slot: int,
-        slot_code: str,
-        slot_name: str,
-        start_time: datetime,
-        end_time: datetime,
-        prefix: str | None = None,
-    ) -> None:
-        """Synchronously update overrides for a slot.
-
-        This method mutates internal state without acquiring
-        ``_lock``.  It is safe during bootstrap (before any async
-        listeners are registered) but **must** be replaced by
-        ``async_update()`` in post-bootstrap code paths once
-        callers are migrated (see Phase 3+).
-        """
-
-        _LOGGER.debug("In EventOverrides.update")
-
-        overrides = self._overrides.copy()
-
-        if prefix is None:
-            prefix = ""
-
-        if slot_name:
-            if prefix:
-                slot_name = _strip_prefix(slot_name, prefix)
-            override: EventOverride = {
-                "slot_name": slot_name,
-                "slot_code": slot_code,
-                "start_time": start_time,
-                "end_time": end_time,
-            }
-            overrides[slot] = override
-        else:
-            overrides[slot] = None
-
-        self._slot_miss_counts.pop(slot, None)
-        self._overrides = overrides
-        self.__assign_next_slot()
-        if len(overrides) == self.max_slots:
-            self._ready = True
-
-        _LOGGER.debug("overrides = %s", self.overrides)
-        _LOGGER.debug("ready = %s", self.ready)
-        _LOGGER.debug("next_slot = %s", self.next_slot)
+    persisted_mappings = property(lambda self: dict(self._persisted_mappings))
+    pending_clear_slots = property(lambda self: dict(self._pending_clear_slots))
+    pending_fences = property(lambda self: dict(self._pending_fences))
+    reconciliation_active = property(lambda self: self._reconciliation_active)
+    diagnostics_snapshot = property(lambda self: dict(self._diagnostics_snapshot))

--- a/custom_components/rental_control/event_overrides_helpers/__init__.py
+++ b/custom_components/rental_control/event_overrides_helpers/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Internal helpers for EventOverrides decomposition.
+
+This package is internal to rental_control. Do not import from
+production callers; use custom_components.rental_control.event_overrides
+instead.
+"""
+
+from .models import EvictionAction
+from .models import EvictionDecision
+from .models import EvictionReason
+from .models import MatchCatalog
+from .models import MatchPhase
+from .models import MatchRequest
+from .models import MatchResult
+from .models import OverrideSnapshot
+from .models import SlotReservationRequest
+from .models import SlotUpdateRequest
+from .models import TrimConfig
+
+__all__ = [
+    "EvictionAction",
+    "EvictionDecision",
+    "EvictionReason",
+    "MatchCatalog",
+    "MatchPhase",
+    "MatchRequest",
+    "MatchResult",
+    "OverrideSnapshot",
+    "SlotReservationRequest",
+    "SlotUpdateRequest",
+    "TrimConfig",
+]

--- a/custom_components/rental_control/event_overrides_helpers/apply_clear.py
+++ b/custom_components/rental_control/event_overrides_helpers/apply_clear.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Pure clear-application decisions for EventOverrides."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..util import is_cleared_keymaster_text_state
+from ..util import is_unreadable_keymaster_text_state
+
+
+def decide_clear_preflight(
+    fresh: tuple[Any, Any] | None,
+    expected_name: str | None,
+    actual_state: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the pure clear preflight outcome."""
+    if fresh is None:
+        return {"status": "unconfirmed", "reason": "read_failed"}
+    fresh_name, fresh_pin = fresh
+    if not isinstance(fresh_name, (str, type(None))) or not isinstance(
+        fresh_pin, (str, type(None))
+    ):
+        return {"status": "unconfirmed", "reason": "non_string"}
+    if is_unreadable_keymaster_text_state(
+        fresh_name
+    ) or is_unreadable_keymaster_text_state(fresh_pin):
+        return {"status": "unconfirmed", "reason": "unreadable"}
+    fresh_empty = is_cleared_keymaster_text_state(
+        fresh_name
+    ) and is_cleared_keymaster_text_state(fresh_pin)
+    if fresh_empty:
+        return {"status": "confirmed", "reason": "already_empty"}
+    planned_name = (
+        actual_state.get("name_state")
+        if "name_state" in actual_state
+        else expected_name
+    )
+    planned_has_code = actual_state.get("has_code")
+    fresh_name_text = "" if fresh_name is None else str(fresh_name)
+    fresh_has_code = not is_cleared_keymaster_text_state(fresh_pin)
+    if planned_name:
+        if str(planned_name) != fresh_name_text:
+            return {"status": "unconfirmed", "reason": "name_changed"}
+    elif not is_cleared_keymaster_text_state(fresh_name):
+        return {"status": "unconfirmed", "reason": "name_appeared"}
+    if isinstance(planned_has_code, bool) and planned_has_code != fresh_has_code:
+        return {"status": "unconfirmed", "reason": "pin_changed"}
+    return {"status": "proceed", "reason": None}
+
+
+def decide_clear_result_mutation(result: Any) -> dict[str, Any]:
+    """Return the in-memory mutation decision for a clear result."""
+    if result.confirmed:
+        return {"clear_slot": True, "record_error": None}
+    if result.failed:
+        return {"clear_slot": False, "record_error": result.error or "clear failed"}
+    if result.lingering_name or result.lingering_pin:
+        return {
+            "clear_slot": False,
+            "record_error": (
+                "lingering state after clear: "
+                f"name={result.lingering_name} pin={result.lingering_pin}"
+            ),
+        }
+    return {"clear_slot": False, "record_error": None}

--- a/custom_components/rental_control/event_overrides_helpers/apply_dispatch.py
+++ b/custom_components/rental_control/event_overrides_helpers/apply_dispatch.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Pure action-dispatch helpers for apply-plan wrappers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..reconciliation import ActionKind
+
+_CLEAR_WARNINGS = {
+    "duplicate_non_canonical": (
+        "Duplicate collapse: clearing non-canonical slot %d "
+        "(duplicate actual assignment)"
+    ),
+    "phantom": "Phantom recovery: clearing slot %d (name-only state, no usable PIN)",
+    "stale": "Stale correction: clearing slot %d (expired or absent reservation)",
+    "mis_assigned": (
+        "Mis-assignment correction: clearing slot %d (wrong reservation in slot)"
+    ),
+}
+
+
+def classify_action(action: Any, res_by_key: dict[str, Any]) -> dict[str, Any]:
+    """Return the pure dispatch decision for a reconciliation action."""
+    if action.kind in {ActionKind.NOOP, ActionKind.BLOCKED}:
+        return {"operation": None, "warning": None, "reservation": None}
+    if action.kind in {ActionKind.CLEAR, ActionKind.RETRY_CLEAR, ActionKind.RESET}:
+        return {
+            "operation": "clear",
+            "warning": _CLEAR_WARNINGS.get(action.reason),
+            "reservation": None,
+        }
+    return _reservation_operation(action, res_by_key)
+
+
+def _reservation_operation(action: Any, res_by_key: dict[str, Any]) -> dict[str, Any]:
+    """Resolve actions that require a reservation lookup."""
+    identity_key = action.identity_key
+    reservation = res_by_key.get(identity_key) if identity_key else None
+    operation = {
+        ActionKind.SET: "set",
+        ActionKind.ASSIGN: "set",
+        ActionKind.UPDATE_TIMES: "update_times",
+        ActionKind.OVERWRITE_MANUAL_CHANGE: "overwrite",
+        ActionKind.UPDATE_IN_PLACE: "overwrite",
+    }.get(action.kind)
+    if operation is None:
+        return {"operation": None, "warning": None, "reservation": None}
+    if reservation is None:
+        return {
+            "operation": None,
+            "warning": _missing_reservation_warning(action.kind, action.slot),
+            "reservation": None,
+        }
+    return {"operation": operation, "warning": None, "reservation": reservation}
+
+
+def _missing_reservation_warning(kind: ActionKind, slot: int) -> str:
+    """Return the existing missing-reservation warning string."""
+    if kind is ActionKind.UPDATE_TIMES:
+        return f"UPDATE_TIMES action for slot {slot} has no reservation; skipping"
+    if kind in {ActionKind.OVERWRITE_MANUAL_CHANGE, ActionKind.UPDATE_IN_PLACE}:
+        return (
+            f"OVERWRITE_MANUAL_CHANGE action for slot {slot} has no reservation; "
+            "skipping"
+        )
+    return f"SET action for slot {slot} has no reservation; skipping"

--- a/custom_components/rental_control/event_overrides_helpers/apply_set.py
+++ b/custom_components/rental_control/event_overrides_helpers/apply_set.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Pure set/assign helpers for EventOverrides."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+
+def build_set_operation_id(plan_id: str, slot: int, identity_key: str) -> str:
+    """Return the deterministic set operation fence token."""
+    digest = hashlib.sha256(identity_key.encode()).hexdigest()[:8]
+    return f"{plan_id}-set-{slot}-{digest}"
+
+
+def build_tentative_override(res: Any) -> dict[str, Any]:
+    """Return the tentative in-memory override for a reservation."""
+    return {
+        "slot_name": res.slot_name,
+        "slot_code": res.slot_code,
+        "start_time": res.buffered_start,
+        "end_time": res.buffered_end,
+    }
+
+
+def build_suppression_changes(lockname: str, slot: int, res: Any) -> dict[str, str]:
+    """Return the state-suppression payload for a set operation."""
+    return {
+        f"switch.{lockname}_code_slot_{slot}_use_date_range_limits": "on",
+        f"text.{lockname}_code_slot_{slot}_name": res.display_slot_name,
+        f"text.{lockname}_code_slot_{slot}_pin": res.slot_code,
+        f"datetime.{lockname}_code_slot_{slot}_date_range_start": res.buffered_start.isoformat(),
+        f"datetime.{lockname}_code_slot_{slot}_date_range_end": res.buffered_end.isoformat(),
+    }
+
+
+def decide_set_result_mutation(result: Any, token: bool, slot: int) -> dict[str, Any]:
+    """Return the in-memory mutation decision for a set result."""
+    del slot
+    if not token:
+        return {"status": "stale", "revert": False, "record_error": None}
+    if result.confirmed:
+        return {"status": "confirmed", "revert": False, "record_error": None}
+    if result.failed:
+        return {
+            "status": "failed",
+            "revert": True,
+            "record_error": result.error or "set failed",
+        }
+    return {"status": "unconfirmed", "revert": False, "record_error": None}

--- a/custom_components/rental_control/event_overrides_helpers/apply_update.py
+++ b/custom_components/rental_control/event_overrides_helpers/apply_update.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Pure update-times and overwrite helpers for EventOverrides."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+def build_update_time_suppression(lockname: str, slot: int, res: Any) -> dict[str, str]:
+    """Return the state-suppression payload for update-times."""
+    return {
+        f"datetime.{lockname}_code_slot_{slot}_date_range_start": res.buffered_start.isoformat(),
+        f"datetime.{lockname}_code_slot_{slot}_date_range_end": res.buffered_end.isoformat(),
+    }
+
+
+def parse_drift_fields(reason: str | None) -> list[str]:
+    """Return parsed drift field names from an overwrite reason string."""
+    if not reason or not reason.startswith("drifted fields: "):
+        return []
+    return [
+        field.strip()
+        for field in reason[len("drifted fields: ") :].split(",")
+        if field.strip()
+    ]
+
+
+def build_replacement_plan_id(slot: int, uuid4: Callable[[], object]) -> str:
+    """Return the synthetic plan id used for clear-before-replace set calls."""
+    return f"replace-{slot}-{uuid4()}"

--- a/custom_components/rental_control/event_overrides_helpers/diagnostics.py
+++ b/custom_components/rental_control/event_overrides_helpers/diagnostics.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Pure diagnostics projection helpers for EventOverrides."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..reconciliation import ActionKind
+
+
+def build_diagnostics_snapshot(
+    plan: Any,
+    pending_clear_slots: dict[int, str],
+    retry_counts: dict[int, int],
+    last_errors: dict[int, str],
+    start_slot: int,
+    max_slots: int,
+) -> dict[str, Any]:
+    """Return the diagnostics snapshot dict stored by the shell."""
+    matched: dict[int, dict[str, Any]] = {}
+    pending_corrections: dict[int, dict[str, Any]] = {}
+    manual_drift_slots: dict[int, dict[str, Any]] = {}
+    for slot_num, planned_slot in plan.slots.items():
+        if planned_slot.desired_identity_key is not None:
+            matched[slot_num] = {
+                "identity_key": planned_slot.desired_identity_key,
+                "action": planned_slot.action.value,
+            }
+        if planned_slot.action.value in {
+            ActionKind.RETRY_CLEAR.value,
+            ActionKind.BLOCKED.value,
+        }:
+            pending_corrections[slot_num] = {
+                "action": planned_slot.action.value,
+                "blocked_reason": planned_slot.pending_reason,
+                "retry_count": planned_slot.retry_count,
+            }
+        if planned_slot.action is ActionKind.OVERWRITE_MANUAL_CHANGE:
+            manual_drift_slots[slot_num] = {
+                "action": planned_slot.action.value,
+                "identity_key": planned_slot.desired_identity_key,
+                "drift_fields": _parse_drift_fields(planned_slot.pending_reason),
+            }
+    return {
+        "plan_id": plan.plan_id,
+        "generated_at": plan.generated_at.isoformat(),
+        "matched_slots": matched,
+        "pending_corrections": pending_corrections,
+        "manual_drift_slots": manual_drift_slots,
+        "pending_clear_slots": sorted(pending_clear_slots.keys()),
+        "slot_retry_counts": {
+            slot: retry_counts.get(slot, 0)
+            for slot in range(start_slot, start_slot + max_slots)
+        },
+        "last_slot_errors": dict(last_errors),
+    }
+
+
+def _parse_drift_fields(reason: str | None) -> list[str]:
+    """Return diagnostics drift field names without raw PIN data."""
+    if not reason or not reason.startswith("drifted fields: "):
+        return []
+    return [
+        field.strip()
+        for field in reason[len("drifted fields: ") :].split(",")
+        if field.strip()
+    ]

--- a/custom_components/rental_control/event_overrides_helpers/greedy_cleanup.py
+++ b/custom_components/rental_control/event_overrides_helpers/greedy_cleanup.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Pure retired-greedy cleanup decisions."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+from typing import Any
+from typing import cast
+
+from .mirror import match_target_slot
+from .models import EvictionAction
+from .models import EvictionDecision
+from .models import EvictionReason
+from .models import MatchCatalog
+from .models import MatchRequest
+from .models import OverrideSnapshot
+from .models import TrimConfig
+
+_SLOT_MISS_THRESHOLD = 2
+
+
+def compute_eviction_decisions(
+    snapshots: MatchCatalog | Sequence[OverrideSnapshot],
+    event_ids: Sequence[Any],
+    calendar: Sequence[Any],
+    max_events: int,
+    slot_miss_counts: dict[int, int],
+    cur_date: date,
+) -> list[EvictionDecision]:
+    """Return pure greedy cleanup decisions for assigned slots."""
+    catalog = _catalog_from(snapshots)
+    if not catalog.snapshots:
+        return []
+    last_end = _last_calendar_end(calendar, max_events)
+    decisions: list[EvictionDecision] = []
+    for snapshot in catalog.snapshots:
+        decision = _match_decision(
+            catalog, snapshot, event_ids, slot_miss_counts, cur_date
+        )
+        if not calendar:
+            decision = EvictionDecision(
+                snapshot.slot,
+                EvictionAction.CLEAR,
+                reason=EvictionReason.EMPTY_CALENDAR,
+            )
+        elif decision.action is not EvictionAction.CLEAR and _start_date(
+            catalog, snapshot
+        ) > _end_date(catalog, snapshot):
+            decision = EvictionDecision(
+                snapshot.slot,
+                EvictionAction.CLEAR,
+                reason=EvictionReason.MALFORMED_WINDOW,
+            )
+        elif (
+            decision.action is not EvictionAction.CLEAR
+            and _end_date(catalog, snapshot) < cur_date
+        ):
+            decision = EvictionDecision(
+                snapshot.slot, EvictionAction.CLEAR, reason=EvictionReason.PAST_END
+            )
+        elif (
+            decision.action is not EvictionAction.CLEAR
+            and last_end is not None
+            and _start_date(catalog, snapshot) > last_end
+        ):
+            decision = EvictionDecision(
+                snapshot.slot,
+                EvictionAction.CLEAR,
+                reason=EvictionReason.BEYOND_BOUNDARY,
+            )
+        decisions.append(decision)
+    return decisions
+
+
+def _catalog_from(snapshots: MatchCatalog | Sequence[OverrideSnapshot]) -> MatchCatalog:
+    """Return a matcher catalog for cleanup decisions."""
+    if isinstance(snapshots, MatchCatalog):
+        return snapshots
+    return MatchCatalog(list(snapshots), TrimConfig(False, 0, "", 0))
+
+
+def _last_calendar_end(calendar: Sequence[Any], max_events: int) -> date | None:
+    """Return the terminal event end date within the managed sensor boundary."""
+    if not calendar:
+        return None
+    index = min(len(calendar), max_events) - 1
+    return cast(date, calendar[index].end.date())
+
+
+def _match_decision(
+    catalog: MatchCatalog,
+    snapshot: OverrideSnapshot,
+    event_ids: Sequence[Any],
+    slot_miss_counts: dict[int, int],
+    cur_date: date,
+) -> EvictionDecision:
+    """Return the base match or miss-count decision for one slot."""
+    if _slot_has_matching_event(catalog, snapshot.slot, event_ids):
+        action = (
+            EvictionAction.RESET_MISS
+            if snapshot.slot in slot_miss_counts
+            else EvictionAction.PRESERVE
+        )
+        return EvictionDecision(snapshot.slot, action, reason=EvictionReason.MATCHED)
+    if _start_date(catalog, snapshot) < cur_date:
+        return EvictionDecision(
+            snapshot.slot, EvictionAction.CLEAR, reason=EvictionReason.MISSING_EVENT
+        )
+    new_count = slot_miss_counts.get(snapshot.slot, 0) + 1
+    if new_count >= _SLOT_MISS_THRESHOLD:
+        return EvictionDecision(
+            snapshot.slot, EvictionAction.CLEAR, new_count, EvictionReason.THRESHOLD
+        )
+    return EvictionDecision(
+        snapshot.slot,
+        EvictionAction.INCREMENT_MISS,
+        new_count,
+        EvictionReason.MISSING_EVENT,
+    )
+
+
+def _slot_has_matching_event(
+    catalog: MatchCatalog,
+    slot: int,
+    event_ids: Sequence[Any],
+) -> bool:
+    """Return whether ``slot`` matches any event in mirror orientation."""
+    for event in event_ids:
+        result = match_target_slot(
+            catalog,
+            slot,
+            MatchRequest(
+                slot_name=event.name,
+                start_time=event.start,
+                end_time=event.end,
+                uid=event.uid,
+                target_slot=slot,
+            ),
+        )
+        if result.slot == slot:
+            return True
+    return False
+
+
+def _start_date(catalog: MatchCatalog, snapshot: OverrideSnapshot) -> date:
+    """Return the stored local start date for cleanup decisions."""
+    if catalog.slot_dates and snapshot.slot in catalog.slot_dates:
+        return catalog.slot_dates[snapshot.slot][0]
+    return snapshot.start_time.date()
+
+
+def _end_date(catalog: MatchCatalog, snapshot: OverrideSnapshot) -> date:
+    """Return the stored local end date for cleanup decisions."""
+    if catalog.slot_dates and snapshot.slot in catalog.slot_dates:
+        return catalog.slot_dates[snapshot.slot][1]
+    return snapshot.end_time.date()

--- a/custom_components/rental_control/event_overrides_helpers/matcher.py
+++ b/custom_components/rental_control/event_overrides_helpers/matcher.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Pure shared matcher helpers for EventOverrides."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from ..util import normalize_uid
+from .models import MatchCatalog
+from .models import MatchPhase
+from .models import MatchRequest
+from .models import MatchResult
+from .models import OverrideSnapshot
+from .slot_bookkeeping import get_slots_with_values
+from .trim import is_trimmed_match
+from .trim import restored_name
+
+
+def build_match_catalog(
+    overrides: dict[int, dict[str, Any] | None],
+    slot_uids: dict[int, str | None],
+    trim_config,
+    exclude_slot: int | None = None,
+    slot_dates: dict[int, tuple[Any, Any]] | None = None,
+) -> MatchCatalog:
+    """Serialize shell override state into a pure matcher catalog."""
+    snapshots: list[OverrideSnapshot] = []
+    for slot in get_slots_with_values(overrides):
+        override = overrides.get(slot)
+        if override is None:
+            continue
+        snapshots.append(
+            OverrideSnapshot(
+                slot=slot,
+                slot_name=override["slot_name"],
+                slot_code_present=bool(override["slot_code"]),
+                start_time=override["start_time"],
+                end_time=override["end_time"],
+                uid=normalize_uid(slot_uids.get(slot)),
+            )
+        )
+    return MatchCatalog(
+        snapshots=snapshots,
+        trim_config=trim_config,
+        exclude_slot=exclude_slot,
+        slot_dates=slot_dates,
+    )
+
+
+def find_uid_positive_exact_name(
+    catalog: MatchCatalog,
+    request: MatchRequest,
+) -> MatchResult | None:
+    """Return a UID-positive exact-name match without overlap checks."""
+    uid = normalize_uid(request.uid)
+    if uid is None:
+        return None
+    for snapshot in catalog.snapshots:
+        if _excluded(snapshot.slot, catalog, request):
+            continue
+        if snapshot.uid == uid and snapshot.slot_name == request.slot_name:
+            return MatchResult(snapshot.slot, MatchPhase.UID_EXACT_NAME)
+    return None
+
+
+def find_exact_name_strict_overlap(
+    catalog: MatchCatalog,
+    request: MatchRequest,
+) -> MatchResult | None:
+    """Return an exact-name overlap match with same-start UID bypass."""
+    request_uid = normalize_uid(request.uid)
+    preferred_slot = _preferred_same_start_slot(catalog, request)
+    for snapshot in catalog.snapshots:
+        if _excluded(snapshot.slot, catalog, request):
+            continue
+        if snapshot.slot_name != request.slot_name:
+            continue
+        if not _strict_overlap(
+            request.start_time, request.end_time, snapshot.start_time, snapshot.end_time
+        ):
+            continue
+        if _uid_conflict_blocks(
+            catalog, request, snapshot, request_uid, preferred_slot
+        ):
+            continue
+        return MatchResult(snapshot.slot, MatchPhase.EXACT_NAME_STRICT_OVERLAP)
+    return None
+
+
+def find_trim_aware_fallback(
+    catalog: MatchCatalog,
+    request: MatchRequest,
+) -> MatchResult | None:
+    """Return a trim-aware fallback match across UID and overlap phases."""
+    config = catalog.trim_config
+    if not config.trim_names:
+        return None
+    request_uid = normalize_uid(request.uid)
+    preferred_slot = _preferred_same_start_slot(catalog, request)
+    if request_uid is not None:
+        for snapshot in catalog.snapshots:
+            if _excluded(snapshot.slot, catalog, request):
+                continue
+            if snapshot.uid != request_uid or snapshot.slot_name == request.slot_name:
+                continue
+            if not is_trimmed_match(
+                snapshot.slot_name, request.slot_name, config.guest_max
+            ):
+                continue
+            return MatchResult(
+                snapshot.slot,
+                MatchPhase.TRIM_UID,
+                restored_name(snapshot.slot_name, request.slot_name, config.guest_max),
+            )
+    for snapshot in catalog.snapshots:
+        if _excluded(snapshot.slot, catalog, request):
+            continue
+        if snapshot.slot_name == request.slot_name:
+            continue
+        if not is_trimmed_match(
+            snapshot.slot_name, request.slot_name, config.guest_max
+        ):
+            continue
+        if not _strict_overlap(
+            request.start_time, request.end_time, snapshot.start_time, snapshot.end_time
+        ):
+            continue
+        if _uid_conflict_blocks(
+            catalog, request, snapshot, request_uid, preferred_slot
+        ):
+            continue
+        return MatchResult(
+            snapshot.slot,
+            MatchPhase.TRIM_STRICT_OVERLAP,
+            restored_name(snapshot.slot_name, request.slot_name, config.guest_max),
+        )
+    return None
+
+
+def _has_other_uid_owner(
+    catalog: MatchCatalog,
+    slot_name: str,
+    uid: str | None,
+    exclude_slot: int | None,
+) -> bool:
+    """Return whether another snapshot already owns ``uid`` for ``slot_name``."""
+    normalized_uid = normalize_uid(uid)
+    if normalized_uid is None:
+        return False
+    guest_max = catalog.trim_config.guest_max
+    for snapshot in catalog.snapshots:
+        if snapshot.slot == exclude_slot or snapshot.uid != normalized_uid:
+            continue
+        if snapshot.slot_name == slot_name:
+            return True
+        if catalog.trim_config.trim_names and is_trimmed_match(
+            snapshot.slot_name, slot_name, guest_max
+        ):
+            return True
+    return False
+
+
+def _get_same_start_uid_bypass_slot(
+    catalog: MatchCatalog,
+    event_slot_name: str,
+    event_start_utc: datetime,
+    event_end_utc: datetime,
+    event_uid: str | None,
+    exclude_slot: int | None,
+) -> int | None:
+    """Return the preferred same-start fallback slot for an incoming event."""
+    del event_uid
+    best_slot: int | None = None
+    best_distance: float | None = None
+    best_exact = False
+    guest_max = catalog.trim_config.guest_max
+    for snapshot in catalog.snapshots:
+        if snapshot.slot == exclude_slot:
+            continue
+        exact_name = snapshot.slot_name == event_slot_name
+        if not exact_name and (
+            not catalog.trim_config.trim_names
+            or not is_trimmed_match(snapshot.slot_name, event_slot_name, guest_max)
+        ):
+            continue
+        if not _strict_overlap(
+            event_start_utc, event_end_utc, snapshot.start_time, snapshot.end_time
+        ):
+            continue
+        candidate_start = _to_utc(snapshot.start_time)
+        if candidate_start != event_start_utc:
+            continue
+        distance = abs((_to_utc(snapshot.end_time) - event_end_utc).total_seconds())
+        if _better_same_start_choice(
+            best_slot,
+            best_distance,
+            best_exact,
+            snapshot.slot,
+            distance,
+            exact_name,
+        ):
+            best_slot = snapshot.slot
+            best_distance = distance
+            best_exact = exact_name
+    return best_slot
+
+
+def match_slot(catalog: MatchCatalog, request: MatchRequest) -> MatchResult:
+    """Run the full three-phase matcher and return the selected slot."""
+    for finder in (
+        find_uid_positive_exact_name,
+        find_exact_name_strict_overlap,
+        find_trim_aware_fallback,
+    ):
+        result = finder(catalog, request)
+        if result is not None:
+            return result
+    return MatchResult(None, None)
+
+
+def _better_same_start_choice(
+    best_slot: int | None,
+    best_distance: float | None,
+    best_exact: bool,
+    slot: int,
+    distance: float,
+    exact_name: bool,
+) -> bool:
+    """Return whether a candidate wins the same-start tie-break."""
+    return (
+        best_slot is None
+        or best_distance is None
+        or distance < best_distance
+        or (
+            distance == best_distance
+            and (
+                (exact_name and not best_exact)
+                or (exact_name == best_exact and slot < best_slot)
+            )
+        )
+    )
+
+
+def _excluded(slot: int, catalog: MatchCatalog, request: MatchRequest) -> bool:
+    """Return whether ``slot`` is excluded for the current request."""
+    return slot in {catalog.exclude_slot, request.exclude_slot}
+
+
+def _preferred_same_start_slot(
+    catalog: MatchCatalog, request: MatchRequest
+) -> int | None:
+    """Return the preferred same-start slot for a request with a UID."""
+    request_uid = normalize_uid(request.uid)
+    if request_uid is None:
+        return None
+    return _get_same_start_uid_bypass_slot(
+        catalog,
+        request.slot_name,
+        _to_utc(request.start_time),
+        _to_utc(request.end_time),
+        request_uid,
+        request.exclude_slot
+        if request.exclude_slot is not None
+        else catalog.exclude_slot,
+    )
+
+
+def _strict_overlap(
+    start_a: datetime,
+    end_a: datetime,
+    start_b: datetime,
+    end_b: datetime,
+) -> bool:
+    """Return whether two windows strictly overlap in UTC."""
+    return _to_utc(start_a) < _to_utc(end_b) and _to_utc(start_b) < _to_utc(end_a)
+
+
+def _to_utc(value: datetime) -> datetime:
+    """Normalize a datetime to UTC without Home Assistant imports."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.astimezone().astimezone(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _uid_conflict_blocks(
+    catalog: MatchCatalog,
+    request: MatchRequest,
+    snapshot: OverrideSnapshot,
+    request_uid: str | None,
+    preferred_slot: int | None,
+) -> bool:
+    """Return whether UID ownership rules reject a candidate snapshot."""
+    if request_uid is None:
+        return False
+    if snapshot.uid is None:
+        return _has_other_uid_owner(
+            catalog, request.slot_name, request_uid, snapshot.slot
+        ) or (preferred_slot is not None and preferred_slot != snapshot.slot)
+    if request_uid == snapshot.uid:
+        return False
+    same_start = _to_utc(request.start_time) == _to_utc(snapshot.start_time)
+    return (
+        not same_start
+        or _has_other_uid_owner(catalog, request.slot_name, request_uid, snapshot.slot)
+        or preferred_slot != snapshot.slot
+    )

--- a/custom_components/rental_control/event_overrides_helpers/mirror.py
+++ b/custom_components/rental_control/event_overrides_helpers/mirror.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Slot-anchored mirror matcher helpers for EventOverrides."""
+
+from __future__ import annotations
+
+from ..util import normalize_uid
+from .matcher import _excluded
+from .matcher import _preferred_same_start_slot
+from .matcher import _strict_overlap
+from .matcher import _uid_conflict_blocks
+from .models import MatchCatalog
+from .models import MatchPhase
+from .models import MatchRequest
+from .models import MatchResult
+from .models import OverrideSnapshot
+from .trim import is_trimmed_match
+from .trim import restored_name
+
+
+def match_target_slot(
+    catalog: MatchCatalog, slot: int, request: MatchRequest
+) -> MatchResult:
+    """Return whether one target slot matches an event in mirror orientation."""
+    snapshot = next(
+        (
+            candidate
+            for candidate in catalog.snapshots
+            if candidate.slot == slot and not _excluded(slot, catalog, request)
+        ),
+        None,
+    )
+    if snapshot is None:
+        return MatchResult(None, None)
+    request_uid = normalize_uid(request.uid)
+    if (
+        snapshot.uid is not None
+        and snapshot.uid == request_uid
+        and snapshot.slot_name == request.slot_name
+    ):
+        return MatchResult(slot, MatchPhase.UID_EXACT_NAME)
+    exact = _target_exact_overlap(catalog, snapshot, request, request_uid)
+    if exact is not None:
+        return exact
+    return _target_trim_fallback(catalog, snapshot, request, request_uid)
+
+
+def _target_exact_overlap(
+    catalog: MatchCatalog,
+    snapshot: OverrideSnapshot,
+    request: MatchRequest,
+    request_uid: str | None,
+) -> MatchResult | None:
+    """Return an anchored exact-name overlap match."""
+    if snapshot.slot_name != request.slot_name or not _strict_overlap(
+        request.start_time, request.end_time, snapshot.start_time, snapshot.end_time
+    ):
+        return None
+    if _uid_conflict_blocks(
+        catalog,
+        request,
+        snapshot,
+        request_uid,
+        _preferred_same_start_slot(catalog, request),
+    ):
+        return None
+    return MatchResult(snapshot.slot, MatchPhase.EXACT_NAME_STRICT_OVERLAP)
+
+
+def _target_trim_fallback(
+    catalog: MatchCatalog,
+    snapshot: OverrideSnapshot,
+    request: MatchRequest,
+    request_uid: str | None,
+) -> MatchResult:
+    """Return an anchored trim-aware match."""
+    config = catalog.trim_config
+    if not config.trim_names:
+        return MatchResult(None, None)
+    if (
+        snapshot.uid is not None
+        and snapshot.uid == request_uid
+        and snapshot.slot_name != request.slot_name
+        and is_trimmed_match(snapshot.slot_name, request.slot_name, config.guest_max)
+    ):
+        return MatchResult(
+            snapshot.slot,
+            MatchPhase.TRIM_UID,
+            restored_name(snapshot.slot_name, request.slot_name, config.guest_max),
+        )
+    return _target_trim_overlap(catalog, snapshot, request, request_uid)
+
+
+def _target_trim_overlap(
+    catalog: MatchCatalog,
+    snapshot: OverrideSnapshot,
+    request: MatchRequest,
+    request_uid: str | None,
+) -> MatchResult:
+    """Return an anchored trim+overlap match."""
+    config = catalog.trim_config
+    if (
+        snapshot.slot_name == request.slot_name
+        or not is_trimmed_match(snapshot.slot_name, request.slot_name, config.guest_max)
+        or not _strict_overlap(
+            request.start_time, request.end_time, snapshot.start_time, snapshot.end_time
+        )
+        or _uid_conflict_blocks(
+            catalog,
+            request,
+            snapshot,
+            request_uid,
+            _preferred_same_start_slot(catalog, request),
+        )
+    ):
+        return MatchResult(None, None)
+    return MatchResult(
+        snapshot.slot,
+        MatchPhase.TRIM_STRICT_OVERLAP,
+        restored_name(snapshot.slot_name, request.slot_name, config.guest_max),
+    )

--- a/custom_components/rental_control/event_overrides_helpers/models.py
+++ b/custom_components/rental_control/event_overrides_helpers/models.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Shared internal models for EventOverrides helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from datetime import datetime
+from enum import Enum
+
+
+class MatchPhase(str, Enum):
+    """Internal matcher phase identifiers."""
+
+    UID_EXACT_NAME = "uid_exact_name"
+    EXACT_NAME_STRICT_OVERLAP = "exact_name_strict_overlap"
+    TRIM_UID = "trim_uid"
+    TRIM_STRICT_OVERLAP = "trim_strict_overlap"
+
+
+@dataclass(frozen=True, slots=True)
+class OverrideSnapshot:
+    """Read-only override state used by pure helpers."""
+
+    slot: int
+    slot_name: str
+    slot_code_present: bool
+    start_time: datetime
+    end_time: datetime
+    uid: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TrimConfig:
+    """Trim and prefix configuration for name matching."""
+
+    trim_names: bool
+    max_name_length: int
+    event_prefix: str
+    prefix_length: int
+
+    @property
+    def guest_max(self) -> int:
+        """Return the usable guest-name length after prefix expansion."""
+        return self.max_name_length - self.prefix_length
+
+
+@dataclass(frozen=True, slots=True)
+class MatchCatalog:
+    """Ordered override snapshots and shared trim configuration."""
+
+    snapshots: list[OverrideSnapshot]
+    trim_config: TrimConfig
+    exclude_slot: int | None = None
+    slot_dates: dict[int, tuple[date, date]] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MatchRequest:
+    """Incoming event identity used by the shared matcher."""
+
+    slot_name: str
+    start_time: datetime
+    end_time: datetime
+    uid: str | None
+    exclude_slot: int | None = None
+    target_slot: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MatchResult:
+    """Shared matcher output for both mirror wrappers."""
+
+    slot: int | None
+    phase: MatchPhase | None
+    restored_slot_name: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SlotReservationRequest:
+    """Normalized retired-greedy reservation request."""
+
+    slot_name: str
+    slot_code: str
+    start_time: datetime
+    end_time: datetime
+    uid: str | None = None
+    prefix: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SlotUpdateRequest:
+    """Normalized override update request."""
+
+    slot: int
+    slot_code: str
+    slot_name: str
+    start_time: datetime
+    end_time: datetime
+    prefix: str | None = None
+
+
+class EvictionAction(str, Enum):
+    """State mutation requested by greedy cleanup."""
+
+    RESET_MISS = "reset_miss"
+    INCREMENT_MISS = "increment_miss"
+    CLEAR = "clear"
+    PRESERVE = "preserve"
+
+
+class EvictionReason(str, Enum):
+    """Why greedy cleanup chose an eviction action."""
+
+    MISSING_EVENT = "missing_event"
+    THRESHOLD = "threshold"
+    EMPTY_CALENDAR = "empty_calendar"
+    MALFORMED_WINDOW = "malformed_window"
+    PAST_END = "past_end"
+    BEYOND_BOUNDARY = "beyond_boundary"
+    MATCHED = "matched"
+
+
+@dataclass(frozen=True, slots=True)
+class EvictionDecision:
+    """Pure decision returned by retired greedy cleanup."""
+
+    slot: int
+    action: EvictionAction
+    new_miss_count: int | None = None
+    reason: EvictionReason = EvictionReason.MATCHED

--- a/custom_components/rental_control/event_overrides_helpers/shell_apply.py
+++ b/custom_components/rental_control/event_overrides_helpers/shell_apply.py
@@ -26,11 +26,10 @@ async def async_apply_plan(self, coordinator: Any, plan, res_by_key):
         for action in plan.actions:
             decision = classify_action(action, res_by_key)
             if decision["warning"]:
-                self._logger.warning(
-                    decision["warning"], action.slot
-                ) if "%d" in decision["warning"] else self._logger.warning(
-                    decision["warning"]
-                )
+                if "%d" in decision["warning"]:
+                    self._logger.warning(decision["warning"], action.slot)
+                else:
+                    self._logger.warning(decision["warning"])
             if decision["operation"] == "clear":
                 results.append(
                     await self._apply_clear(
@@ -96,12 +95,18 @@ async def _apply_clear(
             )
         mutation = decide_clear_result_mutation(result)
         if mutation["clear_slot"]:
+            self._logger.debug("Clear confirmed for slot %d; marking free", slot)
             self._pending_fences.pop(slot, None)
             self._pending_clear_slots.pop(slot, None)
             self._clear_assignment(slot)
             self._clear_slot_error(slot)
         elif mutation["record_error"]:
+            _log_clear_not_confirmed(self, slot, result)
             self._record_slot_error(slot, mutation["record_error"])
+        else:
+            self._logger.debug(
+                "Clear unconfirmed for slot %d; slot remains pending-clear", slot
+            )
         return result
 
 
@@ -134,10 +139,22 @@ async def _apply_set(self, coordinator: Any, slot: int, res, plan_id: str):
             return self._operation_result_type(kind="set", slot=slot, unconfirmed=True)
         self._pending_fences.pop(slot, None)
         if mutation["status"] == "confirmed":
+            self._logger.debug(
+                "Set confirmed for slot %d for reservation %s", slot, res.identity_key
+            )
             self._clear_slot_error(slot)
         elif mutation["revert"]:
+            self._logger.warning(
+                "Set failed for slot %d (error: %s); reverting pre-assignment",
+                slot,
+                result.error,
+            )
             self._clear_assignment(slot)
             self._record_slot_error(slot, mutation["record_error"])
+        else:
+            self._logger.debug(
+                "Set unconfirmed for slot %d; keeping tentative assignment", slot
+            )
     return result
 
 
@@ -192,4 +209,21 @@ async def _apply_overwrite_manual_change(
         slot,
         res,
         build_replacement_plan_id(slot, self._module.uuid.uuid4),
+    )
+
+
+def _log_clear_not_confirmed(self, slot: int, result) -> None:
+    """Log the original failed or lingering clear messages."""
+    if result.failed:
+        self._logger.warning(
+            "Clear failed for slot %d (error: %s); slot remains pending-clear",
+            slot,
+            result.error,
+        )
+        return
+    self._logger.warning(
+        "Clear not fully confirmed for slot %d (lingering_name=%s, lingering_pin=%s); slot remains pending-clear",
+        slot,
+        result.lingering_name,
+        result.lingering_pin,
     )

--- a/custom_components/rental_control/event_overrides_helpers/shell_apply.py
+++ b/custom_components/rental_control/event_overrides_helpers/shell_apply.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Apply-plan shell methods for EventOverrides."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .apply_clear import decide_clear_result_mutation
+from .apply_dispatch import classify_action
+from .apply_set import build_set_operation_id
+from .apply_set import build_suppression_changes
+from .apply_set import build_tentative_override
+from .apply_set import decide_set_result_mutation
+from .apply_update import build_replacement_plan_id
+from .apply_update import build_update_time_suppression
+from .apply_update import parse_drift_fields
+
+
+async def async_apply_plan(self, coordinator: Any, plan, res_by_key):
+    """Apply a desired plan by executing slot actions."""
+    async with self._lock:
+        self._reconciliation_active = True
+    results = []
+    try:
+        for action in plan.actions:
+            decision = classify_action(action, res_by_key)
+            if decision["warning"]:
+                self._logger.warning(
+                    decision["warning"], action.slot
+                ) if "%d" in decision["warning"] else self._logger.warning(
+                    decision["warning"]
+                )
+            if decision["operation"] == "clear":
+                results.append(
+                    await self._apply_clear(
+                        coordinator, action.slot, preflight_read=action.preflight_read
+                    )
+                )
+            elif decision["operation"] == "set":
+                results.append(
+                    await self._apply_set(
+                        coordinator, action.slot, decision["reservation"], plan.plan_id
+                    )
+                )
+            elif decision["operation"] == "update_times":
+                results.append(
+                    await self._apply_update_times(
+                        coordinator, action.slot, decision["reservation"]
+                    )
+                )
+            elif decision["operation"] == "overwrite":
+                results.append(
+                    await self._apply_overwrite_manual_change(
+                        coordinator, action.slot, decision["reservation"], action
+                    )
+                )
+    finally:
+        self.update_diagnostics_snapshot(plan)
+        async with self._lock:
+            self._reconciliation_active = False
+    return results
+
+
+async def _apply_clear(
+    self, coordinator: Any, slot: int, *, preflight_read: bool = False
+):
+    """Apply a CLEAR, RETRY_CLEAR, or RESET action for one slot."""
+    operation_id = str(self._module.uuid.uuid4())
+    async with self._lock:
+        self._pending_fences[slot] = operation_id
+        self._pending_clear_slots[slot] = operation_id
+        expected_name = self.get_slot_name(slot) or None
+    if preflight_read:
+        preflight_result = self._preflight_clear_result(
+            coordinator, slot, expected_name
+        )
+        if preflight_result is not None:
+            async with self._lock:
+                self._pending_fences.pop(slot, None)
+                self._pending_clear_slots.pop(slot, None)
+            return preflight_result
+    result = await self._module.async_fire_clear_code(
+        coordinator, slot, expected_name=expected_name
+    )
+    async with self._lock:
+        if self._pending_fences.get(slot) != operation_id:
+            self._logger.warning(
+                "Stale clear token for slot %d (expected %s, got %s); discarding result",
+                slot,
+                operation_id,
+                self._pending_fences.get(slot),
+            )
+            return self._operation_result_type(
+                kind="clear", slot=slot, unconfirmed=True
+            )
+        mutation = decide_clear_result_mutation(result)
+        if mutation["clear_slot"]:
+            self._pending_fences.pop(slot, None)
+            self._pending_clear_slots.pop(slot, None)
+            self._clear_assignment(slot)
+            self._clear_slot_error(slot)
+        elif mutation["record_error"]:
+            self._record_slot_error(slot, mutation["record_error"])
+        return result
+
+
+async def _apply_set(self, coordinator: Any, slot: int, res, plan_id: str):
+    """Apply a SET or ASSIGN action for one slot."""
+    if not self._slot_confirmed_empty(coordinator, slot):
+        self._record_slot_error(slot, "slot not confirmed empty before set")
+        return self._operation_result_type(
+            kind="set", slot=slot, unconfirmed=True, error="slot not confirmed empty"
+        )
+    operation_id = build_set_operation_id(plan_id, slot, res.identity_key)
+    async with self._lock:
+        self._pending_fences[slot] = operation_id
+        self._overrides[slot] = build_tentative_override(res)
+        self._slot_miss_counts.pop(slot, None)
+        self.suppress_state_changes(
+            slot, build_suppression_changes(coordinator.lockname, slot, res)
+        )
+    result = await self._module.async_fire_set_code(
+        coordinator,
+        self._slot_event_cls(res.slot_name, res.slot_code, res.start, res.end),
+        slot,
+    )
+    async with self._lock:
+        mutation = decide_set_result_mutation(
+            result, self._pending_fences.get(slot) == operation_id, slot
+        )
+        if mutation["status"] == "stale":
+            self._logger.warning("Stale set token for slot %d; discarding result", slot)
+            return self._operation_result_type(kind="set", slot=slot, unconfirmed=True)
+        self._pending_fences.pop(slot, None)
+        if mutation["status"] == "confirmed":
+            self._clear_slot_error(slot)
+        elif mutation["revert"]:
+            self._clear_assignment(slot)
+            self._record_slot_error(slot, mutation["record_error"])
+    return result
+
+
+async def _apply_update_times(self, coordinator: Any, slot: int, res):
+    """Apply an UPDATE_TIMES action for one slot."""
+    async with self._lock:
+        self.suppress_state_changes(
+            slot, build_update_time_suppression(coordinator.lockname, slot, res)
+        )
+    result = await self._module.async_fire_update_times(
+        coordinator,
+        self._slot_event_cls(res.slot_name, res.slot_code, res.start, res.end),
+        slot,
+    )
+    if result.confirmed:
+        async with self._lock:
+            override = self._overrides.get(slot)
+            if override is not None:
+                override["start_time"], override["end_time"] = (
+                    res.buffered_start,
+                    res.buffered_end,
+                )
+    return result
+
+
+async def _apply_overwrite_manual_change(
+    self, coordinator: Any, slot: int, res, action
+):
+    """Apply an OVERWRITE_MANUAL_CHANGE or UPDATE_IN_PLACE action."""
+    actual = self._actual_state_cache.get(slot) or {}
+    self._logger.warning(
+        "Manual/external drift detected on managed slot %d (reservation %s, desired name %r): changed fields=%s, observed name=%r, observed classification=%s, observed has_code=%s; restoring desired state.",
+        slot,
+        res.identity_key,
+        res.display_slot_name,
+        parse_drift_fields(action.reason),
+        actual.get("name_state") or "(unknown)",
+        actual.get("classification") or "(unknown)",
+        actual.get("has_code"),
+    )
+    clear_result = await self._apply_clear(
+        coordinator, slot, preflight_read=action.preflight_read
+    )
+    if not clear_result.confirmed:
+        self._logger.warning(
+            "Skipping replacement set for slot %d because clear was not physically confirmed",
+            slot,
+        )
+        return clear_result
+    return await self._apply_set(
+        coordinator,
+        slot,
+        res,
+        build_replacement_plan_id(slot, self._module.uuid.uuid4),
+    )

--- a/custom_components/rental_control/event_overrides_helpers/shell_cleanup.py
+++ b/custom_components/rental_control/event_overrides_helpers/shell_cleanup.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Retired greedy cleanup shell method for EventOverrides."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from .greedy_cleanup import compute_eviction_decisions
+from .models import EvictionAction
+
+
+async def async_check_overrides(self, coordinator: Any, calendar=None) -> None:
+    """Check overrides and clear stale slots for the retired greedy path."""
+    cal = calendar if calendar is not None else coordinator.data
+    if cal is None:
+        self._logger.debug(
+            "Calendar data not available, not checking override validity"
+        )
+        return
+    event_ids = self._module.get_event_identities(
+        coordinator, calendar=cal[: coordinator.max_events]
+    )
+    async with self._lock:
+        assigned_slots = self._get_slots_with_values()
+        if not assigned_slots:
+            return
+        for slot in assigned_slots:
+            self._slot_has_matching_event(slot, event_ids)
+        decisions = compute_eviction_decisions(
+            self._match_catalog(),
+            event_ids,
+            cal,
+            coordinator.max_events,
+            dict(self._slot_miss_counts),
+            self._today_date(),
+        )
+        for decision in decisions:
+            if decision.action is EvictionAction.RESET_MISS:
+                self._slot_miss_counts.pop(decision.slot, None)
+                continue
+            if decision.action is EvictionAction.INCREMENT_MISS:
+                self._slot_miss_counts[decision.slot] = decision.new_miss_count or 0
+                continue
+            if decision.action is not EvictionAction.CLEAR:
+                continue
+            try:
+                result = await self._module.async_fire_clear_code(
+                    coordinator,
+                    decision.slot,
+                    expected_name=self.get_slot_name(decision.slot),
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self._logger.exception(
+                    "Unexpected error firing clear code for slot %d; slot remains occupied to prevent double-assignment.",
+                    decision.slot,
+                )
+                continue
+            if not isinstance(result, self._operation_result_type):
+                result = self._operation_result_type(
+                    kind="clear", slot=decision.slot, unconfirmed=True
+                )
+            if (
+                not result.confirmed
+                or result.failed
+                or result.lingering_name
+                or result.lingering_pin
+            ):
+                self._logger.warning(
+                    "Clear not confirmed for slot %d (failed=%s, unconfirmed=%s, lingering_name=%s, lingering_pin=%s); slot remains occupied.",
+                    decision.slot,
+                    result.failed,
+                    result.unconfirmed,
+                    result.lingering_name,
+                    result.lingering_pin,
+                )
+                continue
+            self._clear_assignment(decision.slot)
+            self._assign_next_slot()

--- a/custom_components/rental_control/event_overrides_helpers/shell_compat.py
+++ b/custom_components/rental_control/event_overrides_helpers/shell_compat.py
@@ -1,0 +1,502 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Compatibility-boundary methods for the EventOverrides shell."""
+
+from __future__ import annotations
+
+from time import monotonic
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+from ..const import DEFAULT_MAX_RETRY_CYCLES
+from ..util import is_cleared_keymaster_text_state
+from ..util import normalize_uid
+from .apply_clear import decide_clear_preflight
+from .diagnostics import build_diagnostics_snapshot
+from .matcher import _get_same_start_uid_bypass_slot as _matcher_same_start_slot
+from .matcher import _has_other_uid_owner
+from .matcher import build_match_catalog
+from .matcher import match_slot
+from .models import MatchRequest
+from .slot_bookkeeping import compute_next_slot
+from .slot_bookkeeping import get_slots_with_values
+from .slot_bookkeeping import get_slots_without_values
+from .slot_bookkeeping import normalize_reservation_request
+from .slot_bookkeeping import normalize_update_request
+from .trim import make_trim_config
+from .trim import names_match
+from .trim import strip_prefix
+
+if TYPE_CHECKING:
+    from ..event_overrides import ReserveResult
+
+SUPPRESSED_STATE_CHANGE_TTL = 5.0
+
+
+def suppress_state_changes(self, slot: int, changes: dict[str, Any]) -> None:
+    """Mark coordinator-originated state changes to ignore in callbacks."""
+    now = monotonic()
+    pending = self._suppressed_state_changes.setdefault(slot, {})
+    for entity_id, value in changes.items():
+        pending[entity_id] = (str(value), now)
+
+
+def should_suppress_state_change(self, slot: int, entity_id: str, state: str) -> bool:
+    """Return whether a callback is feedback from our own service call."""
+    pending = self._suppressed_state_changes.get(slot)
+    if not pending:
+        return False
+    now = monotonic()
+    for pending_entity_id, (_, created) in list(pending.items()):
+        if now - created > SUPPRESSED_STATE_CHANGE_TTL:
+            pending.pop(pending_entity_id, None)
+    expected = pending.get(entity_id)
+    if expected is None:
+        if not pending:
+            self._suppressed_state_changes.pop(slot, None)
+        return False
+    if self._states_match(expected[0], state):
+        pending.pop(entity_id, None)
+        if not pending:
+            self._suppressed_state_changes.pop(slot, None)
+        return True
+    return False
+
+
+def get_last_slot_error(self, slot: int) -> str | None:
+    """Return the last recorded slot error."""
+    return cast("str | None", self._last_slot_errors.get(slot))
+
+
+def _record_slot_error(self, slot: int, error: str) -> None:
+    """Record a failed operation error."""
+    self._last_slot_errors[slot] = error
+
+
+def _clear_slot_error(self, slot: int) -> None:
+    """Clear any recorded slot error."""
+    self._last_slot_errors.pop(slot, None)
+
+
+def update_diagnostics_snapshot(self, plan) -> None:
+    """Build and store a diagnostics snapshot from the completed plan."""
+    self._diagnostics_snapshot = build_diagnostics_snapshot(
+        plan,
+        self._pending_clear_slots,
+        self._retry_counts,
+        self._last_slot_errors,
+        self._start_slot,
+        self._max_slots,
+    )
+
+
+def load_persisted_mappings(self, mappings: dict[str, dict[str, Any]]) -> None:
+    """Load cache-only mappings without creating assignment fences."""
+    self._persisted_mappings = {key: dict(value) for key, value in mappings.items()}
+
+
+def update_actual_state(self, slot: int, state: dict[str, Any]) -> None:
+    """Store the observed Keymaster state snapshot for a slot."""
+    self._actual_state_cache[slot] = state
+
+
+def get_actual_state(self, slot: int) -> dict[str, Any] | None:
+    """Return the cached actual state for ``slot``."""
+    return cast("dict[str, Any] | None", self._actual_state_cache.get(slot))
+
+
+def release_pending_clear_slot(self, slot: int) -> None:
+    """Release a pending-clear fence after observing an empty slot."""
+    self._pending_clear_slots.pop(slot, None)
+    self._pending_fences.pop(slot, None)
+    self._clear_assignment(slot)
+    self._clear_slot_error(slot)
+
+
+def _slot_confirmed_empty(self, coordinator: Any, slot: int) -> bool:
+    """Return whether a fresh Keymaster read shows blank name and PIN."""
+    lockname = getattr(coordinator, "lockname", None)
+    hass = getattr(coordinator, "hass", None)
+    if not lockname or hass is None:
+        return False
+    name_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_name")
+    pin_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_pin")
+    return (
+        bool(name_state and pin_state)
+        and is_cleared_keymaster_text_state(name_state.state)
+        and is_cleared_keymaster_text_state(pin_state.state)
+    )
+
+
+def _fresh_slot_text_states(
+    self, coordinator: Any, slot: int
+) -> tuple[Any, Any] | None:
+    """Return a fresh physical Keymaster name/PIN read for ``slot``."""
+    lockname = getattr(coordinator, "lockname", None)
+    hass = getattr(coordinator, "hass", None)
+    if not lockname or hass is None:
+        return None
+    name_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_name")
+    pin_state = hass.states.get(f"text.{lockname}_code_slot_{slot}_pin")
+    return (
+        None
+        if name_state is None or pin_state is None
+        else (name_state.state, pin_state.state)
+    )
+
+
+def _preflight_clear_result(
+    self, coordinator: Any, slot: int, expected_name: str | None
+):
+    """Abort stale clear actions when the physical slot changed after plan."""
+    fresh = self._fresh_slot_text_states(coordinator, slot)
+    actual = self._actual_state_cache.get(slot) or {}
+    if (
+        fresh is not None
+        and "name_state" in actual
+        and actual["name_state"] is not None
+    ):
+        fresh_name = "" if fresh[0] is None else str(fresh[0])
+        if self._states_match(str(actual["name_state"]), fresh_name):
+            actual = {**actual, "name_state": fresh_name}
+    outcome = decide_clear_preflight(fresh, expected_name, actual)
+    if outcome["status"] == "proceed":
+        return None
+    if outcome["status"] == "confirmed":
+        self.release_pending_clear_slot(slot)
+        return self._operation_result_type(kind="clear", slot=slot, confirmed=True)
+    self._logger.warning(self._preflight_warnings[outcome["reason"]], slot)
+    return self._operation_result_type(kind="clear", slot=slot, unconfirmed=True)
+
+
+def _assign_next_slot(self) -> None:
+    """Recompute ``_next_slot`` for the deprecated greedy path."""
+    self._next_slot = compute_next_slot(
+        self._overrides, self.start_slot, self.max_slots
+    )
+
+
+def _get_slots_with_values(self) -> list[int]:
+    """Return sorted occupied slot numbers."""
+    return get_slots_with_values(self._overrides)
+
+
+def _get_slots_without_values(self, max_slot: int = 0) -> list[int]:
+    """Return sorted free slot numbers greater than ``max_slot``."""
+    return get_slots_without_values(self._overrides, max_slot)
+
+
+def _match_catalog(self, exclude_slot: int | None = None):
+    """Return a pure catalog snapshot of the current override state."""
+    normalized = {
+        slot: (
+            None
+            if override is None
+            else {
+                **override,
+                "start_time": self._shell_to_utc(override["start_time"]),
+                "end_time": self._shell_to_utc(override["end_time"]),
+            }
+        )
+        for slot, override in self._overrides.items()
+    }
+    return build_match_catalog(
+        normalized,
+        self._slot_uids,
+        make_trim_config(
+            self._trim_names,
+            self._max_name_length,
+            self._event_prefix,
+            self._prefix_length,
+        ),
+        exclude_slot,
+    )
+
+
+def _override_dict(self, slot_code: str, slot_name: str, start_time, end_time):
+    """Return a new override payload dict."""
+    return {
+        "slot_name": slot_name,
+        "slot_code": slot_code,
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+
+
+def _restore_slot_name(self, result: Any) -> None:
+    """Apply a trim-aware full-name restoration from a matcher result."""
+    if (
+        result.slot is not None
+        and result.restored_slot_name
+        and self._overrides.get(result.slot) is not None
+    ):
+        self._overrides[result.slot]["slot_name"] = result.restored_slot_name
+
+
+def _clear_assignment(self, slot: int) -> None:
+    """Clear in-memory override, UID, and miss-count state for ``slot``."""
+    self._overrides[slot] = None
+    self._slot_uids.pop(slot, None)
+    self._slot_miss_counts.pop(slot, None)
+
+
+def _find_overlapping_slot(
+    self,
+    slot_name: str,
+    start_time,
+    end_time,
+    uid: str | None = None,
+    exclude_slot: int | None = None,
+) -> int | None:
+    """Find an existing slot matching a reservation identity."""
+    result = match_slot(
+        self._match_catalog(exclude_slot),
+        MatchRequest(
+            slot_name,
+            self._shell_to_utc(start_time),
+            self._shell_to_utc(end_time),
+            uid,
+            exclude_slot=exclude_slot,
+        ),
+    )
+    self._restore_slot_name(result)
+    return result.slot
+
+
+async def async_reserve_or_get_slot(
+    self, request=None, *values: Any, **legacy: Any
+) -> "ReserveResult":
+    """Atomically find an existing slot or reserve the next available one."""
+    payload = (
+        request
+        if isinstance(request, self._reservation_request_type)
+        else normalize_reservation_request(
+            *(() if request is None else (request,)), *values, **legacy
+        )
+    )
+    slot_name = (
+        strip_prefix(payload.slot_name, payload.prefix or "")
+        if payload.slot_name and payload.prefix
+        else payload.slot_name
+    )
+    async with self._lock:
+        existing = self._find_overlapping_slot(
+            slot_name, payload.start_time, payload.end_time, payload.uid
+        )
+        if existing is not None:
+            self._slot_miss_counts.pop(existing, None)
+            if payload.uid is not None:
+                self._slot_uids[existing] = normalize_uid(payload.uid)
+            override = self._overrides[existing]
+            changed = override is not None and (
+                self._shell_to_utc(override["start_time"])
+                != self._shell_to_utc(payload.start_time)
+                or self._shell_to_utc(override["end_time"])
+                != self._shell_to_utc(payload.end_time)
+            )
+            if changed and override is not None:
+                override["start_time"], override["end_time"] = (
+                    payload.start_time,
+                    payload.end_time,
+                )
+            return cast("ReserveResult", self._reserve_result(existing, False, changed))
+        if self._next_slot is None:
+            self._logger.warning(
+                "All %d override slots are occupied; reservation '%s' could not be assigned a slot",
+                self._max_slots,
+                slot_name,
+            )
+            return cast("ReserveResult", self._reserve_result(None, False, False))
+        slot = self._next_slot
+        self._overrides[slot] = self._override_dict(
+            payload.slot_code, slot_name, payload.start_time, payload.end_time
+        )
+        self._slot_miss_counts.pop(slot, None)
+        if payload.uid is not None:
+            self._slot_uids[slot] = normalize_uid(payload.uid)
+        self._assign_next_slot()
+        return cast("ReserveResult", self._reserve_result(slot, True, False))
+
+
+async def async_update(self, update=None, *values: Any, **legacy: Any) -> None:
+    """Update a slot with duplicate-detection enforcement."""
+    payload = (
+        update
+        if isinstance(update, self._update_request_type)
+        else normalize_update_request(
+            *(() if update is None else (update,)), *values, **legacy
+        )
+    )
+    slot_name = (
+        strip_prefix(payload.slot_name, payload.prefix or "")
+        if payload.slot_name and payload.prefix
+        else payload.slot_name
+    )
+    async with self._lock:
+        slot = payload.slot
+        if slot_name:
+            duplicate = self._find_overlapping_slot(
+                slot_name, payload.start_time, payload.end_time, exclude_slot=slot
+            )
+            if duplicate is not None:
+                self._logger.warning(
+                    "Duplicate slot_name '%s' detected in slot %d while writing slot %d; redirecting write",
+                    slot_name,
+                    duplicate,
+                    slot,
+                )
+                slot = duplicate
+            self._overrides[slot] = self._override_dict(
+                payload.slot_code, slot_name, payload.start_time, payload.end_time
+            )
+            self._slot_miss_counts.pop(slot, None)
+        else:
+            self._clear_assignment(slot)
+        self._assign_next_slot()
+        if len(self._overrides) == self.max_slots:
+            self._ready = True
+
+
+def verify_slot_ownership(self, slot: int, expected_name: str) -> bool:
+    """Return whether ``slot`` is still assigned to ``expected_name``."""
+    override = self._overrides.get(slot)
+    return override is not None and names_match(
+        override["slot_name"],
+        expected_name,
+        make_trim_config(
+            self._trim_names,
+            self._max_name_length,
+            self._event_prefix,
+            self._prefix_length,
+        ),
+    )
+
+
+def record_retry_failure(self, slot: int) -> bool:
+    """Record a failed lock command and return whether escalation is due."""
+    count = self._retry_counts.get(slot, 0) + 1
+    self._retry_counts[slot] = count
+    if count >= DEFAULT_MAX_RETRY_CYCLES and not self._escalated.get(slot, False):
+        self._escalated[slot] = True
+        return True
+    return False
+
+
+def record_retry_success(self, slot: int) -> None:
+    """Reset failure tracking for ``slot``."""
+    self._retry_counts[slot], self._escalated[slot] = 0, False
+
+
+def _slot_has_matching_event(self, slot: int, events) -> bool:
+    """Return whether ``slot`` still wins the shared matcher for any event."""
+    if self._overrides.get(slot) is None:
+        return False
+    catalog = self._match_catalog()
+    for event in events:
+        result = match_slot(
+            catalog,
+            MatchRequest(
+                event.name,
+                self._shell_to_utc(event.start),
+                self._shell_to_utc(event.end),
+                event.uid,
+                target_slot=slot,
+            ),
+        )
+        if result.slot == slot:
+            self._restore_slot_name(result)
+            return True
+    return False
+
+
+def _event_has_other_uid_owner(self, event, exclude_slot: int) -> bool:
+    """Return whether another slot claims ``event`` via an exact UID match."""
+    return bool(
+        self._slot_has_other_uid_owner(event.name, event.uid, exclude_slot=exclude_slot)
+    )
+
+
+def _slot_has_other_uid_owner(
+    self,
+    slot_name: str,
+    uid: str | None,
+    exclude_slot: int | None = None,
+) -> bool:
+    """Return whether another slot already owns ``uid`` for ``slot_name``."""
+    return _has_other_uid_owner(
+        self._match_catalog(exclude_slot), slot_name, uid, exclude_slot
+    )
+
+
+def _get_same_start_uid_bypass_slot(
+    self, event, exclude_slot: int | None = None
+) -> int | None:
+    """Return the preferred same-start fallback slot for ``event``."""
+    return _matcher_same_start_slot(
+        self._match_catalog(exclude_slot),
+        event.name,
+        self._shell_to_utc(event.start),
+        self._shell_to_utc(event.end),
+        event.uid,
+        exclude_slot,
+    )
+
+
+def get_slot_name(self, slot: int) -> str:
+    """Return the slot name for ``slot`` or an empty string."""
+    override = self._overrides.get(slot)
+    return override["slot_name"] if override and "slot_name" in override else ""
+
+
+def get_slot_with_name(self, slot_name: str):
+    """Return the first override whose stored name matches ``slot_name``."""
+    return next(
+        (
+            override
+            for slot in self._get_slots_with_values()
+            if (override := self.overrides[slot]) and override["slot_name"] == slot_name
+        ),
+        None,
+    )
+
+
+def get_slot_key_by_name(self, slot_name: str) -> int:
+    """Return the slot number for ``slot_name`` or ``0`` when absent."""
+    return next(
+        (
+            slot
+            for slot in self._get_slots_with_values()
+            if (override := self.overrides[slot]) and override["slot_name"] == slot_name
+        ),
+        0,
+    )
+
+
+def update(self, update=None, *values: Any, **legacy: Any) -> None:
+    """Synchronously update overrides for a slot."""
+    payload = (
+        update
+        if isinstance(update, self._update_request_type)
+        else normalize_update_request(
+            *(() if update is None else (update,)), *values, **legacy
+        )
+    )
+    slot_name = (
+        strip_prefix(payload.slot_name, payload.prefix or "")
+        if payload.slot_name and payload.prefix
+        else payload.slot_name
+    )
+    overrides = self._overrides.copy()
+    overrides[payload.slot] = (
+        self._override_dict(
+            payload.slot_code, slot_name, payload.start_time, payload.end_time
+        )
+        if slot_name
+        else None
+    )
+    self._slot_miss_counts.pop(payload.slot, None)
+    self._overrides = overrides
+    self._assign_next_slot()
+    if len(overrides) == self.max_slots:
+        self._ready = True

--- a/custom_components/rental_control/event_overrides_helpers/shell_compat.py
+++ b/custom_components/rental_control/event_overrides_helpers/shell_compat.py
@@ -14,9 +14,6 @@ from ..util import is_cleared_keymaster_text_state
 from ..util import normalize_uid
 from .apply_clear import decide_clear_preflight
 from .diagnostics import build_diagnostics_snapshot
-from .matcher import _get_same_start_uid_bypass_slot as _matcher_same_start_slot
-from .matcher import _has_other_uid_owner
-from .matcher import build_match_catalog
 from .matcher import match_slot
 from .models import MatchRequest
 from .slot_bookkeeping import compute_next_slot
@@ -166,7 +163,12 @@ def _preflight_clear_result(
     if outcome["status"] == "confirmed":
         self.release_pending_clear_slot(slot)
         return self._operation_result_type(kind="clear", slot=slot, confirmed=True)
-    self._logger.warning(self._preflight_warnings[outcome["reason"]], slot)
+    log_method = (
+        self._logger.debug
+        if outcome["reason"] == "non_string"
+        else self._logger.warning
+    )
+    log_method(self._preflight_warnings[outcome["reason"]], slot)
     return self._operation_result_type(kind="clear", slot=slot, unconfirmed=True)
 
 
@@ -185,33 +187,6 @@ def _get_slots_with_values(self) -> list[int]:
 def _get_slots_without_values(self, max_slot: int = 0) -> list[int]:
     """Return sorted free slot numbers greater than ``max_slot``."""
     return get_slots_without_values(self._overrides, max_slot)
-
-
-def _match_catalog(self, exclude_slot: int | None = None):
-    """Return a pure catalog snapshot of the current override state."""
-    normalized = {
-        slot: (
-            None
-            if override is None
-            else {
-                **override,
-                "start_time": self._shell_to_utc(override["start_time"]),
-                "end_time": self._shell_to_utc(override["end_time"]),
-            }
-        )
-        for slot, override in self._overrides.items()
-    }
-    return build_match_catalog(
-        normalized,
-        self._slot_uids,
-        make_trim_config(
-            self._trim_names,
-            self._max_name_length,
-            self._event_prefix,
-            self._prefix_length,
-        ),
-        exclude_slot,
-    )
 
 
 def _override_dict(self, slot_code: str, slot_name: str, start_time, end_time):
@@ -268,13 +243,15 @@ async def async_reserve_or_get_slot(
     self, request=None, *values: Any, **legacy: Any
 ) -> "ReserveResult":
     """Atomically find an existing slot or reserve the next available one."""
-    payload = (
-        request
-        if isinstance(request, self._reservation_request_type)
-        else normalize_reservation_request(
+    if isinstance(request, self._reservation_request_type):
+        if values or legacy:
+            msg = "SlotReservationRequest cannot be combined with extra values"
+            raise TypeError(msg)
+        payload = request
+    else:
+        payload = normalize_reservation_request(
             *(() if request is None else (request,)), *values, **legacy
         )
-    )
     slot_name = (
         strip_prefix(payload.slot_name, payload.prefix or "")
         if payload.slot_name and payload.prefix
@@ -321,13 +298,15 @@ async def async_reserve_or_get_slot(
 
 async def async_update(self, update=None, *values: Any, **legacy: Any) -> None:
     """Update a slot with duplicate-detection enforcement."""
-    payload = (
-        update
-        if isinstance(update, self._update_request_type)
-        else normalize_update_request(
+    if isinstance(update, self._update_request_type):
+        if values or legacy:
+            msg = "SlotUpdateRequest cannot be combined with extra values"
+            raise TypeError(msg)
+        payload = update
+    else:
+        payload = normalize_update_request(
             *(() if update is None else (update,)), *values, **legacy
         )
-    )
     slot_name = (
         strip_prefix(payload.slot_name, payload.prefix or "")
         if payload.slot_name and payload.prefix
@@ -386,117 +365,3 @@ def record_retry_failure(self, slot: int) -> bool:
 def record_retry_success(self, slot: int) -> None:
     """Reset failure tracking for ``slot``."""
     self._retry_counts[slot], self._escalated[slot] = 0, False
-
-
-def _slot_has_matching_event(self, slot: int, events) -> bool:
-    """Return whether ``slot`` still wins the shared matcher for any event."""
-    if self._overrides.get(slot) is None:
-        return False
-    catalog = self._match_catalog()
-    for event in events:
-        result = match_slot(
-            catalog,
-            MatchRequest(
-                event.name,
-                self._shell_to_utc(event.start),
-                self._shell_to_utc(event.end),
-                event.uid,
-                target_slot=slot,
-            ),
-        )
-        if result.slot == slot:
-            self._restore_slot_name(result)
-            return True
-    return False
-
-
-def _event_has_other_uid_owner(self, event, exclude_slot: int) -> bool:
-    """Return whether another slot claims ``event`` via an exact UID match."""
-    return bool(
-        self._slot_has_other_uid_owner(event.name, event.uid, exclude_slot=exclude_slot)
-    )
-
-
-def _slot_has_other_uid_owner(
-    self,
-    slot_name: str,
-    uid: str | None,
-    exclude_slot: int | None = None,
-) -> bool:
-    """Return whether another slot already owns ``uid`` for ``slot_name``."""
-    return _has_other_uid_owner(
-        self._match_catalog(exclude_slot), slot_name, uid, exclude_slot
-    )
-
-
-def _get_same_start_uid_bypass_slot(
-    self, event, exclude_slot: int | None = None
-) -> int | None:
-    """Return the preferred same-start fallback slot for ``event``."""
-    return _matcher_same_start_slot(
-        self._match_catalog(exclude_slot),
-        event.name,
-        self._shell_to_utc(event.start),
-        self._shell_to_utc(event.end),
-        event.uid,
-        exclude_slot,
-    )
-
-
-def get_slot_name(self, slot: int) -> str:
-    """Return the slot name for ``slot`` or an empty string."""
-    override = self._overrides.get(slot)
-    return override["slot_name"] if override and "slot_name" in override else ""
-
-
-def get_slot_with_name(self, slot_name: str):
-    """Return the first override whose stored name matches ``slot_name``."""
-    return next(
-        (
-            override
-            for slot in self._get_slots_with_values()
-            if (override := self.overrides[slot]) and override["slot_name"] == slot_name
-        ),
-        None,
-    )
-
-
-def get_slot_key_by_name(self, slot_name: str) -> int:
-    """Return the slot number for ``slot_name`` or ``0`` when absent."""
-    return next(
-        (
-            slot
-            for slot in self._get_slots_with_values()
-            if (override := self.overrides[slot]) and override["slot_name"] == slot_name
-        ),
-        0,
-    )
-
-
-def update(self, update=None, *values: Any, **legacy: Any) -> None:
-    """Synchronously update overrides for a slot."""
-    payload = (
-        update
-        if isinstance(update, self._update_request_type)
-        else normalize_update_request(
-            *(() if update is None else (update,)), *values, **legacy
-        )
-    )
-    slot_name = (
-        strip_prefix(payload.slot_name, payload.prefix or "")
-        if payload.slot_name and payload.prefix
-        else payload.slot_name
-    )
-    overrides = self._overrides.copy()
-    overrides[payload.slot] = (
-        self._override_dict(
-            payload.slot_code, slot_name, payload.start_time, payload.end_time
-        )
-        if slot_name
-        else None
-    )
-    self._slot_miss_counts.pop(payload.slot, None)
-    self._overrides = overrides
-    self._assign_next_slot()
-    if len(overrides) == self.max_slots:
-        self._ready = True

--- a/custom_components/rental_control/event_overrides_helpers/shell_slots.py
+++ b/custom_components/rental_control/event_overrides_helpers/shell_slots.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Slot date/time accessor methods for EventOverrides."""
+
+from __future__ import annotations
+
+from datetime import time as dt_time
+
+
+def get_slot_start_date(self, slot: int):
+    """Return the start date of ``slot`` or today when empty."""
+    override = self._overrides.get(slot)
+    return (
+        override["start_time"].date()
+        if override and "start_time" in override
+        else self._today_date()
+    )
+
+
+def get_slot_start_time(self, slot: int):
+    """Return the start time of ``slot`` or midnight when empty."""
+    override = self._overrides.get(slot)
+    return (
+        override["start_time"].time()
+        if override and "start_time" in override
+        else dt_time()
+    )
+
+
+def get_slot_end_date(self, slot: int):
+    """Return the end date of ``slot`` or today when empty."""
+    override = self._overrides.get(slot)
+    return (
+        override["end_time"].date()
+        if override and "end_time" in override
+        else self._today_date()
+    )
+
+
+def get_slot_end_time(self, slot: int):
+    """Return the end time of ``slot`` or midnight when empty."""
+    override = self._overrides.get(slot)
+    return (
+        override["end_time"].time()
+        if override and "end_time" in override
+        else dt_time()
+    )

--- a/custom_components/rental_control/event_overrides_helpers/shell_slots.py
+++ b/custom_components/rental_control/event_overrides_helpers/shell_slots.py
@@ -5,6 +5,16 @@
 from __future__ import annotations
 
 from datetime import time as dt_time
+from typing import Any
+
+from .matcher import _get_same_start_uid_bypass_slot as _matcher_same_start_slot
+from .matcher import _has_other_uid_owner
+from .matcher import build_match_catalog
+from .mirror import match_target_slot
+from .models import MatchRequest
+from .slot_bookkeeping import normalize_update_request
+from .trim import make_trim_config
+from .trim import strip_prefix
 
 
 def get_slot_start_date(self, slot: int):
@@ -45,3 +55,151 @@ def get_slot_end_time(self, slot: int):
         if override and "end_time" in override
         else dt_time()
     )
+
+
+def _match_catalog(self, exclude_slot: int | None = None):
+    """Return a pure catalog snapshot of the current override state."""
+    return build_match_catalog(
+        {
+            slot: (
+                None
+                if override is None
+                else {
+                    **override,
+                    "start_time": self._shell_to_utc(override["start_time"]),
+                    "end_time": self._shell_to_utc(override["end_time"]),
+                }
+            )
+            for slot, override in self._overrides.items()
+        },
+        self._slot_uids,
+        make_trim_config(
+            self._trim_names,
+            self._max_name_length,
+            self._event_prefix,
+            self._prefix_length,
+        ),
+        exclude_slot,
+        {
+            slot: (override["start_time"].date(), override["end_time"].date())
+            for slot, override in self._overrides.items()
+            if override is not None
+        },
+    )
+
+
+def _slot_has_matching_event(self, slot: int, events) -> bool:
+    """Return whether ``slot`` matches any event in mirror orientation."""
+    if self._overrides.get(slot) is None:
+        return False
+    catalog = self._match_catalog()
+    for event in events:
+        result = match_target_slot(
+            catalog,
+            slot,
+            MatchRequest(
+                event.name,
+                self._shell_to_utc(event.start),
+                self._shell_to_utc(event.end),
+                event.uid,
+                target_slot=slot,
+            ),
+        )
+        if result.slot == slot:
+            self._restore_slot_name(result)
+            return True
+    return False
+
+
+def _event_has_other_uid_owner(self, event, exclude_slot: int) -> bool:
+    """Return whether another slot claims ``event`` via an exact UID match."""
+    return bool(
+        self._slot_has_other_uid_owner(event.name, event.uid, exclude_slot=exclude_slot)
+    )
+
+
+def _slot_has_other_uid_owner(
+    self,
+    slot_name: str,
+    uid: str | None,
+    exclude_slot: int | None = None,
+) -> bool:
+    """Return whether another slot already owns ``uid`` for ``slot_name``."""
+    return _has_other_uid_owner(
+        self._match_catalog(exclude_slot), slot_name, uid, exclude_slot
+    )
+
+
+def _get_same_start_uid_bypass_slot(
+    self, event, exclude_slot: int | None = None
+) -> int | None:
+    """Return the preferred same-start fallback slot for ``event``."""
+    return _matcher_same_start_slot(
+        self._match_catalog(exclude_slot),
+        event.name,
+        self._shell_to_utc(event.start),
+        self._shell_to_utc(event.end),
+        event.uid,
+        exclude_slot,
+    )
+
+
+def get_slot_name(self, slot: int) -> str:
+    """Return the slot name for ``slot`` or an empty string."""
+    override = self._overrides.get(slot)
+    return override["slot_name"] if override and "slot_name" in override else ""
+
+
+def get_slot_with_name(self, slot_name: str):
+    """Return the first override whose stored name matches ``slot_name``."""
+    return next(
+        (
+            override
+            for slot in self._get_slots_with_values()
+            if (override := self.overrides[slot]) and override["slot_name"] == slot_name
+        ),
+        None,
+    )
+
+
+def get_slot_key_by_name(self, slot_name: str) -> int:
+    """Return the slot number for ``slot_name`` or ``0`` when absent."""
+    return next(
+        (
+            slot
+            for slot in self._get_slots_with_values()
+            if (override := self.overrides[slot]) and override["slot_name"] == slot_name
+        ),
+        0,
+    )
+
+
+def update(self, update=None, *values: Any, **legacy: Any) -> None:
+    """Synchronously update overrides for a slot."""
+    if isinstance(update, self._update_request_type):
+        if values or legacy:
+            msg = "SlotUpdateRequest cannot be combined with extra values"
+            raise TypeError(msg)
+        payload = update
+    else:
+        payload = normalize_update_request(
+            *(() if update is None else (update,)), *values, **legacy
+        )
+    slot_name = (
+        strip_prefix(payload.slot_name, payload.prefix or "")
+        if payload.slot_name and payload.prefix
+        else payload.slot_name
+    )
+    overrides = self._overrides.copy()
+    overrides[payload.slot] = (
+        self._override_dict(
+            payload.slot_code, slot_name, payload.start_time, payload.end_time
+        )
+        if slot_name
+        else None
+    )
+    self._slot_miss_counts.pop(payload.slot, None)
+    self._overrides = overrides
+    self._assign_next_slot()
+    if len(overrides) == self.max_slots:
+        self._ready = True

--- a/custom_components/rental_control/event_overrides_helpers/slot_bookkeeping.py
+++ b/custom_components/rental_control/event_overrides_helpers/slot_bookkeeping.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Pure slot-ordering helpers and request normalizers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .models import SlotReservationRequest
+from .models import SlotUpdateRequest
+
+_RESERVATION_FIELDS = ("slot_name", "slot_code", "start_time", "end_time")
+_RESERVATION_POSITIONAL = _RESERVATION_FIELDS + ("uid", "prefix")
+_RESERVATION_KW = _RESERVATION_POSITIONAL
+_UPDATE_FIELDS = ("slot", "slot_code", "slot_name", "start_time", "end_time")
+_UPDATE_POSITIONAL = _UPDATE_FIELDS + ("prefix",)
+_UPDATE_KW = _UPDATE_POSITIONAL
+
+
+def get_slots_with_values(overrides: Mapping[int, object | None]) -> list[int]:
+    """Return sorted occupied slot numbers."""
+    return sorted(slot for slot, override in overrides.items() if override is not None)
+
+
+def get_slots_without_values(
+    overrides: Mapping[int, object | None], max_slot: int = 0
+) -> list[int]:
+    """Return sorted free slot numbers greater than ``max_slot``."""
+    return sorted(
+        slot
+        for slot, override in overrides.items()
+        if override is None and slot > max_slot
+    )
+
+
+def compute_next_slot(
+    overrides: Mapping[int, object | None], start_slot: int, max_slots: int
+) -> int | None:
+    """Return the next free greedy slot, or ``None`` when full/unready."""
+    if len(overrides) != max_slots:
+        return None
+    occupied = get_slots_with_values(overrides)
+    if len(occupied) == max_slots:
+        return None
+    max_slot = occupied[-1] if occupied else start_slot - 1
+    higher = get_slots_without_values(overrides, max_slot)
+    if higher:
+        return higher[0]
+    free_any = get_slots_without_values(overrides)
+    return free_any[0] if free_any else None
+
+
+def normalize_reservation_request(
+    *values: Any, **legacy: Any
+) -> SlotReservationRequest:
+    """Normalize accepted ``async_reserve_or_get_slot`` call styles."""
+    request = legacy.pop("request", None)
+    if isinstance(request, SlotReservationRequest):
+        if values or legacy:
+            msg = "SlotReservationRequest cannot be combined with extra values"
+            raise TypeError(msg)
+        return request
+    positional = ([request] if request is not None else []) + list(values)
+    resolved = _resolve_arguments(
+        positional,
+        legacy,
+        positional_fields=_RESERVATION_POSITIONAL,
+        keyword_fields=_RESERVATION_KW,
+        context="async_reserve_or_get_slot",
+    )
+    resolved.setdefault("uid", None)
+    resolved.setdefault("prefix", None)
+    return SlotReservationRequest(**resolved)
+
+
+def normalize_update_request(*values: Any, **legacy: Any) -> SlotUpdateRequest:
+    """Normalize accepted ``async_update`` and ``update`` call styles."""
+    request = legacy.pop("update", None) or legacy.pop("request", None)
+    if isinstance(request, SlotUpdateRequest):
+        if values or legacy:
+            msg = "SlotUpdateRequest cannot be combined with extra values"
+            raise TypeError(msg)
+        return request
+    positional = ([request] if request is not None else []) + list(values)
+    resolved = _resolve_arguments(
+        positional,
+        legacy,
+        positional_fields=_UPDATE_POSITIONAL,
+        keyword_fields=_UPDATE_KW,
+        context="event_override_update",
+    )
+    resolved.setdefault("prefix", None)
+    return SlotUpdateRequest(**resolved)
+
+
+def _resolve_arguments(
+    positional: list[Any],
+    legacy: dict[str, Any],
+    *,
+    positional_fields: tuple[str, ...],
+    keyword_fields: tuple[str, ...],
+    context: str,
+) -> dict[str, Any]:
+    """Resolve positional and keyword arguments into one dict."""
+    unknown = set(legacy) - set(keyword_fields)
+    if unknown:
+        msg = f"Unknown {context} arguments: {sorted(unknown)}"
+        raise TypeError(msg)
+    if len(positional) > len(positional_fields):
+        msg = f"Too many positional values for {context}"
+        raise TypeError(msg)
+    resolved = dict(zip(positional_fields, positional, strict=False))
+    for name, value in legacy.items():
+        if name in resolved:
+            msg = f"Duplicate value for {context} argument {name!r}"
+            raise TypeError(msg)
+        resolved[name] = value
+    required = (
+        positional_fields[:4]
+        if context == "async_reserve_or_get_slot"
+        else positional_fields[:5]
+    )
+    missing = [name for name in required if name not in resolved]
+    if missing:
+        msg = f"Missing required {context} arguments: {missing}"
+        raise TypeError(msg)
+    return resolved

--- a/custom_components/rental_control/event_overrides_helpers/trim.py
+++ b/custom_components/rental_control/event_overrides_helpers/trim.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+"""Pure trim and prefix helpers for EventOverrides."""
+
+from __future__ import annotations
+
+from ..util import trim_name
+from .models import TrimConfig
+
+
+def strip_prefix(slot_name: str, prefix: str) -> str:
+    """Remove a leading ``prefix + ' '`` from ``slot_name``."""
+    candidate = f"{prefix} "
+    return (
+        slot_name[len(candidate) :]
+        if prefix and slot_name.startswith(candidate)
+        else slot_name
+    )
+
+
+def is_trimmed_match(name_a: str, name_b: str, guest_max: int) -> bool:
+    """Return whether one name is the trimmed form of the other."""
+    if name_a == name_b or guest_max <= 0:
+        return False
+    shorter, longer = sorted((name_a, name_b), key=len)
+    return trim_name(longer, guest_max) == shorter
+
+
+def make_trim_config(
+    trim_names: bool,
+    max_name_length: int,
+    event_prefix: str,
+    prefix_length: int,
+) -> TrimConfig:
+    """Build a :class:`TrimConfig` from shell configuration."""
+    return TrimConfig(trim_names, max_name_length, event_prefix, prefix_length)
+
+
+def names_match(stored_name: str, expected_name: str, config: TrimConfig) -> bool:
+    """Return whether a stored slot name still belongs to ``expected_name``."""
+    if stored_name == expected_name:
+        return True
+    if not config.trim_names or config.max_name_length <= 0:
+        return False
+    normalized = strip_prefix(stored_name, config.event_prefix)
+    if normalized == expected_name:
+        return True
+    return len(expected_name) > len(normalized) and is_trimmed_match(
+        normalized, expected_name, config.guest_max
+    )
+
+
+def restored_name(stored_name: str, event_name: str, guest_max: int) -> str | None:
+    """Return the longer event name when trim matching should restore it."""
+    if len(event_name) > len(stored_name) and is_trimmed_match(
+        stored_name, event_name, guest_max
+    ):
+        return event_name
+    return None

--- a/specs/017-decompose-event-overrides/tasks.md
+++ b/specs/017-decompose-event-overrides/tasks.md
@@ -105,17 +105,17 @@ boundary.
 **Purpose**: Establish behavior, import, call-site, complexity, and hot-path
 baselines before moving any production code.
 
-- [ ] T001 Run `.specify/scripts/bash/check-prerequisites.sh --json` with `SPECIFY_FEATURE=017-decompose-event-overrides` from the repository root and confirm `specs/017-decompose-event-overrides/` reports `research.md`, `data-model.md`, and `quickstart.md`
-- [ ] T002 Inspect US1-US4, FR-001 through FR-023, constraints, security considerations, and SC-001 through SC-010 in `specs/017-decompose-event-overrides/spec.md`
-- [ ] T003 Inspect the Project Structure, Concrete Decomposition Design, shared matcher, plan application split, parameter-count strategy, and `aislop` directive removal sections in `specs/017-decompose-event-overrides/plan.md`
-- [ ] T004 Inspect all research decisions, helper entities, request objects, and quickstart parity commands in `specs/017-decompose-event-overrides/research.md`, `specs/017-decompose-event-overrides/data-model.md`, and `specs/017-decompose-event-overrides/quickstart.md`
-- [ ] T005 Inventory `_find_overlapping_slot`, `_slot_has_matching_event`, `_event_has_other_uid_owner`, `_slot_has_other_uid_owner`, `_get_same_start_uid_bypass_slot`, `async_check_overrides`, `async_apply_plan`, `_apply_clear`, `_apply_set`, `_apply_update_times`, `_apply_overwrite_manual_change`, `async_reserve_or_get_slot`, `async_update`, `verify_slot_ownership`, diagnostics methods, and `update` in `custom_components/rental_control/event_overrides.py`
-- [ ] T006 Inventory production caller imports and call styles in `custom_components/rental_control/coordinator.py`, `custom_components/rental_control/coordinator_helpers/coordinator_config_shell.py`, `custom_components/rental_control/coordinator_helpers/coordinator_setup_shell.py`, `custom_components/rental_control/coordinator_helpers/coordinator_refresh_shell.py`, and `custom_components/rental_control/util.py`, recording that no caller import or usage may change
-- [ ] T007 Inventory existing event override, slot concurrency, refresh-cycle, coordinator, sensor, utility, and diagnostics behavior coverage in `tests/unit/test_event_overrides.py`, `tests/unit/test_coordinator.py`, `tests/unit/test_sensors.py`, `tests/unit/test_util.py`, `tests/unit/test_keymaster_event_diagnostics.py`, `tests/integration/test_refresh_cycle.py`, and `tests/integration/test_slot_concurrency.py`
-- [ ] T008 Run unchanged baseline event-override parity tests with `uv run pytest tests/unit/test_event_overrides.py tests/integration/test_slot_concurrency.py -q` against the listed test files
-- [ ] T009 Run unchanged baseline caller coverage with `uv run pytest tests/unit/test_coordinator.py tests/unit/test_sensors.py tests/unit/test_util.py tests/unit/test_keymaster_event_diagnostics.py tests/integration/test_refresh_cycle.py -q` against the listed test files
-- [ ] T010 Record the current line, function-length, and parameter-count baseline for `custom_components/rental_control/event_overrides.py`, including the exact `# aislop-ignore-file complexity/file-too-large complexity/function-too-long` directive and that there is no hallucinated-import directive on this file
-- [ ] T011 Record the current Home Assistant state-read, Keymaster service-call, Store-neutral cache, and coordinator refresh boundaries in `custom_components/rental_control/event_overrides.py` so helper extraction can prove no new hot-path I/O or user-visible delays
+- [X] T001 Run `.specify/scripts/bash/check-prerequisites.sh --json` with `SPECIFY_FEATURE=017-decompose-event-overrides` from the repository root and confirm `specs/017-decompose-event-overrides/` reports `research.md`, `data-model.md`, and `quickstart.md`
+- [X] T002 Inspect US1-US4, FR-001 through FR-023, constraints, security considerations, and SC-001 through SC-010 in `specs/017-decompose-event-overrides/spec.md`
+- [X] T003 Inspect the Project Structure, Concrete Decomposition Design, shared matcher, plan application split, parameter-count strategy, and `aislop` directive removal sections in `specs/017-decompose-event-overrides/plan.md`
+- [X] T004 Inspect all research decisions, helper entities, request objects, and quickstart parity commands in `specs/017-decompose-event-overrides/research.md`, `specs/017-decompose-event-overrides/data-model.md`, and `specs/017-decompose-event-overrides/quickstart.md`
+- [X] T005 Inventory `_find_overlapping_slot`, `_slot_has_matching_event`, `_event_has_other_uid_owner`, `_slot_has_other_uid_owner`, `_get_same_start_uid_bypass_slot`, `async_check_overrides`, `async_apply_plan`, `_apply_clear`, `_apply_set`, `_apply_update_times`, `_apply_overwrite_manual_change`, `async_reserve_or_get_slot`, `async_update`, `verify_slot_ownership`, diagnostics methods, and `update` in `custom_components/rental_control/event_overrides.py`
+- [X] T006 Inventory production caller imports and call styles in `custom_components/rental_control/coordinator.py`, `custom_components/rental_control/coordinator_helpers/coordinator_config_shell.py`, `custom_components/rental_control/coordinator_helpers/coordinator_setup_shell.py`, `custom_components/rental_control/coordinator_helpers/coordinator_refresh_shell.py`, and `custom_components/rental_control/util.py`, recording that no caller import or usage may change
+- [X] T007 Inventory existing event override, slot concurrency, refresh-cycle, coordinator, sensor, utility, and diagnostics behavior coverage in `tests/unit/test_event_overrides.py`, `tests/unit/test_coordinator.py`, `tests/unit/test_sensors.py`, `tests/unit/test_util.py`, `tests/unit/test_keymaster_event_diagnostics.py`, `tests/integration/test_refresh_cycle.py`, and `tests/integration/test_slot_concurrency.py`
+- [X] T008 Run unchanged baseline event-override parity tests with `uv run pytest tests/unit/test_event_overrides.py tests/integration/test_slot_concurrency.py -q` against the listed test files
+- [X] T009 Run unchanged baseline caller coverage with `uv run pytest tests/unit/test_coordinator.py tests/unit/test_sensors.py tests/unit/test_util.py tests/unit/test_keymaster_event_diagnostics.py tests/integration/test_refresh_cycle.py -q` against the listed test files
+- [X] T010 Record the current line, function-length, and parameter-count baseline for `custom_components/rental_control/event_overrides.py`, including the exact `# aislop-ignore-file complexity/file-too-large complexity/function-too-long` directive and that there is no hallucinated-import directive on this file
+- [X] T011 Record the current Home Assistant state-read, Keymaster service-call, Store-neutral cache, and coordinator refresh boundaries in `custom_components/rental_control/event_overrides.py` so helper extraction can prove no new hot-path I/O or user-visible delays
 
 ---
 
@@ -131,19 +131,19 @@ service helpers.
 
 ### Foundational Tests
 
-- [ ] T012 [US4] Add internal helper package import and model construction tests for `OverrideSnapshot`, `TrimConfig`, `MatchCatalog`, `MatchRequest`, `MatchResult`, `MatchPhase`, `SlotUpdateRequest`, `SlotReservationRequest`, and `EvictionDecision` in `tests/unit/test_event_overrides_matcher.py`
-- [ ] T013 [US2] Add apply decision model construction tests for dispatch, clear, set, update, overwrite, suppression, and diagnostics value types in `tests/unit/test_event_overrides_apply.py`
-- [ ] T014 [US4] Add tests proving `custom_components/rental_control/event_overrides_helpers/models.py` is side-effect-free and does not import Home Assistant, Store, coordinator, or Keymaster service modules in `tests/unit/test_event_overrides_matcher.py`
+- [X] T012 [US4] Add internal helper package import and model construction tests for `OverrideSnapshot`, `TrimConfig`, `MatchCatalog`, `MatchRequest`, `MatchResult`, `MatchPhase`, `SlotUpdateRequest`, `SlotReservationRequest`, and `EvictionDecision` in `tests/unit/test_event_overrides_matcher.py`
+- [X] T013 [US2] Add apply decision model construction tests for dispatch, clear, set, update, overwrite, suppression, and diagnostics value types in `tests/unit/test_event_overrides_apply.py`
+- [X] T014 [US4] Add tests proving `custom_components/rental_control/event_overrides_helpers/models.py` is side-effect-free and does not import Home Assistant, Store, coordinator, or Keymaster service modules in `tests/unit/test_event_overrides_matcher.py`
 
 ### Foundational Implementation
 
-- [ ] T015 Create `custom_components/rental_control/event_overrides_helpers/__init__.py` with SPDX headers, a module docstring, internal typed exports, and no production caller dependency
-- [ ] T016 [US4] Create `custom_components/rental_control/event_overrides_helpers/models.py` with `OverrideSnapshot`, `TrimConfig`, `MatchCatalog`, `MatchRequest`, `MatchResult`, and `MatchPhase` covering the PLAN fields while keeping enum values internal
-- [ ] T017 [US3] Add `SlotUpdateRequest` and `SlotReservationRequest` to `custom_components/rental_control/event_overrides_helpers/models.py` with fields matching the real `async_update`, `update`, and `async_reserve_or_get_slot` call styles
-- [ ] T018 [US1] Add `EvictionDecision` and miss-count action value types to `custom_components/rental_control/event_overrides_helpers/models.py` for stale-slot cleanup parity
-- [ ] T019 [US2] Add plan-application and diagnostics decision value types to `custom_components/rental_control/event_overrides_helpers/models.py` without carrying raw PIN values into diagnostics fields
-- [ ] T020 [US4] Ensure every model and helper-owned dataclass initializer in `custom_components/rental_control/event_overrides_helpers/models.py` has no more than six explicit parameters unless an external framework signature requires otherwise
-- [ ] T021 Run foundational validation with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides_apply.py -q` against the new model tests
+- [X] T015 Create `custom_components/rental_control/event_overrides_helpers/__init__.py` with SPDX headers, a module docstring, internal typed exports, and no production caller dependency
+- [X] T016 [US4] Create `custom_components/rental_control/event_overrides_helpers/models.py` with `OverrideSnapshot`, `TrimConfig`, `MatchCatalog`, `MatchRequest`, `MatchResult`, and `MatchPhase` covering the PLAN fields while keeping enum values internal
+- [X] T017 [US3] Add `SlotUpdateRequest` and `SlotReservationRequest` to `custom_components/rental_control/event_overrides_helpers/models.py` with fields matching the real `async_update`, `update`, and `async_reserve_or_get_slot` call styles
+- [X] T018 [US1] Add `EvictionDecision` and miss-count action value types to `custom_components/rental_control/event_overrides_helpers/models.py` for stale-slot cleanup parity
+- [X] T019 [US2] Add plan-application and diagnostics decision value types to `custom_components/rental_control/event_overrides_helpers/models.py` without carrying raw PIN values into diagnostics fields
+- [X] T020 [US4] Ensure every model and helper-owned dataclass initializer in `custom_components/rental_control/event_overrides_helpers/models.py` has no more than six explicit parameters unless an external framework signature requires otherwise
+- [X] T021 Run foundational validation with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides_apply.py -q` against the new model tests
 
 **Checkpoint**: The internal package exists, shared dataclasses are stable,
 helper modules can import them, and FR-019/FR-021 parameter limits are accounted
@@ -168,18 +168,18 @@ shared phase implementation selects the checked slot for any current event.
 > **NOTE: Add focused parity tests first. Existing `tests/unit/test_event_overrides.py`
 > behavior assertions must remain unchanged.**
 
-- [ ] T022 [US1] Add matcher fixture builders that serialize current `EventOverrides` state into `OverrideSnapshot`, `TrimConfig`, and `MatchCatalog` inputs in `tests/unit/test_event_overrides_matcher.py`
-- [ ] T023 [US1] Add UID-positive exact-name matcher tests proving normalized non-empty UID plus exact slot name wins before overlap or trim fallback and does not require time overlap in `tests/unit/test_event_overrides_matcher.py`
-- [ ] T024 [US1] Add exact-name strict-overlap tests proving `start_a < end_b AND start_b < end_a`, non-overlap misses, `exclude_slot`, UID-owner exclusion, and preferred-slot tie-breaking in `tests/unit/test_event_overrides_matcher.py`
-- [ ] T025 [US1] Add same-start UID bypass tests proving PR #566 behavior for same UTC start acceptance, different-start rejection, exact UID owner precedence, preferred same-start slot selection, and duplicate-name disambiguation in `tests/unit/test_event_overrides_matcher.py`
-- [ ] T026 [US1] Add mirror-consistency tests proving `_find_overlapping_slot` and `_slot_has_matching_event` use equivalent UID-positive, name/overlap, PR #566 same-start bypass, #624/#625 trim-aware, and UID-owner exclusion semantics while preserving return-shape differences in `tests/unit/test_event_overrides_matcher.py`
+- [X] T022 [US1] Add matcher fixture builders that serialize current `EventOverrides` state into `OverrideSnapshot`, `TrimConfig`, and `MatchCatalog` inputs in `tests/unit/test_event_overrides_matcher.py`
+- [X] T023 [US1] Add UID-positive exact-name matcher tests proving normalized non-empty UID plus exact slot name wins before overlap or trim fallback and does not require time overlap in `tests/unit/test_event_overrides_matcher.py`
+- [X] T024 [US1] Add exact-name strict-overlap tests proving `start_a < end_b AND start_b < end_a`, non-overlap misses, `exclude_slot`, UID-owner exclusion, and preferred-slot tie-breaking in `tests/unit/test_event_overrides_matcher.py`
+- [X] T025 [US1] Add same-start UID bypass tests proving PR #566 behavior for same UTC start acceptance, different-start rejection, exact UID owner precedence, preferred same-start slot selection, and duplicate-name disambiguation in `tests/unit/test_event_overrides_matcher.py`
+- [X] T026 [US1] Add mirror-consistency tests proving `_find_overlapping_slot` and `_slot_has_matching_event` use equivalent UID-positive, name/overlap, PR #566 same-start bypass, #624/#625 trim-aware, and UID-owner exclusion semantics while preserving return-shape differences in `tests/unit/test_event_overrides_matcher.py`
 
 ### Implementation for Shared Matcher
 
-- [ ] T027 [US1] Implement `custom_components/rental_control/event_overrides_helpers/matcher.py` with `build_match_catalog()`, `find_uid_positive_exact_name()`, `find_exact_name_strict_overlap()`, `find_trim_aware_fallback()`, and a shared matcher dispatcher using `MatchCatalog` and `MatchRequest`
-- [ ] T028 [US1] Preserve UID normalization, occupied-slot ordering, `exclude_slot`, exact-name precedence, strict-overlap comparison, same-start preferred-slot selection, exact UID owner precedence, and restored-name reporting in `custom_components/rental_control/event_overrides_helpers/matcher.py`
-- [ ] T029 [US1] Verify `custom_components/rental_control/event_overrides_helpers/matcher.py` performs only in-memory matching and does not call Home Assistant APIs, Store APIs, Keymaster service helpers, `async_request_refresh()`, or mutate `EventOverrides` state directly
-- [ ] T030 [US1] Run matcher validation with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides.py -q` against the listed test files
+- [X] T027 [US1] Implement `custom_components/rental_control/event_overrides_helpers/matcher.py` with `build_match_catalog()`, `find_uid_positive_exact_name()`, `find_exact_name_strict_overlap()`, `find_trim_aware_fallback()`, and a shared matcher dispatcher using `MatchCatalog` and `MatchRequest`
+- [X] T028 [US1] Preserve UID normalization, occupied-slot ordering, `exclude_slot`, exact-name precedence, strict-overlap comparison, same-start preferred-slot selection, exact UID owner precedence, and restored-name reporting in `custom_components/rental_control/event_overrides_helpers/matcher.py`
+- [X] T029 [US1] Verify `custom_components/rental_control/event_overrides_helpers/matcher.py` performs only in-memory matching and does not call Home Assistant APIs, Store APIs, Keymaster service helpers, `async_request_refresh()`, or mutate `EventOverrides` state directly
+- [X] T030 [US1] Run matcher validation with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides.py -q` against the listed test files
 
 **Checkpoint**: Shared matcher helper behavior proves FR-003, FR-004, FR-005,
 FR-006, FR-007, FR-008, SC-002, and the matching portions of SC-005 without yet
@@ -200,18 +200,18 @@ resets, tolerance-threshold clears, and immediate stale clears.
 
 ### Tests for Trim, Bookkeeping, and Cleanup
 
-- [ ] T031 [US1] Add focused trim helper tests for `_strip_prefix`, `trim_name` delegation, #624/#625 guest maximum calculation, prefix-aware comparison, and restored-full-name decisions in `tests/unit/test_event_overrides_matcher.py`
-- [ ] T032 [US1] Add slot bookkeeping tests for sorted occupied slots, sorted free slots, retired greedy next-slot selection, UID owner lookup, same-start preferred-slot tie-breaking, and `exclude_slot` handling in `tests/unit/test_event_overrides_matcher.py`
-- [ ] T033 [US1] Add greedy cleanup helper tests for PR #552 matched-slot miss-count reset, future missing-slot increment, `SLOT_MISS_THRESHOLD` clear, empty-calendar clear, malformed-window clear, past clear, beyond-boundary clear, and conservative failed/unconfirmed clear preservation in `tests/unit/test_event_overrides_matcher.py`
+- [X] T031 [US1] Add focused trim helper tests for `_strip_prefix`, `trim_name` delegation, #624/#625 guest maximum calculation, prefix-aware comparison, and restored-full-name decisions in `tests/unit/test_event_overrides_matcher.py`
+- [X] T032 [US1] Add slot bookkeeping tests for sorted occupied slots, sorted free slots, retired greedy next-slot selection, UID owner lookup, same-start preferred-slot tie-breaking, and `exclude_slot` handling in `tests/unit/test_event_overrides_matcher.py`
+- [X] T033 [US1] Add greedy cleanup helper tests for PR #552 matched-slot miss-count reset, future missing-slot increment, `SLOT_MISS_THRESHOLD` clear, empty-calendar clear, malformed-window clear, past clear, beyond-boundary clear, and conservative failed/unconfirmed clear preservation in `tests/unit/test_event_overrides_matcher.py`
 
 ### Implementation for Trim, Bookkeeping, and Cleanup
 
-- [ ] T034 [US1] Implement `custom_components/rental_control/event_overrides_helpers/trim.py` with prefix stripping, `TrimConfig` construction, trim-name comparison via the existing `trim_name` behavior, and restored-full-name decisions
-- [ ] T035 [US1] Implement `custom_components/rental_control/event_overrides_helpers/slot_bookkeeping.py` with sorted occupied/free slot helpers, next-slot selection, UID-owner checks, and same-start preferred-slot selection used by matcher and shell wrappers
-- [ ] T036 [US1] Implement `custom_components/rental_control/event_overrides_helpers/greedy_cleanup.py` with pure `EvictionDecision` production for `async_check_overrides` miss-count resets, increments, threshold clears, immediate stale clears, and preserve decisions
-- [ ] T037 [US1] Wire `async_check_overrides` in `custom_components/rental_control/event_overrides.py` to apply `greedy_cleanup.py` decisions while retaining the lock boundary, `async_fire_clear_code`, failed/unconfirmed/lingering preservation, and `__assign_next_slot()` only for retired greedy clears
-- [ ] T038 [US1] Verify `trim.py`, `slot_bookkeeping.py`, and `greedy_cleanup.py` perform no Home Assistant state reads, Store writes, coordinator refresh requests, or Keymaster service calls
-- [ ] T039 [US1] Run cleanup validation with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides.py -q` against the listed test files
+- [X] T034 [US1] Implement `custom_components/rental_control/event_overrides_helpers/trim.py` with prefix stripping, `TrimConfig` construction, trim-name comparison via the existing `trim_name` behavior, and restored-full-name decisions
+- [X] T035 [US1] Implement `custom_components/rental_control/event_overrides_helpers/slot_bookkeeping.py` with sorted occupied/free slot helpers, next-slot selection, UID-owner checks, and same-start preferred-slot selection used by matcher and shell wrappers
+- [X] T036 [US1] Implement `custom_components/rental_control/event_overrides_helpers/greedy_cleanup.py` with pure `EvictionDecision` production for `async_check_overrides` miss-count resets, increments, threshold clears, immediate stale clears, and preserve decisions
+- [X] T037 [US1] Wire `async_check_overrides` in `custom_components/rental_control/event_overrides.py` to apply `greedy_cleanup.py` decisions while retaining the lock boundary, `async_fire_clear_code`, failed/unconfirmed/lingering preservation, and `__assign_next_slot()` only for retired greedy clears
+- [X] T038 [US1] Verify `trim.py`, `slot_bookkeeping.py`, and `greedy_cleanup.py` perform no Home Assistant state reads, Store writes, coordinator refresh requests, or Keymaster service calls
+- [X] T039 [US1] Run cleanup validation with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides.py -q` against the listed test files
 
 **Checkpoint**: Trim and cleanup prove FR-007, FR-009, FR-010, FR-022, SC-003,
 and the stale-slot portions of SC-005 while preserving the retired greedy shim.
@@ -230,22 +230,22 @@ retry/error state, cached overrides, and side-effect ordering.
 
 ### Tests for Plan Application
 
-- [ ] T040 [US2] Add dispatch tests for `NOOP`, `BLOCKED`, `CLEAR`, `RETRY_CLEAR`, `RESET`, `SET`, `ASSIGN`, `UPDATE_TIMES`, `OVERWRITE_MANUAL_CHANGE`, `UPDATE_IN_PLACE`, missing reservations, warning reasons, result ordering, and ignored unknown actions in `tests/unit/test_event_overrides_apply.py`
-- [ ] T041 [US2] Add clear preflight and clear-result tests for fresh state reads, unreadable state, changed physical state, confirmed-empty release, operation fences, pending-clear cleanup, failed clear errors, lingering name/PIN errors, stale tokens, and no retired-greedy next-slot update in `tests/unit/test_event_overrides_apply.py`
-- [ ] T042 [US2] Add set and assign tests for confirmed-empty checks before programming, no unsafe write on occupied physical state, tentative assignment timing, suppression payloads, stale-token handling, failure rollback, unconfirmed preservation, and no retired-greedy next-slot update in `tests/unit/test_event_overrides_apply.py`
-- [ ] T043 [US2] Add update-times tests for service-call arguments, suppression markers, confirmed cached buffered start/end updates, failed or unconfirmed result behavior, retry/error state, and operation-result parity in `tests/unit/test_event_overrides_apply.py`
-- [ ] T044 [US2] Add overwrite-manual-change and update-in-place tests for drift logging without raw PINs, clear-before-replace ordering, skipped replacement when clear is not confirmed, replacement set plan-id generation, and side-effect ordering in `tests/unit/test_event_overrides_apply.py`
-- [ ] T045 [US2] Add `async_apply_plan` lifecycle tests proving `reconciliation_active` becomes true before dispatch, diagnostics update in `finally`, false is set under the lock, and exceptions preserve current finalization behavior in `tests/unit/test_event_overrides_apply.py`
+- [X] T040 [US2] Add dispatch tests for `NOOP`, `BLOCKED`, `CLEAR`, `RETRY_CLEAR`, `RESET`, `SET`, `ASSIGN`, `UPDATE_TIMES`, `OVERWRITE_MANUAL_CHANGE`, `UPDATE_IN_PLACE`, missing reservations, warning reasons, result ordering, and ignored unknown actions in `tests/unit/test_event_overrides_apply.py`
+- [X] T041 [US2] Add clear preflight and clear-result tests for fresh state reads, unreadable state, changed physical state, confirmed-empty release, operation fences, pending-clear cleanup, failed clear errors, lingering name/PIN errors, stale tokens, and no retired-greedy next-slot update in `tests/unit/test_event_overrides_apply.py`
+- [X] T042 [US2] Add set and assign tests for confirmed-empty checks before programming, no unsafe write on occupied physical state, tentative assignment timing, suppression payloads, stale-token handling, failure rollback, unconfirmed preservation, and no retired-greedy next-slot update in `tests/unit/test_event_overrides_apply.py`
+- [X] T043 [US2] Add update-times tests for service-call arguments, suppression markers, confirmed cached buffered start/end updates, failed or unconfirmed result behavior, retry/error state, and operation-result parity in `tests/unit/test_event_overrides_apply.py`
+- [X] T044 [US2] Add overwrite-manual-change and update-in-place tests for drift logging without raw PINs, clear-before-replace ordering, skipped replacement when clear is not confirmed, replacement set plan-id generation, and side-effect ordering in `tests/unit/test_event_overrides_apply.py`
+- [X] T045 [US2] Add `async_apply_plan` lifecycle tests proving `reconciliation_active` becomes true before dispatch, diagnostics update in `finally`, false is set under the lock, and exceptions preserve current finalization behavior in `tests/unit/test_event_overrides_apply.py`
 
 ### Implementation for Plan Application
 
-- [ ] T046 [US2] Implement `custom_components/rental_control/event_overrides_helpers/apply_dispatch.py` with pure action classification, skip decisions, missing-reservation handling, clear warning reasons, and operation-result ordering decisions
-- [ ] T047 [US2] Implement `custom_components/rental_control/event_overrides_helpers/apply_clear.py` with clear preflight and clear-result decisions while leaving operation fences, fresh Home Assistant reads, Keymaster clear calls, and shell state mutation ordering in `event_overrides.py`
-- [ ] T048 [US2] Implement `custom_components/rental_control/event_overrides_helpers/apply_set.py` with deterministic set operation IDs, confirmed-empty set decisions, tentative override payloads, feedback suppression payloads, stale-token handling, failure rollback, and unconfirmed preservation decisions
-- [ ] T049 [US2] Implement `custom_components/rental_control/event_overrides_helpers/apply_update.py` with update-times suppression decisions, cached start/end updates, overwrite drift fields, clear-before-replace decisions, failed/unconfirmed short-circuiting, and replacement set plan-id decisions
-- [ ] T050 [US2] Wire `async_apply_plan`, `_apply_clear`, `_apply_set`, `_apply_update_times`, and `_apply_overwrite_manual_change` in `custom_components/rental_control/event_overrides.py` to the apply helpers while preserving clear preflight reads, confirmed-empty set checks, Keymaster service helper call order, pending fences, pending-clear state, suppression markers, retry/error state, cached overrides, and returned operation-result ordering byte-for-byte
-- [ ] T051 [US2] Verify `apply_dispatch.py`, `apply_clear.py`, `apply_set.py`, and `apply_update.py` do not call Home Assistant APIs, Store APIs, Keymaster service helpers, `async_request_refresh()`, or mutate `EventOverrides` state directly
-- [ ] T052 [US2] Run plan-application validation with `uv run pytest tests/unit/test_event_overrides_apply.py tests/unit/test_event_overrides.py tests/integration/test_refresh_cycle.py -q` against the listed test files
+- [X] T046 [US2] Implement `custom_components/rental_control/event_overrides_helpers/apply_dispatch.py` with pure action classification, skip decisions, missing-reservation handling, clear warning reasons, and operation-result ordering decisions
+- [X] T047 [US2] Implement `custom_components/rental_control/event_overrides_helpers/apply_clear.py` with clear preflight and clear-result decisions while leaving operation fences, fresh Home Assistant reads, Keymaster clear calls, and shell state mutation ordering in `event_overrides.py`
+- [X] T048 [US2] Implement `custom_components/rental_control/event_overrides_helpers/apply_set.py` with deterministic set operation IDs, confirmed-empty set decisions, tentative override payloads, feedback suppression payloads, stale-token handling, failure rollback, and unconfirmed preservation decisions
+- [X] T049 [US2] Implement `custom_components/rental_control/event_overrides_helpers/apply_update.py` with update-times suppression decisions, cached start/end updates, overwrite drift fields, clear-before-replace decisions, failed/unconfirmed short-circuiting, and replacement set plan-id decisions
+- [X] T050 [US2] Wire `async_apply_plan`, `_apply_clear`, `_apply_set`, `_apply_update_times`, and `_apply_overwrite_manual_change` in `custom_components/rental_control/event_overrides.py` to the apply helpers while preserving clear preflight reads, confirmed-empty set checks, Keymaster service helper call order, pending fences, pending-clear state, suppression markers, retry/error state, cached overrides, and returned operation-result ordering byte-for-byte
+- [X] T051 [US2] Verify `apply_dispatch.py`, `apply_clear.py`, `apply_set.py`, and `apply_update.py` do not call Home Assistant APIs, Store APIs, Keymaster service helpers, `async_request_refresh()`, or mutate `EventOverrides` state directly
+- [X] T052 [US2] Run plan-application validation with `uv run pytest tests/unit/test_event_overrides_apply.py tests/unit/test_event_overrides.py tests/integration/test_refresh_cycle.py -q` against the listed test files
 
 **Checkpoint**: Plan application proves FR-011, FR-012, FR-013, FR-014,
 FR-015, FR-016, FR-022, SC-004, and reconciliation-package integration without
@@ -265,14 +265,14 @@ after extraction.
 
 ### Tests for Diagnostics
 
-- [ ] T053 [US2] Add diagnostics projection tests for matched slots, pending corrections, manual drift slots, pending clear slots, slot retry counts, last slot errors, enum string values, sorting, and raw PIN redaction in `tests/unit/test_event_overrides_apply.py`
+- [X] T053 [US2] Add diagnostics projection tests for matched slots, pending corrections, manual drift slots, pending clear slots, slot retry counts, last slot errors, enum string values, sorting, and raw PIN redaction in `tests/unit/test_event_overrides_apply.py`
 
 ### Implementation for Diagnostics
 
-- [ ] T054 [US2] Implement `custom_components/rental_control/event_overrides_helpers/diagnostics.py` with pure diagnostics snapshot projection from `DesiredPlan`, retry/error state, pending clear state, and configured slot range
-- [ ] T055 [US2] Wire `update_diagnostics_snapshot` in `custom_components/rental_control/event_overrides.py` to `diagnostics.py` while storing the returned dict at the same point in `async_apply_plan`'s `finally` block
-- [ ] T056 [US2] Verify `custom_components/rental_control/event_overrides_helpers/diagnostics.py` never includes raw slot codes and performs no Home Assistant, Store, Keymaster, or coordinator refresh side effects
-- [ ] T057 [US2] Run diagnostics validation with `uv run pytest tests/unit/test_event_overrides_apply.py tests/unit/test_keymaster_event_diagnostics.py -q` against the listed test files
+- [X] T054 [US2] Implement `custom_components/rental_control/event_overrides_helpers/diagnostics.py` with pure diagnostics snapshot projection from `DesiredPlan`, retry/error state, pending clear state, and configured slot range
+- [X] T055 [US2] Wire `update_diagnostics_snapshot` in `custom_components/rental_control/event_overrides.py` to `diagnostics.py` while storing the returned dict at the same point in `async_apply_plan`'s `finally` block
+- [X] T056 [US2] Verify `custom_components/rental_control/event_overrides_helpers/diagnostics.py` never includes raw slot codes and performs no Home Assistant, Store, Keymaster, or coordinator refresh side effects
+- [X] T057 [US2] Run diagnostics validation with `uv run pytest tests/unit/test_event_overrides_apply.py tests/unit/test_keymaster_event_diagnostics.py -q` against the listed test files
 
 **Checkpoint**: Diagnostics extraction proves FR-001, FR-011, FR-014, FR-017,
 SC-004, and the raw-PIN security requirement.
@@ -291,17 +291,17 @@ wrappers delegate to the one shared matcher.
 
 ### Tests for Shell Delegation
 
-- [ ] T058 [US1] Add shell delegation tests proving `_find_overlapping_slot` and `_slot_has_matching_event` both build a shared `MatchCatalog`, call the same matcher phase implementation in opposite orientations, and apply restored full-name mutations only when the current engine would in `tests/unit/test_event_overrides_matcher.py`
-- [ ] T059 [US3] Add compatibility-surface tests proving `EventOverrides`, `EventOverride`, `ReserveResult`, all FR-017 members, and FR-018 private regression seams remain available from `custom_components.rental_control.event_overrides` in `tests/unit/test_event_overrides.py`
-- [ ] T060 [US3] Add production import-boundary tests proving coordinator setup/config helpers still use `from ..event_overrides import EventOverrides` and no production module imports from `event_overrides_helpers/` in `tests/unit/test_event_overrides.py`
+- [X] T058 [US1] Add shell delegation tests proving `_find_overlapping_slot` and `_slot_has_matching_event` both build a shared `MatchCatalog`, call the same matcher phase implementation in opposite orientations, and apply restored full-name mutations only when the current engine would in `tests/unit/test_event_overrides_matcher.py`
+- [X] T059 [US3] Add compatibility-surface tests proving `EventOverrides`, `EventOverride`, `ReserveResult`, all FR-017 members, and FR-018 private regression seams remain available from `custom_components.rental_control.event_overrides` in `tests/unit/test_event_overrides.py`
+- [X] T060 [US3] Add production import-boundary tests proving coordinator setup/config helpers still use `from ..event_overrides import EventOverrides` and no production module imports from `event_overrides_helpers/` in `tests/unit/test_event_overrides.py`
 
 ### Implementation for Shell Delegation
 
-- [ ] T061 [US1] Wire `_find_overlapping_slot` in `custom_components/rental_control/event_overrides.py` to build `MatchCatalog`, call the shared matcher, return the selected slot, and apply restored full-name mutation at the same point as today
-- [ ] T062 [US1] Wire `_slot_has_matching_event` in `custom_components/rental_control/event_overrides.py` to evaluate events through the same shared matcher and return true only when the shared result selects the checked slot
-- [ ] T063 [US3] Keep `EventOverrides`, `EventOverride`, `ReserveResult`, properties, date/time getters, `verify_slot_ownership`, retry helpers, suppression helpers, actual-state helpers, diagnostics helpers, `_apply_*` wrappers, and consumed private state reachable from `custom_components/rental_control/event_overrides.py`
-- [ ] T064 [US3] Verify reconciliation integration by confirming `custom_components/rental_control/event_overrides.py` and `event_overrides_helpers/*.py` continue consuming `ActionKind`, `DesiredPlan`, `Reservation`, and `SlotAction` from `custom_components/rental_control/reconciliation/` without caller-side behavior changes
-- [ ] T065 [US3] Run shell compatibility validation with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides.py tests/unit/test_coordinator.py tests/unit/test_sensors.py tests/integration/test_refresh_cycle.py tests/integration/test_slot_concurrency.py -q` against the listed test files
+- [X] T061 [US1] Wire `_find_overlapping_slot` in `custom_components/rental_control/event_overrides.py` to build `MatchCatalog`, call the shared matcher, return the selected slot, and apply restored full-name mutation at the same point as today
+- [X] T062 [US1] Wire `_slot_has_matching_event` in `custom_components/rental_control/event_overrides.py` to evaluate events through the same shared matcher and return true only when the shared result selects the checked slot
+- [X] T063 [US3] Keep `EventOverrides`, `EventOverride`, `ReserveResult`, properties, date/time getters, `verify_slot_ownership`, retry helpers, suppression helpers, actual-state helpers, diagnostics helpers, `_apply_*` wrappers, and consumed private state reachable from `custom_components/rental_control/event_overrides.py`
+- [X] T064 [US3] Verify reconciliation integration by confirming `custom_components/rental_control/event_overrides.py` and `event_overrides_helpers/*.py` continue consuming `ActionKind`, `DesiredPlan`, `Reservation`, and `SlotAction` from `custom_components/rental_control/reconciliation/` without caller-side behavior changes
+- [X] T065 [US3] Run shell compatibility validation with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides.py tests/unit/test_coordinator.py tests/unit/test_sensors.py tests/integration/test_refresh_cycle.py tests/integration/test_slot_concurrency.py -q` against the listed test files
 
 **Checkpoint**: Shell delegation proves FR-001, FR-002, FR-008, FR-015,
 FR-016, FR-017, FR-018, SC-001, SC-002, and SC-005 with the mirror wrappers
@@ -319,18 +319,18 @@ then verify production call sites and existing tests remain source-compatible.
 
 ### Tests for Wrapper Compatibility
 
-- [ ] T066 [US3] Add `async_reserve_or_get_slot` compatibility tests for `SlotReservationRequest`, all keyword fields, four positional values plus `uid=`, optional `prefix=`, unknown keyword rejection, and current `ReserveResult` semantics in `tests/unit/test_event_overrides.py`
-- [ ] T067 [US3] Add `async_update` compatibility tests for `SlotUpdateRequest`, coordinator's six-positional `(slot, code, name, start, end, prefix)` form, util's five-positional reset `(slot_num, "", "", start, start)` form, keyword forms, duplicate redirect with `exclude_slot`, prefix stripping, and unknown keyword rejection in `tests/unit/test_event_overrides.py`
-- [ ] T068 [US3] Add synchronous `update` compatibility tests for `SlotUpdateRequest`, five positional values, keyword fields, `prefix=` cases, copy-on-write behavior, empty-name clearing, next-slot reassignment, and unknown keyword rejection in `tests/unit/test_event_overrides.py`
+- [X] T066 [US3] Add `async_reserve_or_get_slot` compatibility tests for `SlotReservationRequest`, all keyword fields, four positional values plus `uid=`, optional `prefix=`, unknown keyword rejection, and current `ReserveResult` semantics in `tests/unit/test_event_overrides.py`
+- [X] T067 [US3] Add `async_update` compatibility tests for `SlotUpdateRequest`, coordinator's six-positional `(slot, code, name, start, end, prefix)` form, util's five-positional reset `(slot_num, "", "", start, start)` form, keyword forms, duplicate redirect with `exclude_slot`, prefix stripping, and unknown keyword rejection in `tests/unit/test_event_overrides.py`
+- [X] T068 [US3] Add synchronous `update` compatibility tests for `SlotUpdateRequest`, five positional values, keyword fields, `prefix=` cases, copy-on-write behavior, empty-name clearing, next-slot reassignment, and unknown keyword rejection in `tests/unit/test_event_overrides.py`
 
 ### Implementation for Wrapper Compatibility
 
-- [ ] T069 [US3] Implement request normalizers in `custom_components/rental_control/event_overrides_helpers/slot_bookkeeping.py` or `models.py` for `SlotReservationRequest` and `SlotUpdateRequest`, preserving accepted legacy positional and keyword forms while failing unknown keywords fast
-- [ ] T070 [US3] Change `async_reserve_or_get_slot` in `custom_components/rental_control/event_overrides.py` to a thin no-more-than-six-parameter compatibility wrapper accepting a request object or legacy call form while preserving lock acquisition, prefix stripping, matcher delegation, miss-count reset, UID recording, next-slot assignment, and `ReserveResult` behavior
-- [ ] T071 [US3] Change `async_update` in `custom_components/rental_control/event_overrides.py` to a thin no-more-than-six-parameter compatibility wrapper accepting `update=None, *values, **legacy`, including the coordinator six-positional form, util reset form, request object, and keyword forms while preserving duplicate redirect, prefix stripping, state mutation, miss-count reset, `__assign_next_slot()`, and readiness behavior
-- [ ] T072 [US3] Change synchronous `update` in `custom_components/rental_control/event_overrides.py` to a thin no-more-than-six-parameter compatibility wrapper accepting the request object, five positional form, keyword forms, and `prefix=` while preserving copy-on-write assignment and readiness behavior
-- [ ] T073 [US3] Verify no caller import or usage changes in `custom_components/rental_control/util.py` (`verify_slot_ownership` at clear/set/update-times helpers and reset `async_update`), `custom_components/rental_control/coordinator.py` (`async_update`), `custom_components/rental_control/coordinator_helpers/coordinator_refresh_shell.py` (`async_apply_plan`), setup/config shells (`EventOverrides` import), and existing tests
-- [ ] T074 [US3] Run wrapper and caller validation with `uv run pytest tests/unit/test_event_overrides.py tests/unit/test_util.py tests/unit/test_coordinator.py tests/unit/test_sensors.py tests/integration/test_refresh_cycle.py -q` against the listed test files
+- [X] T069 [US3] Implement request normalizers in `custom_components/rental_control/event_overrides_helpers/slot_bookkeeping.py` or `models.py` for `SlotReservationRequest` and `SlotUpdateRequest`, preserving accepted legacy positional and keyword forms while failing unknown keywords fast
+- [X] T070 [US3] Change `async_reserve_or_get_slot` in `custom_components/rental_control/event_overrides.py` to a thin no-more-than-six-parameter compatibility wrapper accepting a request object or legacy call form while preserving lock acquisition, prefix stripping, matcher delegation, miss-count reset, UID recording, next-slot assignment, and `ReserveResult` behavior
+- [X] T071 [US3] Change `async_update` in `custom_components/rental_control/event_overrides.py` to a thin no-more-than-six-parameter compatibility wrapper accepting `update=None, *values, **legacy`, including the coordinator six-positional form, util reset form, request object, and keyword forms while preserving duplicate redirect, prefix stripping, state mutation, miss-count reset, `__assign_next_slot()`, and readiness behavior
+- [X] T072 [US3] Change synchronous `update` in `custom_components/rental_control/event_overrides.py` to a thin no-more-than-six-parameter compatibility wrapper accepting the request object, five positional form, keyword forms, and `prefix=` while preserving copy-on-write assignment and readiness behavior
+- [X] T073 [US3] Verify no caller import or usage changes in `custom_components/rental_control/util.py` (`verify_slot_ownership` at clear/set/update-times helpers and reset `async_update`), `custom_components/rental_control/coordinator.py` (`async_update`), `custom_components/rental_control/coordinator_helpers/coordinator_refresh_shell.py` (`async_apply_plan`), setup/config shells (`EventOverrides` import), and existing tests
+- [X] T074 [US3] Run wrapper and caller validation with `uv run pytest tests/unit/test_event_overrides.py tests/unit/test_util.py tests/unit/test_coordinator.py tests/unit/test_sensors.py tests/integration/test_refresh_cycle.py -q` against the listed test files
 
 **Checkpoint**: Parameter reduction proves FR-017, FR-018, FR-019, FR-015,
 FR-016, SC-005, and SC-006 while preserving all real production and test call
@@ -349,15 +349,15 @@ removal and run `aislop` after removal without replacement complexity ignores.
 
 ### Tests and Cleanup for Maintainability
 
-- [ ] T075 [US4] Confirm final implementation diff is limited to `custom_components/rental_control/event_overrides.py`, `custom_components/rental_control/event_overrides_helpers/`, `tests/unit/test_event_overrides.py`, `tests/unit/test_event_overrides_matcher.py`, `tests/unit/test_event_overrides_apply.py`, and directly required existing caller test files
-- [ ] T076 [US4] Remove temporary extraction shims from `custom_components/rental_control/event_overrides.py` and `custom_components/rental_control/event_overrides_helpers/*.py`, leaving only planned public class members, private regression-seam wrappers, and internal helper exports
-- [ ] T077 [US4] Ensure every project-owned function in `custom_components/rental_control/event_overrides.py` and `custom_components/rental_control/event_overrides_helpers/*.py` is below 80 lines, splitting helper functions without changing behavior where needed
-- [ ] T078 [US4] Ensure every project-owned parameter list in `custom_components/rental_control/event_overrides.py` and `custom_components/rental_control/event_overrides_helpers/*.py` has no more than six parameters, with `async_reserve_or_get_slot`, `async_update`, and `update` covered by request wrappers
-- [ ] T079 [US4] Immediately before removing the complexity directive, measure `custom_components/rental_control/event_overrides.py` and every `custom_components/rental_control/event_overrides_helpers/*.py` file with `wc -l` and confirm each file is below 400 lines
-- [ ] T080 [US4] Run isolated complexity validation with `uv run pre-commit run aislop` against the staged event-override implementation files and confirm file-size, function-length, and parameter-count thresholds pass
-- [ ] T081 [US4] Remove the `# aislop-ignore-file complexity/file-too-large complexity/function-too-long` directive from `custom_components/rental_control/event_overrides.py` after T079 and T080 pass, and do not add any replacement complexity suppression or hallucinated-import directive
-- [ ] T082 [US4] Re-run `uv run pre-commit run aislop` after directive removal and confirm all in-scope event-override files still pass active thresholds
-- [ ] T083 [US4] Confirm no new matching semantics, reconciliation actions, services, sensors, configuration options, Store authority, Home Assistant state writes, coordinator refreshes, blocking I/O, or user-visible delays were introduced in `custom_components/rental_control/event_overrides.py` or `event_overrides_helpers/*.py`
+- [X] T075 [US4] Confirm final implementation diff is limited to `custom_components/rental_control/event_overrides.py`, `custom_components/rental_control/event_overrides_helpers/`, `tests/unit/test_event_overrides.py`, `tests/unit/test_event_overrides_matcher.py`, `tests/unit/test_event_overrides_apply.py`, and directly required existing caller test files
+- [X] T076 [US4] Remove temporary extraction shims from `custom_components/rental_control/event_overrides.py` and `custom_components/rental_control/event_overrides_helpers/*.py`, leaving only planned public class members, private regression-seam wrappers, and internal helper exports
+- [X] T077 [US4] Ensure every project-owned function in `custom_components/rental_control/event_overrides.py` and `custom_components/rental_control/event_overrides_helpers/*.py` is below 80 lines, splitting helper functions without changing behavior where needed
+- [X] T078 [US4] Ensure every project-owned parameter list in `custom_components/rental_control/event_overrides.py` and `custom_components/rental_control/event_overrides_helpers/*.py` has no more than six parameters, with `async_reserve_or_get_slot`, `async_update`, and `update` covered by request wrappers
+- [X] T079 [US4] Immediately before removing the complexity directive, measure `custom_components/rental_control/event_overrides.py` and every `custom_components/rental_control/event_overrides_helpers/*.py` file with `wc -l` and confirm each file is below 400 lines
+- [X] T080 [US4] Run isolated complexity validation with `uv run pre-commit run aislop` against the staged event-override implementation files and confirm file-size, function-length, and parameter-count thresholds pass
+- [X] T081 [US4] Remove the `# aislop-ignore-file complexity/file-too-large complexity/function-too-long` directive from `custom_components/rental_control/event_overrides.py` after T079 and T080 pass, and do not add any replacement complexity suppression or hallucinated-import directive
+- [X] T082 [US4] Re-run `uv run pre-commit run aislop` after directive removal and confirm all in-scope event-override files still pass active thresholds
+- [X] T083 [US4] Confirm no new matching semantics, reconciliation actions, services, sensors, configuration options, Store authority, Home Assistant state writes, coordinator refreshes, blocking I/O, or user-visible delays were introduced in `custom_components/rental_control/event_overrides.py` or `event_overrides_helpers/*.py`
 
 **Checkpoint**: Maintainability proves FR-020, FR-021, FR-022, FR-023, SC-007,
 SC-008, SC-009, and the implementation-stage complexity goals.
@@ -371,15 +371,15 @@ traceability, and docs-only stage boundaries.
 
 ### Acceptance and Quality Gates
 
-- [ ] T084 Run unchanged event-override parity tests with `uv run pytest tests/unit/test_event_overrides.py tests/integration/test_slot_concurrency.py -q` against the listed test files
-- [ ] T085 Run all new focused helper tests with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides_apply.py -q` against the listed test files
-- [ ] T086 Run unchanged caller and integration coverage with `uv run pytest tests/unit/test_coordinator.py tests/unit/test_sensors.py tests/unit/test_util.py tests/unit/test_keymaster_event_diagnostics.py tests/integration/test_refresh_cycle.py -q` against the listed test files
-- [ ] T087 Run full regression tests with `uv run pytest tests/ -x -q` against `tests/`
-- [ ] T088 Run linting with `uv run ruff check custom_components/ tests/` against `custom_components/` and `tests/`
-- [ ] T089 Run full pre-commit validation with `uv run pre-commit run --all-files` against repository-tracked files, including reuse, yamllint, actionlint, aislop, ruff, ruff-format, mypy, interrogate, and gitlint hooks
-- [ ] T090 Verify every FR-001 through FR-023 has a test, implementation, or acceptance task mapped in `specs/017-decompose-event-overrides/tasks.md`
-- [ ] T091 Verify every SC-001 through SC-010 has a test, implementation, or acceptance task mapped in `specs/017-decompose-event-overrides/tasks.md`
-- [ ] T092 Review `specs/017-decompose-event-overrides/quickstart.md` and confirm the implementation PR notes list unchanged parity commands, new focused matcher/apply commands, mirror-consistency coverage, wrapper compatibility forms, caller-import verification, hot-path safeguards, file-size measurement before directive removal, final `aislop` results, and final validation results
+- [X] T084 Run unchanged event-override parity tests with `uv run pytest tests/unit/test_event_overrides.py tests/integration/test_slot_concurrency.py -q` against the listed test files
+- [X] T085 Run all new focused helper tests with `uv run pytest tests/unit/test_event_overrides_matcher.py tests/unit/test_event_overrides_apply.py -q` against the listed test files
+- [X] T086 Run unchanged caller and integration coverage with `uv run pytest tests/unit/test_coordinator.py tests/unit/test_sensors.py tests/unit/test_util.py tests/unit/test_keymaster_event_diagnostics.py tests/integration/test_refresh_cycle.py -q` against the listed test files
+- [X] T087 Run full regression tests with `uv run pytest tests/ -x -q` against `tests/`
+- [X] T088 Run linting with `uv run ruff check custom_components/ tests/` against `custom_components/` and `tests/`
+- [X] T089 Run full pre-commit validation with `uv run pre-commit run --all-files` against repository-tracked files, including reuse, yamllint, actionlint, aislop, ruff, ruff-format, mypy, interrogate, and gitlint hooks
+- [X] T090 Verify every FR-001 through FR-023 has a test, implementation, or acceptance task mapped in `specs/017-decompose-event-overrides/tasks.md`
+- [X] T091 Verify every SC-001 through SC-010 has a test, implementation, or acceptance task mapped in `specs/017-decompose-event-overrides/tasks.md`
+- [X] T092 Review `specs/017-decompose-event-overrides/quickstart.md` and confirm the implementation PR notes list unchanged parity commands, new focused matcher/apply commands, mirror-consistency coverage, wrapper compatibility forms, caller-import verification, hot-path safeguards, file-size measurement before directive removal, final `aislop` results, and final validation results
 
 ---
 

--- a/tests/unit/test_event_overrides.py
+++ b/tests/unit/test_event_overrides.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from datetime import time
 from datetime import timedelta
 import logging
+from pathlib import Path
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -22,6 +23,12 @@ from custom_components.rental_control.const import DOMAIN
 from custom_components.rental_control.event_overrides import EventOverride
 from custom_components.rental_control.event_overrides import EventOverrides
 from custom_components.rental_control.event_overrides import ReserveResult
+from custom_components.rental_control.event_overrides_helpers.models import (
+    SlotReservationRequest,
+)
+from custom_components.rental_control.event_overrides_helpers.models import (
+    SlotUpdateRequest,
+)
 from custom_components.rental_control.reconciliation import ActionKind
 from custom_components.rental_control.reconciliation import DesiredPlan
 from custom_components.rental_control.reconciliation import Reservation
@@ -467,6 +474,28 @@ class TestTrimAwareSlotOwnership:
             34,
             "Nicole Amidon (homeaway) - by Hostaway",
         )
+
+    def test_verify_slot_ownership_rejects_prefix_when_trim_disabled(self) -> None:
+        """Prefix stripping is gated behind trim-enabled ownership matching."""
+        eo = EventOverrides(start_slot=34, max_slots=1)
+        eo.trim_names = False
+        eo.max_name_length = 16
+        eo.event_prefix = "RC"
+        now = dt_util.now()
+        eo.update(34, "1234", "RC Alice", now, now + timedelta(days=3))
+
+        assert not eo.verify_slot_ownership(34, "Alice")
+
+    def test_verify_slot_ownership_accepts_prefix_when_trim_enabled(self) -> None:
+        """Trim-enabled ownership strips the configured display prefix."""
+        eo = EventOverrides(start_slot=34, max_slots=1)
+        eo.trim_names = True
+        eo.max_name_length = 16
+        eo.event_prefix = "RC"
+        now = dt_util.now()
+        eo.update(34, "1234", "RC Alice", now, now + timedelta(days=3))
+
+        assert eo.verify_slot_ownership(34, "Alice")
 
     def test_verify_slot_ownership_accepts_prefixed_trimmed_name(self) -> None:
         """Verify a stored Keymaster display name can include the prefix."""
@@ -3698,7 +3727,9 @@ class TestApplyPlanActions:
         assert results[0].confirmed is True
         assert observed == [True, True]
         assert eo.overrides[1] is not None
-        assert eo.overrides[1]["slot_name"] == "Guest"
+        override = eo.overrides[1]
+        assert override is not None
+        assert override["slot_name"] == "Guest"
         assert 1 not in eo.pending_fences
 
     async def test_set_action_passes_unbuffered_dates(self) -> None:
@@ -3937,7 +3968,9 @@ class TestApplyPlanActions:
 
         assert results[0].unconfirmed is True
         assert eo.overrides[1] is not None
-        assert eo.overrides[1]["slot_name"] == "Guest"
+        override = eo.overrides[1]
+        assert override is not None
+        assert override["slot_name"] == "Guest"
         mock_clear.assert_not_called()
 
     async def test_preflight_clear_accepts_prefixed_physical_name(self) -> None:
@@ -5164,6 +5197,33 @@ class TestManualDriftLogging:
         log_text = " ".join(r.message for r in caplog.records)
         assert "date_range_enabled" in log_text
 
+    async def test_overwrite_uses_shell_uuid_patch_point(self) -> None:
+        """Overwrite replacement IDs remain patchable via shell UUID."""
+        eo = EventOverrides(start_slot=5, max_slots=2)
+        res = self._make_res()
+        action = self._make_overwrite_action(drift_fields=["name"])
+        coordinator = MagicMock()
+        apply_clear = AsyncMock(
+            return_value=OperationResult(kind="clear", slot=5, confirmed=True)
+        )
+        apply_set = AsyncMock(
+            return_value=OperationResult(kind="set", slot=5, confirmed=True)
+        )
+
+        with (
+            patch.object(eo, "_apply_clear", apply_clear),
+            patch.object(eo, "_apply_set", apply_set),
+            patch(
+                "custom_components.rental_control.event_overrides.uuid.uuid4",
+                return_value="patched-token",
+            ),
+        ):
+            await eo._apply_overwrite_manual_change(coordinator, 5, res, action)
+
+        apply_set.assert_awaited_once()
+        assert apply_set.await_args is not None
+        assert apply_set.await_args.args[3] == "replace-5-patched-token"
+
     async def test_raw_pin_never_in_log(self, caplog: pytest.LogCaptureFixture) -> None:
         """Raw PIN value must never appear in WARNING (or above) log records during overwrite.
 
@@ -6244,3 +6304,203 @@ class TestSlotNameTrimmingRegression:
         ]
         assert result.confirmed is True
         assert name_calls[-1]["service_data"]["value"] == "RC Alice"
+
+
+class TestRequestObjectCompatibility:
+    """T059-T068: request-object wrappers and compatibility surface tests."""
+
+    @pytest.mark.asyncio
+    async def test_async_reserve_accepts_request_object(
+        self, populated_eo: EventOverrides
+    ) -> None:
+        """async_reserve_or_get_slot accepts SlotReservationRequest directly."""
+        req = SlotReservationRequest(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2026, 1, 1),
+            end_time=_make_dt(2026, 1, 4),
+            uid="uid-1",
+        )
+
+        result = await populated_eo.async_reserve_or_get_slot(req)
+
+        assert result.is_new is True
+        assert result.slot is not None
+        assert populated_eo._slot_uids[result.slot] == "uid-1"
+
+    @pytest.mark.asyncio
+    async def test_async_reserve_rejects_unknown_keyword(
+        self, populated_eo: EventOverrides
+    ) -> None:
+        """Unknown greedy-reservation keywords still fail fast."""
+        with pytest.raises(TypeError):
+            await populated_eo.async_reserve_or_get_slot(
+                slot_name="Alice",
+                slot_code="1234",
+                start_time=_make_dt(2026, 1, 1),
+                end_time=_make_dt(2026, 1, 4),
+                unexpected=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_reserve_request_rejects_extras(
+        self, populated_eo: EventOverrides
+    ) -> None:
+        """Request-object greedy-reservation extras still fail fast."""
+        req = SlotReservationRequest(
+            slot_name="Alice",
+            slot_code="1234",
+            start_time=_make_dt(2026, 1, 1),
+            end_time=_make_dt(2026, 1, 4),
+        )
+
+        with pytest.raises(TypeError):
+            await populated_eo.async_reserve_or_get_slot(req, unexpected=True)
+
+    @pytest.mark.asyncio
+    async def test_async_update_accepts_request_object_and_redirects(self) -> None:
+        """async_update accepts SlotUpdateRequest and preserves dedup redirect."""
+        eo = EventOverrides(start_slot=1, max_slots=2)
+        now = dt_util.now()
+        eo.update(1, "", "", now, now)
+        eo.update(2, "2222", "Guest", _make_dt(2026, 1, 1), _make_dt(2026, 1, 5))
+
+        req = SlotUpdateRequest(
+            slot=1,
+            slot_code="9999",
+            slot_name="Guest",
+            start_time=_make_dt(2026, 1, 2),
+            end_time=_make_dt(2026, 1, 6),
+        )
+        await eo.async_update(req)
+
+        assert eo.overrides[1] is None
+        override = eo.overrides[2]
+        assert override is not None
+        assert override["slot_code"] == "9999"
+
+    @pytest.mark.asyncio
+    async def test_async_update_rejects_unknown_keyword(self) -> None:
+        """Unknown async_update keywords still fail fast."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        with pytest.raises(TypeError):
+            await eo.async_update(
+                slot=1,
+                slot_code="1234",
+                slot_name="Guest",
+                start_time=_make_dt(2026, 1, 1),
+                end_time=_make_dt(2026, 1, 4),
+                unexpected=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_update_request_rejects_extras(self) -> None:
+        """Request-object async_update extras still fail fast."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        req = SlotUpdateRequest(
+            slot=1,
+            slot_code="1234",
+            slot_name="Guest",
+            start_time=_make_dt(2026, 1, 1),
+            end_time=_make_dt(2026, 1, 4),
+        )
+
+        with pytest.raises(TypeError):
+            await eo.async_update(req, unexpected=True)
+
+    def test_update_accepts_request_object_and_prefix(self) -> None:
+        """Synchronous update accepts SlotUpdateRequest and strips prefixes."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        req = SlotUpdateRequest(
+            slot=1,
+            slot_code="1234",
+            slot_name="Rental Guest",
+            start_time=_make_dt(2026, 1, 1),
+            end_time=_make_dt(2026, 1, 4),
+            prefix="Rental",
+        )
+
+        eo.update(req)
+
+        override = eo.overrides[1]
+        assert override is not None
+        assert override["slot_name"] == "Guest"
+
+    def test_update_rejects_unknown_keyword(self) -> None:
+        """Unknown sync update keywords still fail fast."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        with pytest.raises(TypeError):
+            eo.update(
+                slot=1,
+                slot_code="1234",
+                slot_name="Guest",
+                start_time=_make_dt(2026, 1, 1),
+                end_time=_make_dt(2026, 1, 4),
+                unexpected=True,
+            )
+
+    def test_update_request_rejects_extras(self) -> None:
+        """Request-object sync update extras still fail fast."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        req = SlotUpdateRequest(
+            slot=1,
+            slot_code="1234",
+            slot_name="Guest",
+            start_time=_make_dt(2026, 1, 1),
+            end_time=_make_dt(2026, 1, 4),
+        )
+
+        with pytest.raises(TypeError):
+            eo.update(req, unexpected=True)
+
+    def test_public_surface_members_remain_available(self) -> None:
+        """EventOverrides shell still exports the expected public members."""
+        assert hasattr(_eo_module, "EventOverrides")
+        assert hasattr(_eo_module, "EventOverride")
+        assert hasattr(_eo_module, "ReserveResult")
+
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        for name in (
+            "async_apply_plan",
+            "async_check_overrides",
+            "async_reserve_or_get_slot",
+            "async_update",
+            "diagnostics_snapshot",
+            "get_last_slot_error",
+            "load_persisted_mappings",
+            "pending_clear_slots",
+            "pending_fences",
+            "record_retry_failure",
+            "record_retry_success",
+            "release_pending_clear_slot",
+            "should_suppress_state_change",
+            "suppress_state_changes",
+            "update",
+            "verify_slot_ownership",
+            "_apply_clear",
+            "_apply_overwrite_manual_change",
+            "_find_overlapping_slot",
+            "_slot_has_matching_event",
+        ):
+            assert hasattr(eo, name)
+
+    def test_production_modules_do_not_import_helper_package(self) -> None:
+        """Production callers keep the public shell import boundary."""
+        root = (
+            Path(__file__).resolve().parents[2] / "custom_components" / "rental_control"
+        )
+        setup_shell = root / "coordinator_helpers" / "coordinator_setup_shell.py"
+        config_shell = root / "coordinator_helpers" / "coordinator_config_shell.py"
+
+        assert "from ..event_overrides import EventOverrides" in setup_shell.read_text()
+        assert (
+            "from ..event_overrides import EventOverrides" in config_shell.read_text()
+        )
+
+        for path in root.rglob("*.py"):
+            if (
+                "event_overrides_helpers" in path.parts
+                or path.name == "event_overrides.py"
+            ):
+                continue
+            assert "event_overrides_helpers" not in path.read_text()

--- a/tests/unit/test_event_overrides_apply.py
+++ b/tests/unit/test_event_overrides_apply.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+
+"""Focused apply-helper and diagnostics tests for EventOverrides decomposition."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from homeassistant.util import dt as dt_util
+import pytest
+
+from custom_components.rental_control.event_overrides import EventOverrides
+from custom_components.rental_control.event_overrides_helpers.apply_clear import (
+    decide_clear_preflight,
+)
+from custom_components.rental_control.event_overrides_helpers.apply_clear import (
+    decide_clear_result_mutation,
+)
+from custom_components.rental_control.event_overrides_helpers.apply_dispatch import (
+    classify_action,
+)
+from custom_components.rental_control.event_overrides_helpers.apply_set import (
+    build_set_operation_id,
+)
+from custom_components.rental_control.event_overrides_helpers.apply_set import (
+    build_suppression_changes,
+)
+from custom_components.rental_control.event_overrides_helpers.apply_set import (
+    build_tentative_override,
+)
+from custom_components.rental_control.event_overrides_helpers.apply_set import (
+    decide_set_result_mutation,
+)
+from custom_components.rental_control.event_overrides_helpers.apply_update import (
+    build_replacement_plan_id,
+)
+from custom_components.rental_control.event_overrides_helpers.apply_update import (
+    build_update_time_suppression,
+)
+from custom_components.rental_control.event_overrides_helpers.apply_update import (
+    parse_drift_fields,
+)
+from custom_components.rental_control.event_overrides_helpers.diagnostics import (
+    build_diagnostics_snapshot,
+)
+from custom_components.rental_control.reconciliation import ActionKind
+from custom_components.rental_control.reconciliation import DesiredPlan
+from custom_components.rental_control.reconciliation import PlannedSlot
+from custom_components.rental_control.reconciliation import Reservation
+from custom_components.rental_control.reconciliation import SlotAction
+from custom_components.rental_control.util import OperationResult
+
+
+def _dt(day: int, hour: int = 14) -> datetime:
+    """Return a UTC-aware datetime for February 2026."""
+    return datetime(2026, 2, day, hour, tzinfo=dt_util.UTC)
+
+
+def _reservation(identity_key: str = "res-1") -> Reservation:
+    """Return a reservation suitable for apply helper tests."""
+    start = _dt(1)
+    end = _dt(5)
+    return Reservation(
+        identity_key=identity_key,
+        start=start,
+        end=end,
+        buffered_start=start,
+        buffered_end=end,
+        summary="Guest",
+        slot_name="Guest",
+        display_slot_name="RC Guest",
+        slot_code="1234",
+    )
+
+
+class TestApplyHelpers:
+    """T013/T040-T045/T053: focused apply helper tests."""
+
+    def test_dispatch_classifies_actions(self) -> None:
+        """Dispatch helper preserves operation selection and warnings."""
+        res = _reservation()
+        res_by_key = {res.identity_key: res}
+
+        clear = classify_action(
+            SlotAction(kind=ActionKind.CLEAR, slot=1, reason="stale"), res_by_key
+        )
+        set_op = classify_action(
+            SlotAction(kind=ActionKind.SET, slot=1, identity_key=res.identity_key),
+            res_by_key,
+        )
+        update_op = classify_action(
+            SlotAction(
+                kind=ActionKind.UPDATE_TIMES, slot=1, identity_key=res.identity_key
+            ),
+            res_by_key,
+        )
+        overwrite = classify_action(
+            SlotAction(
+                kind=ActionKind.OVERWRITE_MANUAL_CHANGE,
+                slot=1,
+                identity_key=res.identity_key,
+            ),
+            res_by_key,
+        )
+        missing = classify_action(
+            SlotAction(kind=ActionKind.SET, slot=1, identity_key="missing"), res_by_key
+        )
+        noop = classify_action(SlotAction(kind=ActionKind.NOOP, slot=1), res_by_key)
+
+        assert clear["operation"] == "clear"
+        assert "Stale correction" in clear["warning"]
+        assert set_op["reservation"] is res
+        assert update_op["operation"] == "update_times"
+        assert overwrite["operation"] == "overwrite"
+        assert "has no reservation" in missing["warning"]
+        assert noop["operation"] is None
+
+    def test_clear_preflight_and_result_decisions(self) -> None:
+        """Clear helpers preserve preflight safety and result mutation choices."""
+        already_empty = decide_clear_preflight(("", ""), "Guest", {})
+        name_changed = decide_clear_preflight(
+            ("Other", "1234"), "Guest", {"name_state": "Guest"}
+        )
+        pin_changed = decide_clear_preflight(("Guest", ""), "Guest", {"has_code": True})
+
+        assert already_empty["status"] == "confirmed"
+        assert name_changed["reason"] == "name_changed"
+        assert pin_changed["reason"] == "pin_changed"
+
+        confirmed = decide_clear_result_mutation(
+            OperationResult(kind="clear", slot=1, confirmed=True)
+        )
+        failed = decide_clear_result_mutation(
+            OperationResult(kind="clear", slot=1, failed=True, error="boom")
+        )
+        lingering = decide_clear_result_mutation(
+            OperationResult(kind="clear", slot=1, lingering_name=True)
+        )
+
+        assert confirmed["clear_slot"] is True
+        assert failed["record_error"] == "boom"
+        assert "lingering state after clear" in lingering["record_error"]
+
+    def test_set_and_update_helpers_build_expected_payloads(self) -> None:
+        """Set/update helpers keep deterministic tokens and payload shapes."""
+        res = _reservation("res-99")
+        operation_id = build_set_operation_id("plan-1", 3, res.identity_key)
+        tentative = build_tentative_override(res)
+        suppression = build_suppression_changes("lock", 3, res)
+        update = build_update_time_suppression("lock", 3, res)
+        drift_fields = parse_drift_fields("drifted fields: name, start, end")
+        replacement = build_replacement_plan_id(3, lambda: "token-123")
+
+        assert operation_id == build_set_operation_id("plan-1", 3, res.identity_key)
+        assert tentative["slot_name"] == "Guest"
+        assert suppression["text.lock_code_slot_3_name"] == "RC Guest"
+        assert (
+            update["datetime.lock_code_slot_3_date_range_start"]
+            == res.buffered_start.isoformat()
+        )
+        assert drift_fields == ["name", "start", "end"]
+        assert replacement == "replace-3-token-123"
+
+        confirmed = decide_set_result_mutation(
+            OperationResult(kind="set", slot=3, confirmed=True), True, 3
+        )
+        stale = decide_set_result_mutation(
+            OperationResult(kind="set", slot=3), False, 3
+        )
+        failed = decide_set_result_mutation(
+            OperationResult(kind="set", slot=3, failed=True, error="fail"), True, 3
+        )
+
+        assert confirmed["status"] == "confirmed"
+        assert stale["status"] == "stale"
+        assert failed["revert"] is True
+
+    def test_build_diagnostics_snapshot_redacts_raw_codes(self) -> None:
+        """Diagnostics projection keeps behaviorally relevant metadata only."""
+        plan = DesiredPlan(plan_id="diag-1", generated_at=_dt(1))
+        plan.slots[1] = PlannedSlot(1, "res-1", "occupied", ActionKind.NOOP)
+        plan.slots[2] = PlannedSlot(
+            2,
+            None,
+            "blocked",
+            ActionKind.BLOCKED,
+            pending_reason="slot entity unavailable",
+            retry_count=2,
+        )
+        plan.slots[3] = PlannedSlot(
+            3,
+            "res-3",
+            "occupied",
+            ActionKind.OVERWRITE_MANUAL_CHANGE,
+            pending_reason="drifted fields: name, end",
+        )
+
+        snapshot = build_diagnostics_snapshot(
+            plan,
+            {2: "token"},
+            {1: 1, 3: 2},
+            {3: "needs overwrite"},
+            1,
+            3,
+        )
+
+        assert snapshot["matched_slots"][1]["identity_key"] == "res-1"
+        assert snapshot["pending_corrections"][2]["retry_count"] == 2
+        assert snapshot["manual_drift_slots"][3]["drift_fields"] == ["name", "end"]
+        assert snapshot["pending_clear_slots"] == [2]
+        assert "slot_code" not in str(snapshot)
+
+    @pytest.mark.asyncio
+    async def test_async_apply_plan_finalizes_activity_and_diagnostics(self) -> None:
+        """async_apply_plan toggles reconciliation_active and updates diagnostics."""
+        eo = EventOverrides(start_slot=1, max_slots=1)
+        now = _dt(1)
+        eo.update(1, "", "", now, now)
+        res = _reservation()
+        plan = DesiredPlan(plan_id="plan-1", generated_at=now)
+        plan.actions = [
+            SlotAction(kind=ActionKind.SET, slot=1, identity_key=res.identity_key)
+        ]
+        coordinator = SimpleNamespace(
+            lockname="lock", hass=SimpleNamespace(states=None, services=None)
+        )
+        coordinator.hass.states = SimpleNamespace(
+            get=lambda _entity_id: SimpleNamespace(state="")
+        )
+        coordinator.hass.services = SimpleNamespace(async_call=None)
+
+        async def fake_apply_set(_coordinator, _slot, _res, _plan_id):
+            """Assert lifecycle state during the delegated set call."""
+            assert eo.reconciliation_active is True
+            return OperationResult(kind="set", slot=1, confirmed=True)
+
+        with (
+            patch.object(eo, "_apply_set", side_effect=fake_apply_set),
+            patch.object(eo, "update_diagnostics_snapshot") as snapshot,
+        ):
+            results = await eo.async_apply_plan(
+                coordinator, plan, {res.identity_key: res}
+            )
+
+        assert results == [OperationResult(kind="set", slot=1, confirmed=True)]
+        assert eo.reconciliation_active is False
+        snapshot.assert_called_once_with(plan)

--- a/tests/unit/test_event_overrides_matcher.py
+++ b/tests/unit/test_event_overrides_matcher.py
@@ -1,0 +1,366 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+
+"""Focused matcher and cleanup tests for EventOverrides decomposition."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import importlib
+import sys
+from types import SimpleNamespace
+from typing import Any
+from typing import cast
+from zoneinfo import ZoneInfo
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.rental_control.event_overrides import EventOverrides
+from custom_components.rental_control.event_overrides_helpers.greedy_cleanup import (
+    compute_eviction_decisions,
+)
+from custom_components.rental_control.event_overrides_helpers.matcher import (
+    build_match_catalog,
+)
+from custom_components.rental_control.event_overrides_helpers.matcher import (
+    find_exact_name_strict_overlap,
+)
+from custom_components.rental_control.event_overrides_helpers.matcher import (
+    find_trim_aware_fallback,
+)
+from custom_components.rental_control.event_overrides_helpers.matcher import (
+    find_uid_positive_exact_name,
+)
+from custom_components.rental_control.event_overrides_helpers.matcher import match_slot
+from custom_components.rental_control.event_overrides_helpers.models import (
+    EvictionAction,
+)
+from custom_components.rental_control.event_overrides_helpers.models import (
+    EvictionDecision,
+)
+from custom_components.rental_control.event_overrides_helpers.models import (
+    EvictionReason,
+)
+from custom_components.rental_control.event_overrides_helpers.models import MatchCatalog
+from custom_components.rental_control.event_overrides_helpers.models import MatchPhase
+from custom_components.rental_control.event_overrides_helpers.models import MatchRequest
+from custom_components.rental_control.event_overrides_helpers.models import MatchResult
+from custom_components.rental_control.event_overrides_helpers.models import (
+    OverrideSnapshot,
+)
+from custom_components.rental_control.event_overrides_helpers.models import (
+    SlotReservationRequest,
+)
+from custom_components.rental_control.event_overrides_helpers.models import (
+    SlotUpdateRequest,
+)
+from custom_components.rental_control.event_overrides_helpers.models import TrimConfig
+from custom_components.rental_control.event_overrides_helpers.slot_bookkeeping import (
+    compute_next_slot,
+)
+from custom_components.rental_control.event_overrides_helpers.slot_bookkeeping import (
+    get_slots_with_values,
+)
+from custom_components.rental_control.event_overrides_helpers.slot_bookkeeping import (
+    get_slots_without_values,
+)
+from custom_components.rental_control.event_overrides_helpers.trim import (
+    is_trimmed_match,
+)
+from custom_components.rental_control.event_overrides_helpers.trim import (
+    make_trim_config,
+)
+from custom_components.rental_control.event_overrides_helpers.trim import strip_prefix
+from custom_components.rental_control.util import EventIdentity
+from custom_components.rental_control.util import trim_name
+
+
+def _dt(day: int, hour: int = 14) -> datetime:
+    """Return a UTC-aware datetime for January 2026."""
+    return datetime(2026, 1, day, hour, tzinfo=dt_util.UTC)
+
+
+def _ready_eo(max_slots: int = 3) -> EventOverrides:
+    """Return a ready EventOverrides with empty managed slots."""
+    eo = EventOverrides(start_slot=1, max_slots=max_slots)
+    now = _dt(1)
+    for slot in range(1, max_slots + 1):
+        eo.update(slot, "", "", now, now)
+    return eo
+
+
+def _catalog_from_eo(
+    eo: EventOverrides, exclude_slot: int | None = None
+) -> MatchCatalog:
+    """Serialize current EventOverrides state into a MatchCatalog."""
+    return build_match_catalog(
+        cast(dict[int, dict[str, Any] | None], eo.overrides),
+        eo._slot_uids,
+        make_trim_config(
+            eo.trim_names,
+            eo.max_name_length,
+            eo.event_prefix,
+            eo.prefix_length,
+        ),
+        exclude_slot,
+    )
+
+
+class TestHelperModels:
+    """T012/T014: foundational helper model tests."""
+
+    def test_model_construction(self) -> None:
+        """All foundational helper models construct with expected values."""
+        start = _dt(2)
+        end = _dt(5)
+        snapshot = OverrideSnapshot(1, "Guest", True, start, end, "uid-1")
+        trim = TrimConfig(True, 12, "Rental", 7)
+        catalog = MatchCatalog([snapshot], trim, exclude_slot=3)
+        request = MatchRequest(
+            "Guest", start, end, "uid-1", exclude_slot=2, target_slot=1
+        )
+        result = MatchResult(1, MatchPhase.UID_EXACT_NAME, "Guest")
+        update = SlotUpdateRequest(1, "1234", "Guest", start, end, "Rental")
+        reserve = SlotReservationRequest("Guest", "1234", start, end, "uid-1", "Rental")
+        decision = EvictionDecision(
+            1, EvictionAction.CLEAR, 2, EvictionReason.THRESHOLD
+        )
+
+        assert trim.guest_max == 5
+        assert catalog.exclude_slot == 3
+        assert request.target_slot == 1
+        assert result.phase is MatchPhase.UID_EXACT_NAME
+        assert update.prefix == "Rental"
+        assert reserve.uid == "uid-1"
+        assert decision.reason is EvictionReason.THRESHOLD
+
+    def test_models_import_without_forbidden_runtime_modules(self) -> None:
+        """Importing models adds no HA/coordinator/store/keymaster modules."""
+        module_name = "custom_components.rental_control.event_overrides_helpers.models"
+        forbidden = (
+            "homeassistant",
+            "custom_components.rental_control.coordinator",
+            "custom_components.rental_control.coordinator_helpers",
+            "custom_components.rental_control.store",
+            "keymaster",
+        )
+        saved = {
+            name: module
+            for name, module in sys.modules.items()
+            if any(
+                name == prefix or name.startswith(f"{prefix}.") for prefix in forbidden
+            )
+        }
+        sys.modules.pop(module_name, None)
+        for name in saved:
+            sys.modules.pop(name, None)
+        try:
+            before = set(sys.modules)
+            importlib.import_module(module_name)
+            loaded = set(sys.modules) - before
+
+            for prefix in forbidden:
+                assert not any(
+                    name == prefix or name.startswith(f"{prefix}.") for name in loaded
+                )
+        finally:
+            for name in list(sys.modules):
+                if any(
+                    name == prefix or name.startswith(f"{prefix}.")
+                    for prefix in forbidden
+                ):
+                    sys.modules.pop(name, None)
+            sys.modules.update(saved)
+
+
+class TestSharedMatcher:
+    """T022-T032/T058: focused shared matcher tests."""
+
+    def test_uid_positive_exact_name_ignores_overlap(self) -> None:
+        """UID+name wins even when the time window no longer overlaps."""
+        eo = _ready_eo()
+        eo.update(1, "1111", "Guest", _dt(1), _dt(5))
+        eo._slot_uids[1] = "uid-1"
+
+        request = MatchRequest("Guest", _dt(10), _dt(12), " uid-1 ")
+        result = find_uid_positive_exact_name(_catalog_from_eo(eo), request)
+
+        assert result == MatchResult(1, MatchPhase.UID_EXACT_NAME)
+
+    def test_exact_name_overlap_respects_exclude_slot(self) -> None:
+        """Strict overlap matches unless the slot is explicitly excluded."""
+        eo = _ready_eo()
+        eo.update(1, "1111", "Guest", _dt(1), _dt(5))
+        request = MatchRequest("Guest", _dt(3), _dt(6), None)
+
+        assert find_exact_name_strict_overlap(
+            _catalog_from_eo(eo), request
+        ) == MatchResult(
+            1,
+            MatchPhase.EXACT_NAME_STRICT_OVERLAP,
+        )
+        assert (
+            find_exact_name_strict_overlap(
+                _catalog_from_eo(eo, exclude_slot=1),
+                request,
+            )
+            is None
+        )
+
+    def test_same_start_uid_bypass_prefers_best_slot(self) -> None:
+        """Same-start UID bypass keeps PR #566 preferred-slot tie-breaking."""
+        eo = _ready_eo()
+        eo.update(1, "1111", "Guest", _dt(1), _dt(4))
+        eo._slot_uids[1] = "old-1"
+        eo.update(2, "2222", "Guest", _dt(1), _dt(6))
+        eo._slot_uids[2] = "old-2"
+
+        event = EventIdentity("Guest", _dt(1), _dt(5), "new-uid")
+        assert eo._get_same_start_uid_bypass_slot(event) == 1
+        assert (
+            eo._find_overlapping_slot(event.name, event.start, event.end, event.uid)
+            == 1
+        )
+
+    def test_trim_fallback_restores_full_name(self) -> None:
+        """Trim-aware fallback returns and applies the longer full name."""
+        eo = _ready_eo()
+        eo.trim_names = True
+        eo.max_name_length = 18
+        eo.event_prefix = "Rental"
+        full_name = "Alice Bob Charlie"
+        stored_name = trim_name(full_name, eo.max_name_length - eo.prefix_length)
+        eo.update(1, "1111", stored_name, _dt(1), _dt(5))
+        eo._slot_uids[1] = "uid-1"
+
+        result = find_trim_aware_fallback(
+            _catalog_from_eo(eo),
+            MatchRequest(full_name, _dt(9), _dt(10), "uid-1"),
+        )
+
+        assert result == MatchResult(1, MatchPhase.TRIM_UID, full_name)
+        assert eo._find_overlapping_slot(full_name, _dt(9), _dt(10), "uid-1") == 1
+        override = eo.overrides[1]
+        assert override is not None
+        assert override["slot_name"] == full_name
+
+    def test_mirror_methods_share_matcher_semantics(self) -> None:
+        """The shell mirror methods agree on the shared matcher winner."""
+        eo = _ready_eo()
+        eo.update(1, "1111", "Guest", _dt(1), _dt(5))
+        eo._slot_uids[1] = "uid-1"
+        eo.update(2, "2222", "Other", _dt(6), _dt(8))
+        eo._slot_uids[2] = "uid-2"
+        event = EventIdentity("Guest", _dt(3), _dt(4), "uid-1")
+        result = match_slot(
+            _catalog_from_eo(eo),
+            MatchRequest(event.name, event.start, event.end, event.uid),
+        )
+
+        assert result.slot == eo._find_overlapping_slot(
+            event.name, event.start, event.end, event.uid
+        )
+        assert eo._slot_has_matching_event(1, [event]) is True
+        assert eo._slot_has_matching_event(2, [event]) is False
+
+    def test_slot_has_matching_event_is_slot_anchored_for_duplicates(self) -> None:
+        """Duplicate non-UID slot matches stay true for each matching slot."""
+        eo = _ready_eo(max_slots=2)
+        eo.update(1, "1111", "Guest", _dt(1), _dt(5))
+        eo.update(2, "2222", "Guest", _dt(1), _dt(5))
+        event = EventIdentity("Guest", _dt(2), _dt(3), None)
+
+        assert eo._find_overlapping_slot(event.name, event.start, event.end) == 1
+        assert eo._slot_has_matching_event(1, [event]) is True
+        assert eo._slot_has_matching_event(2, [event]) is True
+
+    def test_trim_and_slot_bookkeeping_helpers(self) -> None:
+        """Trim, free-slot ordering, and next-slot helpers stay deterministic."""
+        eo = _ready_eo()
+        eo.update(1, "1111", "Guest", _dt(1), _dt(2))
+        eo.update(3, "3333", "Other", _dt(3), _dt(4))
+
+        assert strip_prefix("Rental Guest", "Rental") == "Guest"
+        assert is_trimmed_match("Alice Bob Charlie", "Alice Bob", 10) is True
+        assert get_slots_with_values(eo.overrides) == [1, 3]
+        assert get_slots_without_values(eo.overrides) == [2]
+        assert compute_next_slot(eo.overrides, eo.start_slot, eo.max_slots) == 2
+
+    def test_greedy_cleanup_decisions_cover_match_miss_and_clears(self) -> None:
+        """Greedy cleanup returns reset, increment, threshold, and immediate clears."""
+        eo = _ready_eo(max_slots=2)
+        eo.update(1, "1111", "Guest", _dt(5), _dt(7))
+        eo._slot_uids[1] = "uid-1"
+        eo.update(2, "2222", "Other", _dt(9), _dt(11))
+        catalog = _catalog_from_eo(eo)
+        event_ids = [EventIdentity("Guest", _dt(5), _dt(7), "uid-1")]
+        calendar = [SimpleNamespace(end=_dt(12))]
+
+        decisions = compute_eviction_decisions(
+            catalog, event_ids, calendar, 2, {1: 1}, _dt(4).date()
+        )
+        assert decisions[0].action is EvictionAction.RESET_MISS
+        assert decisions[1].action is EvictionAction.INCREMENT_MISS
+        assert decisions[1].new_miss_count == 1
+
+        threshold = compute_eviction_decisions(
+            catalog, [], calendar, 2, {2: 1}, _dt(4).date()
+        )
+        assert threshold[1] == EvictionDecision(
+            2, EvictionAction.CLEAR, 2, EvictionReason.THRESHOLD
+        )
+
+        empty = compute_eviction_decisions(catalog, event_ids, [], 2, {}, _dt(4).date())
+        assert all(
+            decision.reason is EvictionReason.EMPTY_CALENDAR for decision in empty
+        )
+
+        malformed = compute_eviction_decisions(
+            MatchCatalog(
+                [
+                    OverrideSnapshot(9, "Bad", True, _dt(8), _dt(7), None),
+                ],
+                TrimConfig(False, 0, "", 0),
+            ),
+            [],
+            calendar,
+            2,
+            {},
+            _dt(4).date(),
+        )
+        assert malformed[0].reason is EvictionReason.MALFORMED_WINDOW
+
+    def test_greedy_cleanup_uses_stored_local_dates_for_miss_tolerance(self) -> None:
+        """Eviction tolerance uses original stored dates, not UTC-shifted dates."""
+        tokyo = ZoneInfo("Asia/Tokyo")
+        start = datetime(2026, 1, 5, 0, 30, tzinfo=tokyo)
+        end = datetime(2026, 1, 6, 10, 0, tzinfo=tokyo)
+        start_utc = start.astimezone(dt_util.UTC)
+        end_utc = end.astimezone(dt_util.UTC)
+        catalog = build_match_catalog(
+            {
+                1: {
+                    "slot_name": "Guest",
+                    "slot_code": "1111",
+                    "start_time": start_utc,
+                    "end_time": end_utc,
+                }
+            },
+            {},
+            TrimConfig(False, 0, "", 0),
+            slot_dates={1: (start.date(), end.date())},
+        )
+        calendar = [SimpleNamespace(end=end)]
+
+        decisions = compute_eviction_decisions(
+            catalog, [], calendar, 1, {}, start.date()
+        )
+
+        assert decisions == [
+            EvictionDecision(
+                1,
+                EvictionAction.INCREMENT_MISS,
+                1,
+                EvictionReason.MISSING_EVENT,
+            )
+        ]


### PR DESCRIPTION
## Summary
- Split the EventOverrides engine into event_overrides_helpers/ while keeping custom_components.rental_control.event_overrides as the public shell.
- Added shared MatchCatalog-based mirror matching for _find_overlapping_slot and _slot_has_matching_event with behavior-preserving wrappers.
- Added request-object compatibility wrappers for reserve/update call forms and preserved production caller imports/usages.
- Extracted apply-plan, cleanup, diagnostics, trim, and slot bookkeeping helpers and removed the event_overrides.py complexity directive.

Closes #575

Implementation stage for the 017 decompose-event-overrides speckit pipeline.

## Validation
- uv run pytest tests/ -x -q
- uv run ruff check custom_components/ tests/
- uv run pre-commit run aislop --all-files
- uv run pre-commit run --all-files