### PR TITLE
CI: Use shared semantic PR workflow

### DIFF
--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2021 Andrew Grimberg <tykeal@bardicgrove.org>
 
-name: '🛠️ Semantic Pull Request'
+name: 'Semantic Pull Request 🛠️'
 
 # yamllint disable-line rule:truthy
 on:
@@ -14,43 +14,17 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
   semantic-pull-request:
     name: "Semantic Pull Request"
+    # Delegate to the shared reusable workflow, which tolerates Dependabot's
+    # truncated single-commit subjects for long dependency names that
+    # otherwise trip validateSingleCommitMatchesPrTitle.
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-semantic-pull-request.yaml@f412e6f89527da7611a5f4a5f861de86d98d3e9e  # v0.7.0
     permissions:
       contents: read
-      pull-requests: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    steps:
-      # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: "Validate pull request title"
-        # yamllint disable-line rule:line-length
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Requires the type to be capitalised,
-          # but accept any of the standard types
-          types: |
-            Fix
-            Feat
-            Chore
-            Docs
-            Style
-            Refactor
-            Perf
-            Test
-            Revert
-            CI
-            Build
-          validateSingleCommit: true
-          validateSingleCommitMatchesPrTitle: true
+      pull-requests: read  # Gate step queries the PR API (avoids 403)


### PR DESCRIPTION
Adopt the shared reusable semantic-pull-request workflow, matching the
lfreleng-actions reference. Enforces the same capitalized Conventional
Commit types with the same defaults, and adds tolerance for Dependabot's
truncated single-commit subjects.

Note: the resulting required check is renamed from `Semantic Pull
Request` to `Semantic Pull Request / Semantic Pull Request`. The
repository owner will update the "Best Practices" ruleset required-check
context and handle the merge.
