### PR TITLE
Test(coverage): Raise fail_under floor to 95

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ source = ["custom_components.rental_control"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 85
+fail_under = 95
 
 [tool.mypy]
 warn_return_any = true


### PR DESCRIPTION
Raise the coverage gate `[tool.coverage.report] fail_under` from **85 → 95**.

The suite is at **95.15%** line coverage on `custom_components.rental_control` after the decomposition + #640 bug-hardening work (every decomposed module ships with focused tests). This locks the floor so coverage can't silently regress.

Enforcement: `pytest-cov` reads `fail_under` from the coverage config, and the CI `python-test-action` runs with `permit_fail: false` and adopts the project's `pyproject.toml` coverage config — so a drop below 95% fails the build (mirrors the aislop `failBelow: 100` gate).

Verified locally: `Required test coverage of 95.0% reached. Total coverage: 95.15%`.