### PR TITLE
Chore(aislop): Prune stale ignores, gate at 100

### DIFF
--- a/.aislop/config.yml
+++ b/.aislop/config.yml
@@ -7,3 +7,8 @@ version: 1
 
 # aislop 0.10.x supports precise false-positive handling via inline
 # `aislop-ignore-*` directives in source. Keep project-local config here.
+
+# Fail the CI quality gate if the project score drops below a perfect 100.
+# The whole tree is at 100/100; this prevents silent regressions.
+ci:
+  failBelow: 100

--- a/custom_components/rental_control/coordinator.py
+++ b/custom_components/rental_control/coordinator.py
@@ -50,8 +50,6 @@ from .reconciliation import DesiredPlan as _DesiredPlan
 from .reconciliation import ManagedSlot as _ManagedSlot
 from .reconciliation import compute_desired_plan as compute_desired_plan  # noqa: F401
 
-# aislop-ignore-file ai-slop/hallucinated-import -- Provided by Home Assistant runtime.
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/rental_control/coordinator_helpers/calendar_parsing.py
+++ b/custom_components/rental_control/coordinator_helpers/calendar_parsing.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
 
     from .models import CalendarParseContext
 
-# aislop-ignore-file ai-slop/hallucinated-import -- Provided by Home Assistant runtime.
 
 import logging
 

--- a/custom_components/rental_control/event_overrides.py
+++ b/custom_components/rental_control/event_overrides.py
@@ -13,8 +13,9 @@
 ##############################################################################
 """Rental Control EventOverrides."""
 
-# aislop-ignore-file ai-slop/unused-import -- Keymaster fire helpers and uuid are
-# retained re-exports accessed via self._module for test monkeypatch compatibility.
+# aislop-ignore-file ai-slop/unused-import -- ``uuid`` is imported solely so the
+# shell apply helpers can reach it via ``self._module.uuid.uuid4()``; aislop cannot
+# see that runtime module-attribute access.
 
 from __future__ import annotations
 


### PR DESCRIPTION
Cleanup following the decomposition work, prompted by a review of the remaining aislop suppressions.

## Changes
- **Remove 2 stale `ai-slop/hallucinated-import` directives** (`coordinator.py`, `coordinator_helpers/calendar_parsing.py`). Verified they suppress **zero** findings on current `main` — aislop now resolves their Home Assistant imports. Dead cruft from earlier emergency work.
- **Refine the `event_overrides.py` `unused-import` suppression comment** to accurately explain why `uuid` is retained: it is reached at runtime via `self._module.uuid.uuid4()` in the shell apply helpers, which aislop cannot see. (Directive kept — it is a genuine false positive.)
- **Add `ci.failBelow: 100`** to `.aislop/config.yml` so the quality gate fails on any regression from the current 100/100 score.

## Verification
- `aislop scan`: 100/100, 0 errors, 0 warnings (2 legit voluptuous/HA-runtime suppressions remain).
- `aislop ci` exits 0 at 100, exits 1 at 99 (failBelow gate confirmed working).
- ruff/pre-commit clean; 426 coordinator+event_overrides tests pass.

No behavior change.