### PR TITLE
Chore(ci): Scan full repo in aislop hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,8 +61,8 @@ repos:
   - repo: local
     hooks:
       - id: aislop
-        name: aislop ci (staged)
-        entry: aislop ci --staged
+        name: aislop ci (full repo)
+        entry: aislop ci
         language: node
         additional_dependencies:
           - aislop@0.12.0


### PR DESCRIPTION
Switch the pre-commit `aislop` hook from `aislop ci --staged` to a whole-tree `aislop ci` scan.

With `ci.failBelow: 100` (added in #664), the staged-only mode could miss a regression in an unstaged file. Full-repo scanning on every commit ensures the **whole project** must stay at 100/100, not just the files in the current change set.

Verified: `pre-commit run aislop --all-files` passes (100/100); yamllint clean. No behavior change to the integration.