### PR TITLE
Chore(git): Ignore in-repo .worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Thumbs.db
 *.tmp
 *.swp
 .idea/
+.worktrees/


### PR DESCRIPTION
Add `.worktrees/` to `.gitignore` as a safety net.

Repository convention places git worktrees in a sibling `worktrees/`
directory rather than inside the repository, but an in-repo
`.worktrees/` path can still be created accidentally by tooling.
Ignoring it prevents such a worktree from being committed.