### PR TITLE
Fix(coordinator): Harden calendar and store paths

### DIFF
--- a/custom_components/rental_control/coordinator_helpers/calendar_parsing.py
+++ b/custom_components/rental_control/coordinator_helpers/calendar_parsing.py
@@ -255,7 +255,7 @@ def _select_event_times(
         return checkin, checkout
     try:
         return event["DTSTART"].dt.time(), event["DTEND"].dt.time()
-    except AttributeError:
+    except (AttributeError, KeyError):  # fmt: skip
         return ctx.checkin, ctx.checkout
 
 

--- a/custom_components/rental_control/coordinator_helpers/calendar_parsing.py
+++ b/custom_components/rental_control/coordinator_helpers/calendar_parsing.py
@@ -39,6 +39,11 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 
 
+def _event_summary(event: Any) -> str:
+    """Return the VEVENT summary, or empty string when missing."""
+    return str(event["SUMMARY"]) if "SUMMARY" in event else ""
+
+
 def combine_event_time(value: Any, selected_time: time, timezone: tzinfo) -> datetime:
     """Return an event-date datetime using the selected local time."""
     event_date = value.date() if isinstance(value, datetime) else value
@@ -158,10 +163,11 @@ def _vevent_filtered(
     event: Any, from_date: datetime, to_date: datetime, ctx: Any
 ) -> bool:
     """Return whether an event should be skipped before time selection."""
+    summary = _event_summary(event)
     if "RRULE" in event:
-        _LOGGER.error("RRULE in event: %s", str(event["SUMMARY"]))
+        _LOGGER.error("RRULE in event: %s", summary)
         return True
-    if "Check-in" in event["SUMMARY"] or "Check-out" in event["SUMMARY"]:
+    if "Check-in" in summary or "Check-out" in summary:
         _LOGGER.debug("Smoobu extra event, ignoring")
         return True
     try:
@@ -177,7 +183,7 @@ def _vevent_filtered(
     except (AttributeError, TypeError):  # fmt: skip
         pass
     if ctx.ignore_non_reserved and any(
-        x in event["SUMMARY"] for x in ["Blocked", "Not available"]
+        x in summary for x in ["Blocked", "Not available"]
     ):
         return True
     return False
@@ -190,10 +196,11 @@ def _parse_vevent(
     if _vevent_filtered(event, from_date, to_date, ctx):
         return None
 
+    summary = _event_summary(event)
     if "DESCRIPTION" in event:
-        slot_name = get_slot_name(event["SUMMARY"], event["DESCRIPTION"], "")
+        slot_name = get_slot_name(summary, event["DESCRIPTION"], "")
     else:
-        slot_name = get_slot_name(event["SUMMARY"], "", "")
+        slot_name = get_slot_name(summary, "", "")
 
     override = None
     if slot_name and ctx.override_lookup is not None:
@@ -213,7 +220,7 @@ def _parse_vevent(
     end = dtend
 
     if ctx.event_prefix:
-        event["SUMMARY"] = ctx.event_prefix + " " + event["SUMMARY"]
+        event["SUMMARY"] = f"{ctx.event_prefix} {_event_summary(event)}".strip()
 
     return _build_calendar_event(start, end, from_date, event, ctx)
 
@@ -303,7 +310,7 @@ def _build_calendar_event(
         description=description,
         end=end.astimezone(ctx.timezone),
         location=event.get("LOCATION"),
-        summary=event.get("SUMMARY", "Unknown"),
+        summary=_event_summary(event),
         start=start.astimezone(ctx.timezone),
         uid=normalize_uid(str(raw_uid) if raw_uid is not None else None),
     )

--- a/custom_components/rental_control/coordinator_helpers/calendar_parsing.py
+++ b/custom_components/rental_control/coordinator_helpers/calendar_parsing.py
@@ -44,6 +44,12 @@ def _event_summary(event: Any) -> str:
     return str(event["SUMMARY"]) if "SUMMARY" in event else ""
 
 
+def _event_date(value: Any) -> Any:
+    """Return a comparable date from a VEVENT DTSTART/DTEND value."""
+    event_value = value.dt
+    return event_value.date() if isinstance(event_value, datetime) else event_value
+
+
 def combine_event_time(value: Any, selected_time: time, timezone: tzinfo) -> datetime:
     """Return an event-date datetime using the selected local time."""
     event_date = value.date() if isinstance(value, datetime) else value
@@ -171,14 +177,14 @@ def _vevent_filtered(
         _LOGGER.debug("Smoobu extra event, ignoring")
         return True
     try:
-        if "DTEND" in event and event["DTEND"].dt < from_date.date() - timedelta(
-            days=EVENT_AGE_THRESHOLD_DAYS
-        ):
+        if "DTEND" in event and _event_date(
+            event["DTEND"]
+        ) < from_date.date() - timedelta(days=EVENT_AGE_THRESHOLD_DAYS):
             return True
     except (AttributeError, TypeError):  # fmt: skip
         pass
     try:
-        if "DTSTART" in event and event["DTSTART"].dt > to_date.date():
+        if "DTSTART" in event and _event_date(event["DTSTART"]) > to_date.date():
             return True
     except (AttributeError, TypeError):  # fmt: skip
         pass

--- a/custom_components/rental_control/coordinator_helpers/ghost_reservations.py
+++ b/custom_components/rental_control/coordinator_helpers/ghost_reservations.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 from typing import Any
 
@@ -19,6 +20,23 @@ from .models import ReservationBuildContext
 from .models import _format_display_slot_name
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _coerce_persisted_datetime(value: Any) -> datetime | None:
+    """Return a valid persisted datetime, or None for corrupt values."""
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        parsed = _dt.parse_datetime(value)
+        return parsed if isinstance(parsed, datetime) else None
+    return None
+
+
+def _persisted_string_set(value: Any) -> set[str]:
+    """Return persisted string aliases while ignoring corrupt values."""
+    if not isinstance(value, (list, set, tuple)):
+        return set()
+    return {item for item in value if isinstance(item, str)}
 
 
 def build_ghost_reservations(
@@ -54,7 +72,10 @@ def _build_one_ghost(
     if status not in (SLOT_STATUS_OCCUPIED, SLOT_STATUS_PENDING_SET):
         return None
 
-    new_mc = mapping.get("missing_count", 0) + 1
+    missing_count = mapping.get("missing_count", 0)
+    if not isinstance(missing_count, int):
+        missing_count = 0
+    new_mc = missing_count + 1
     mapping["missing_count"] = new_mc
 
     if status == SLOT_STATUS_PENDING_SET and new_mc >= 3:
@@ -83,8 +104,15 @@ def _ghost_from_mapping(
 ) -> _Reservation | None:
     """Return a ghost reservation from a persisted mapping, or None when fenced."""
     identity = mapping.get("identity", {})
-    slot_name: str = identity.get("slot_name", "")
+    if not isinstance(identity, dict):
+        identity = {}
+    slot_name_raw = identity.get("slot_name", "")
+    slot_name = slot_name_raw if isinstance(slot_name_raw, str) else ""
+    summary_raw = identity.get("summary", "")
+    summary = summary_raw if isinstance(summary_raw, str) else ""
     last_actual = mapping.get("last_observed_actual", {})
+    if not isinstance(last_actual, dict):
+        last_actual = {}
     actual_name = last_actual.get("name_state")
     if _ghost_physical_name_mismatch(
         actual_name, slot_name, prefix, observed_mapping_keys, key, ctx
@@ -110,10 +138,12 @@ def _ghost_from_mapping(
         )
         return None
 
-    start_dt = (
-        _dt.parse_datetime(start_raw) if isinstance(start_raw, str) else start_raw
-    )
-    end_dt = _dt.parse_datetime(end_raw) if isinstance(end_raw, str) else end_raw
+    start_dt = _coerce_persisted_datetime(start_raw)
+    end_dt = _coerce_persisted_datetime(end_raw)
+    if start_dt is not None and start_dt.tzinfo is None:
+        start_dt = start_dt.replace(tzinfo=ctx.timezone)
+    if end_dt is not None and end_dt.tzinfo is None:
+        end_dt = end_dt.replace(tzinfo=ctx.timezone)
     if start_dt is None or end_dt is None or start_dt >= end_dt:
         _LOGGER.debug(
             "Ghost reservation %s: invalid dates (start=%s end=%s); "
@@ -132,15 +162,17 @@ def _ghost_from_mapping(
             end=end_dt,
             buffered_start=start_dt,
             buffered_end=end_dt,
-            summary=identity.get("summary", ""),
+            summary=summary,
             slot_name=slot_name,
             display_slot_name=_format_display_slot_name(
                 slot_name, prefix, ctx.trim_names, ctx.max_name_length
             ),
             slot_code="",
-            uid_aliases=set(identity.get("uid_aliases", [])),
-            booking_aliases=set(identity.get("booking_aliases", [])),
-            fingerprint_history=set(mapping.get("fingerprint_history", [])),
+            uid_aliases=_persisted_string_set(identity.get("uid_aliases", [])),
+            booking_aliases=_persisted_string_set(identity.get("booking_aliases", [])),
+            fingerprint_history=_persisted_string_set(
+                mapping.get("fingerprint_history", [])
+            ),
             missing_count=new_mc,
         )
     except ValueError:

--- a/custom_components/rental_control/coordinator_helpers/store_sync.py
+++ b/custom_components/rental_control/coordinator_helpers/store_sync.py
@@ -262,6 +262,7 @@ def build_save_payload(
         "updated_at": now_str,
         "mappings": mappings,
         "aliases": current_store.get("aliases", {}),
+        "blocked_slots": current_store.get("blocked_slots", {}),
         "last_plan": current_store.get("last_plan", {}),
         "migration_notes": current_store.get("migration_notes", []),
     }

--- a/custom_components/rental_control/coordinator_helpers/store_sync.py
+++ b/custom_components/rental_control/coordinator_helpers/store_sync.py
@@ -196,6 +196,8 @@ def normalize_loaded_store(
     schema_version = raw.get("schema_version", 0)
     if not isinstance(schema_version, int):
         return None
+    if schema_version > STORE_SCHEMA_VERSION:
+        return None
     if schema_version < 1:
         raw = migrate_to_v1(raw, defaults)
     mappings = raw.get("mappings", {})

--- a/custom_components/rental_control/helpers.py
+++ b/custom_components/rental_control/helpers.py
@@ -293,7 +293,8 @@ def compute_early_expiry_time(
 def get_slot_name(summary: str, description: str, prefix: str) -> str | None:
     """Determine the name for a given slot / event."""
     if prefix:
-        name = re.compile(f"{prefix} (.*)").findall(summary)[0]
+        matches = re.compile(f"{re.escape(prefix)} (.*)").findall(summary)
+        name = matches[0] if matches else summary
     else:
         name = summary
     if re.compile("Not available|Blocked").search(name):

--- a/tests/unit/test_coordinator_parsing.py
+++ b/tests/unit/test_coordinator_parsing.py
@@ -99,3 +99,31 @@ def test_parse_calendar_prefixes_missing_summary_without_trailing_space() -> Non
 
     assert len(events) == 1
     assert events[0].summary == "RC"
+
+
+def test_select_event_times_defaults_without_dtend() -> None:
+    """A timed VEVENT without DTEND uses configured default times."""
+    event = Event()
+    event.add("dtstart", datetime(2026, 6, 15, 12, tzinfo=timezone.utc))
+
+    assert calendar_parsing._select_event_times(event, None, _parse_ctx()) == (
+        time(16, 0),
+        time(10, 0),
+    )
+
+
+def test_parse_calendar_preserves_missing_dtend_zero_length() -> None:
+    """A timed VEVENT without DTEND keeps the existing zero-length stay."""
+    event = Event()
+    event.add("summary", "Alice")
+    event.add("dtstart", datetime(2026, 6, 15, 12, tzinfo=timezone.utc))
+
+    events = calendar_parsing.parse_calendar(
+        _calendar_with_event(event),
+        datetime(2026, 6, 1, tzinfo=timezone.utc),
+        datetime(2026, 6, 30, tzinfo=timezone.utc),
+        _parse_ctx(),
+    )
+
+    assert len(events) == 1
+    assert events[0].end == events[0].start

--- a/tests/unit/test_coordinator_parsing.py
+++ b/tests/unit/test_coordinator_parsing.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 from datetime import date
 from datetime import datetime
 from datetime import time
+from datetime import timedelta
 from datetime import timezone
 
 from icalendar import Calendar
 from icalendar import Event
 
+from custom_components.rental_control.const import EVENT_AGE_THRESHOLD_DAYS
 from custom_components.rental_control.coordinator_helpers import calendar_parsing
 from custom_components.rental_control.coordinator_helpers.models import (
     CalendarParseContext,
@@ -127,3 +129,55 @@ def test_parse_calendar_preserves_missing_dtend_zero_length() -> None:
 
     assert len(events) == 1
     assert events[0].end == events[0].start
+
+
+def test_vevent_filter_handles_timed_stale_events() -> None:
+    """Timed stale events are filtered using their calendar date."""
+    from_date = datetime(2026, 6, 30, tzinfo=timezone.utc)
+    event = Event()
+    event.add("summary", "Alice")
+    event.add("dtstart", from_date - timedelta(days=EVENT_AGE_THRESHOLD_DAYS + 2))
+    event.add("dtend", from_date - timedelta(days=EVENT_AGE_THRESHOLD_DAYS + 1))
+
+    assert calendar_parsing._vevent_filtered(
+        event, from_date, datetime(2026, 7, 30, tzinfo=timezone.utc), _parse_ctx()
+    )
+
+
+def test_vevent_filter_handles_timed_future_events() -> None:
+    """Timed future events are filtered using their calendar date."""
+    to_date = datetime(2026, 6, 30, tzinfo=timezone.utc)
+    event = Event()
+    event.add("summary", "Alice")
+    event.add("dtstart", to_date + timedelta(days=1))
+    event.add("dtend", to_date + timedelta(days=2))
+
+    assert calendar_parsing._vevent_filtered(
+        event, datetime(2026, 6, 1, tzinfo=timezone.utc), to_date, _parse_ctx()
+    )
+
+
+def test_vevent_filter_keeps_all_day_boundaries() -> None:
+    """All-day stale and future filtering still uses date values."""
+    stale = Event()
+    stale.add("summary", "Alice")
+    stale.add("dtstart", date(2026, 5, 29))
+    stale.add("dtend", date(2026, 5, 30))
+
+    future = Event()
+    future.add("summary", "Bob")
+    future.add("dtstart", date(2026, 7, 1))
+    future.add("dtend", date(2026, 7, 2))
+
+    assert calendar_parsing._vevent_filtered(
+        stale,
+        datetime(2026, 6, 30, tzinfo=timezone.utc),
+        datetime(2026, 7, 30, tzinfo=timezone.utc),
+        _parse_ctx(),
+    )
+    assert calendar_parsing._vevent_filtered(
+        future,
+        datetime(2026, 6, 1, tzinfo=timezone.utc),
+        datetime(2026, 6, 30, tzinfo=timezone.utc),
+        _parse_ctx(),
+    )

--- a/tests/unit/test_coordinator_parsing.py
+++ b/tests/unit/test_coordinator_parsing.py
@@ -4,11 +4,44 @@
 
 from __future__ import annotations
 
+from datetime import date
 from datetime import datetime
 from datetime import time
 from datetime import timezone
 
+from icalendar import Calendar
+from icalendar import Event
+
 from custom_components.rental_control.coordinator_helpers import calendar_parsing
+from custom_components.rental_control.coordinator_helpers.models import (
+    CalendarParseContext,
+)
+
+
+def _parse_ctx(
+    *,
+    event_prefix: str | None = None,
+    ignore_non_reserved: bool = False,
+    honor_event_times: bool = False,
+) -> CalendarParseContext:
+    """Return a minimal calendar parse context for tests."""
+    return CalendarParseContext(
+        timezone=timezone.utc,
+        checkin=time(16, 0),
+        checkout=time(10, 0),
+        event_prefix=event_prefix,
+        ignore_non_reserved=ignore_non_reserved,
+        honor_event_times=honor_event_times,
+        code_buffer_before=0,
+        code_buffer_after=0,
+    )
+
+
+def _calendar_with_event(event: Event) -> Calendar:
+    """Return a calendar containing one VEVENT."""
+    calendar = Calendar()
+    calendar.add_component(event)
+    return calendar
 
 
 def test_datetimes_match_true_for_equal_instants() -> None:
@@ -32,3 +65,37 @@ def test_combine_event_time_returns_datetime() -> None:
     assert isinstance(result, datetime)
     assert result.hour == 11
     assert result.minute == 30
+
+
+def test_parse_calendar_tolerates_missing_summary() -> None:
+    """A VEVENT without SUMMARY is handled as an empty-summary event."""
+    event = Event()
+    event.add("dtstart", date(2026, 6, 15))
+    event.add("dtend", date(2026, 6, 16))
+
+    events = calendar_parsing.parse_calendar(
+        _calendar_with_event(event),
+        datetime(2026, 6, 1, tzinfo=timezone.utc),
+        datetime(2026, 6, 30, tzinfo=timezone.utc),
+        _parse_ctx(),
+    )
+
+    assert len(events) == 1
+    assert events[0].summary == ""
+
+
+def test_parse_calendar_prefixes_missing_summary_without_trailing_space() -> None:
+    """A missing-summary VEVENT with a prefix has no trailing space."""
+    event = Event()
+    event.add("dtstart", date(2026, 6, 15))
+    event.add("dtend", date(2026, 6, 16))
+
+    events = calendar_parsing.parse_calendar(
+        _calendar_with_event(event),
+        datetime(2026, 6, 1, tzinfo=timezone.utc),
+        datetime(2026, 6, 30, tzinfo=timezone.utc),
+        _parse_ctx(event_prefix="RC"),
+    )
+
+    assert len(events) == 1
+    assert events[0].summary == "RC"

--- a/tests/unit/test_coordinator_reservations.py
+++ b/tests/unit/test_coordinator_reservations.py
@@ -4,8 +4,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from datetime import timezone
 
+from custom_components.rental_control.const import SLOT_STATUS_OCCUPIED
 from custom_components.rental_control.coordinator_helpers import reservations
 from custom_components.rental_control.coordinator_helpers.models import (
     GhostReservationResult,
@@ -42,3 +44,80 @@ def test_build_ghost_reservations_empty_persisted() -> None:
     result = reservations.build_ghost_reservations(set(), {}, "RC ", None, _ctx())
     assert isinstance(result, GhostReservationResult)
     assert result.reservations == []
+
+
+def test_build_ghost_reservations_fences_corrupt_mapping() -> None:
+    """Corrupt persisted ghost fields are treated as empty values."""
+    persisted: dict[str, dict[str, object]] = {
+        "none-fields": {
+            "status": SLOT_STATUS_OCCUPIED,
+            "missing_count": None,
+            "identity": None,
+            "last_observed_actual": None,
+        },
+        "bad-fields": {
+            "status": SLOT_STATUS_OCCUPIED,
+            "missing_count": "x",
+            "identity": "bad",
+            "last_observed_actual": "bad",
+        },
+    }
+
+    result = reservations.build_ghost_reservations(
+        set(), persisted, "RC ", None, _ctx()
+    )
+
+    assert result.reservations == []
+    assert persisted["none-fields"]["missing_count"] == 1
+    assert persisted["bad-fields"]["missing_count"] == 1
+
+
+def test_build_ghost_reservations_fences_corrupt_nested_values() -> None:
+    """Corrupt nested ghost values are fenced instead of raising."""
+    persisted: dict[str, dict[str, object]] = {
+        "bad-nested": {
+            "status": SLOT_STATUS_OCCUPIED,
+            "missing_count": 0,
+            "identity": {
+                "slot_name": 12,
+                "summary": object(),
+                "uid_aliases": object(),
+            },
+            "last_observed_actual": {
+                "name_state": "RC Alice",
+                "start_state": 1,
+                "end_state": 2,
+            },
+            "fingerprint_history": object(),
+        }
+    }
+
+    result = reservations.build_ghost_reservations(
+        set(), persisted, "RC ", {"bad-nested"}, _ctx()
+    )
+
+    assert result.reservations == []
+    assert persisted["bad-nested"]["missing_count"] == 1
+
+
+def test_build_ghost_reservations_handles_mixed_datetime_awareness() -> None:
+    """Mixed naive and aware persisted ghost datetimes are fenced."""
+    persisted: dict[str, dict[str, object]] = {
+        "mixed-dates": {
+            "status": SLOT_STATUS_OCCUPIED,
+            "missing_count": 0,
+            "identity": {"slot_name": "Alice", "summary": "Alice"},
+            "last_observed_actual": {
+                "name_state": "RC Alice",
+                "start_state": datetime(2026, 1, 2),
+                "end_state": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            },
+        }
+    }
+
+    result = reservations.build_ghost_reservations(
+        set(), persisted, "RC ", {"mixed-dates"}, _ctx()
+    )
+
+    assert result.reservations == []
+    assert persisted["mixed-dates"]["missing_count"] == 1

--- a/tests/unit/test_coordinator_store_sync.py
+++ b/tests/unit/test_coordinator_store_sync.py
@@ -41,6 +41,49 @@ def test_normalize_loaded_store_rejects_non_dict() -> None:
     assert result is None
 
 
+def test_normalize_loaded_store_rejects_future_schema() -> None:
+    """Store payloads from newer schemas normalize to None."""
+    result = store_sync.normalize_loaded_store(
+        {
+            "schema_version": STORE_SCHEMA_VERSION + 1,
+            "mappings": {},
+            "aliases": {},
+            "migration_notes": [],
+        },
+        ("entry-1", "lock", 1, 4, "2026-01-01T00:00:00"),
+    )
+
+    assert result is None
+
+
+def test_normalize_loaded_store_accepts_current_schema() -> None:
+    """Current schema payloads continue to normalize."""
+    result = store_sync.normalize_loaded_store(
+        {
+            "schema_version": STORE_SCHEMA_VERSION,
+            "mappings": {},
+            "aliases": {},
+            "migration_notes": [],
+        },
+        ("entry-1", "lock", 1, 4, "2026-01-01T00:00:00"),
+    )
+
+    assert result is not None
+    assert result["schema_version"] == STORE_SCHEMA_VERSION
+
+
+def test_normalize_loaded_store_still_migrates_legacy_schema() -> None:
+    """Legacy schema payloads continue to migrate to version 1."""
+    result = store_sync.normalize_loaded_store(
+        {"schema_version": 0, "mappings": {"k": {"slot": 5}}},
+        ("entry-1", "lock", 1, 4, "2026-01-01T00:00:00"),
+    )
+
+    assert result is not None
+    assert result["schema_version"] == 1
+    assert result["mappings"] == {"k": {"slot": 5}}
+
+
 def test_build_store_sync_plan_empty() -> None:
     """An empty plan produces an empty mutation plan."""
     plan = DesiredPlan(

--- a/tests/unit/test_coordinator_store_sync.py
+++ b/tests/unit/test_coordinator_store_sync.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from datetime import datetime
 from datetime import timezone
 
+from custom_components.rental_control.const import STORE_SCHEMA_VERSION
 from custom_components.rental_control.coordinator_helpers import store_sync
 from custom_components.rental_control.coordinator_helpers.models import StoreSyncPlan
 from custom_components.rental_control.reconciliation import DesiredPlan
@@ -56,3 +57,37 @@ def test_build_store_sync_plan_empty() -> None:
     assert isinstance(result, StoreSyncPlan)
     assert result.remove_identity_keys == []
     assert result.upsert_mappings == {}
+
+
+def test_build_save_payload_preserves_blocked_slots() -> None:
+    """Blocked slot metadata is included in the save payload."""
+    payload = store_sync.build_save_payload(
+        {"mappings": {}, "blocked_slots": {"slot-1": {"reason": "owner"}}},
+        ("entry-1", "lock", 1, 4, "2026-01-01T00:00:00"),
+    )
+
+    assert payload["blocked_slots"] == {"slot-1": {"reason": "owner"}}
+
+
+def test_loaded_store_save_round_trip_preserves_blocked_slots() -> None:
+    """Loaded blocked slot metadata survives a normalize-to-save cycle."""
+    raw = {
+        "schema_version": STORE_SCHEMA_VERSION,
+        "entry_id": "entry-1",
+        "lockname": "lock",
+        "mappings": {},
+        "aliases": {},
+        "migration_notes": [],
+        "blocked_slots": {"slot-2": {"reason": "maintenance"}},
+    }
+
+    normalized = store_sync.normalize_loaded_store(
+        raw, ("entry-1", "lock", 1, 4, "2026-01-01T00:00:00")
+    )
+    assert normalized is not None
+
+    payload = store_sync.build_save_payload(
+        normalized, ("entry-1", "lock", 1, 4, "2026-01-01T00:00:00")
+    )
+
+    assert payload["blocked_slots"] == {"slot-2": {"reason": "maintenance"}}

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -376,15 +376,17 @@ class TestGetSlotNameFallback:
         result = get_slot_name("Rental Plain Name", "", "Rental")
         assert result == "Plain Name"
 
-    def test_prefix_not_matching_summary_raises(self) -> None:
-        """Verify prefix that does not match summary raises IndexError.
+    def test_prefix_not_matching_summary_returns_summary(self) -> None:
+        """Verify a mismatched prefix falls back to the original summary."""
+        assert get_slot_name("Some Event", "", "RC") == "Some Event"
 
-        This documents a known deficiency in get_slot_name: when a
-        non-empty prefix is supplied but does not appear in the summary,
-        the regex returns an empty list and accessing index 0 crashes.
-        """
-        with pytest.raises(IndexError):
-            get_slot_name("Guest Q", "", "Vacation")
+    def test_matching_prefix_still_strips_prefix(self) -> None:
+        """Verify a matching prefix is still stripped from the slot name."""
+        assert get_slot_name("RC Alice", "", "RC") == "Alice"
+
+    def test_regex_prefix_is_matched_literally(self) -> None:
+        """Verify regex metacharacters in prefixes are treated literally."""
+        assert get_slot_name("RC+ Alice", "", "RC+") == "Alice"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the latent coordinator crash/data-loss bugs tracked in #640.

- tolerate VEVENTs missing SUMMARY by treating the summary as empty
- fall back to the original summary when event_prefix no longer matches
- default missing-DTEND time selection without changing the existing zero-length duration
- filter timed stale and future VEVENTs using normalized calendar dates
- fence corrupt persisted ghost reservation data instead of crashing refresh
- preserve blocked_slots on the main Store save path
- reject Store payloads with future schema_version values

Bug #4 intentionally remains zero-length per maintainer decision and is folded into the missing-DTEND crash fix.

## Behavior changes for release-drafter

- Malformed calendar feed events and corrupt persisted Store data are skipped/fenced instead of aborting refresh.
- Timed stale/future events are now filtered consistently with all-day events.
- Blocked slot metadata now round-trips through saves.
- Future Store schemas now fall back to an empty cache instead of being accepted.

Closes #640

## Validation

- uv run pytest tests/ -x -q
- uv run ruff check custom_components/ tests/
- uv run pre-commit run --all-files
- uv run pre-commit run aislop --all-files --verbose (score 100)
