### PR TITLE
CI: Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -1,0 +1,43 @@
+---
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# This workflow uses actions that are not certified by GitHub. They are
+# provided by a third-party and are governed by separate terms of service,
+# privacy policy, and support documentation.
+
+name: 'OpenSSF Scorecard'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '50 4 * * 0'
+  push:
+    branches: ['main']
+    paths:
+      - '**'
+      - '!.github/**'
+
+# Declare default permissions as none.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  openssf-scorecard:
+    name: 'OpenSSF Scorecard'
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@50e324ef804880c13d4aebcefcac07ad81661d01  # v0.6.1
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write  # Upload Scorecard results to code scanning.
+      # Needed to publish results and get a badge (see publish_results).
+      id-token: write  # Publish results and mint the badge.


### PR DESCRIPTION
Adds an OpenSSF Scorecard workflow via the lfreleng reusable workflow (`lfit/releng-reusable-workflows/.../reuse-openssf-scorecard.yaml@v0.6.1`), matching the lfreleng `dependamerge` reference spec.

This was the one workflow missing versus the spec. It scores supply-chain security posture, uploads results to the code-scanning dashboard, and can mint a public badge. Deny-all `permissions: {}` default; `security-events: write` + `id-token: write` on the job; concurrency group; SHA-pinned.

Validated: actionlint, yamllint, reuse all pass.

Closes #669. (CodeQL alignment is the companion #668 — handled separately due to a required-status-check rename.)