### PR TITLE
Chore(overrides): Quiet patch-target import warns

### DIFF
--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -13,6 +13,9 @@
 ##############################################################################
 """Rental Control EventOverrides."""
 
+# aislop-ignore-file ai-slop/unused-import -- Keymaster fire helpers and uuid are
+# retained re-exports accessed via self._module for test monkeypatch compatibility.
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
Suppress 5 false-positive `ai-slop/unused-import` warnings on `event_overrides.py` introduced by the #575 decomposition. The flagged imports (uuid + Keymaster fire-code helpers) are intentionally retained re-exports accessed via `self._module` for test monkeypatch compatibility. Adds a file-level `ai-slop/unused-import` suppression. No behavior change.

Follow-up to PR #644 / #575.